### PR TITLE
Add triton-ascend patch script and update Ascend installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,89 @@ ACCELERATOR=metax pip install -e . --no-build-isolation
 
 ### Build from Source (Ascend Platform)
 
+#### 1. Install FlagGems (FLAGOS Backend)
+
+On Ascend, FlagGems must be installed from our fork (`torch_fl` branch) with `FLAGGEMS_BACKEND=FLAGOS`. This avoids the `libtorch_npu.so` dependency — instead, FlagGems obtains the ACL stream via `torch_fl`'s `GetCurrentStream` C API.
+
 ```bash
-# Ensure CANN toolkit is installed and environment is sourced
-# (typically: source /usr/local/Ascend/ascend-toolkit/set_env.sh)
+# Clone FlagGems (torch_fl branch)
+git clone -b torch_fl https://github.com/Hchnr/FlagGems.git
+cd FlagGems
+
+# Ensure CANN toolkit environment is sourced
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+
+# Install FlagGems with FLAGOS backend (skip C++ extensions)
+pip install --no-build-isolation -e . \
+  --config-settings=cmake.define.FLAGGEMS_BACKEND=FLAGOS \
+  --config-settings=cmake.define.FLAGGEMS_BUILD_C_EXTENSIONS=OFF
+
+cd ..
+```
+
+> **Why FLAGOS backend?**
+> The default ascend/npu backend links against `libtorch_npu.so`, which doesn't exist in our environment (`torch_fl` is the PrivateUse1 backend, not `torch_npu`).
+> The `FLAGOS` backend resolves device streams via `extern "C" void* GetCurrentStream(int)`, provided by `torch_fl`'s `libstream_api.so`.
+
+#### 2. Install torch_fl
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
 
 ACCELERATOR=ascend FLAGGEMS_KERNEL=0 FLAGGEMS_PYTHON=1 \
   CUDA_KERNEL=0 ASCEND_KERNEL=1 \
   pip install --no-build-isolation -vvv -e .
 ```
 
-On Ascend, FlagGems C++ kernels and CUDA kernels are disabled. Only the Ascend kernel backend (ACL NN API) is compiled, with FlagGems Python wrappers enabled for ops that route to FlagGems.
+Notes:
+- `FLAGGEMS_KERNEL=0`: Disable FlagGems C++ kernel wrappers (FLAGOS backend does not compile `liboperators.so`)
+- `FLAGGEMS_PYTHON=1`: Enable FlagGems Python wrappers to route ops to FlagGems Triton kernels
+- `ASCEND_KERNEL=1`: Compile the Ascend C++ operator backend (ACL NN API)
+
+#### 3. Patch triton-ascend
+
+The stock triton-ascend package depends on `torch_npu` / `libtorch_npu.so`. Since `torch_fl` replaces `torch_npu` as the PrivateUse1 backend, we need to patch triton-ascend to use the `flagos` device interface instead:
+
+```bash
+python scripts/patch_triton_ascend.py
+```
+
+The script auto-detects the triton install path and applies the necessary changes. It is idempotent — running it multiple times is safe. After patching, clear any stale kernel cache:
+
+```bash
+rm -rf ~/.triton/cache/
+```
+
+#### 4. Verify Installation
+
+```bash
+python -c "
+import torch_fl
+print('device count:', torch_fl.flagos.device_count())
+print('FlagGems enabled:', torch_fl.is_flaggems_enabled())
+print('registered ops:', len(torch_fl.get_registered_ops()))
+"
+```
+
+#### 5. Run Tests
+
+```bash
+# Inference test
+pytest tests/integration/test_qwen3_infer.py -v -s --model /path/to/Qwen3-0.6B
+
+# Training test
+pytest tests/integration/test_qwen3_train.py -v -s --model /path/to/Qwen3-0.6B
+```
+
+> **Troubleshooting: `libtorch_npu.so: cannot open shared object file`**
+>
+> This error means triton-ascend is still trying to load `torch_npu`. Verify that:
+> 1. You ran `python scripts/patch_triton_ascend.py` after installing triton-ascend
+> 2. FlagGems was installed from `https://github.com/Hchnr/FlagGems` branch `torch_fl`
+> 3. It was built with `FLAGGEMS_BACKEND=FLAGOS`
+> 4. The triton kernel cache was cleared (`rm -rf ~/.triton/cache/`)
 
 ### Build Environment Variables
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -30,8 +30,9 @@
     - MetaX cu-bridge 库（仅在 MetaX 平台需要）
     - CANN toolkit（仅在 Ascend 平台需要）
 - PyTorch 2.11.0
-- FlagGems（5.0.2 版本以上，需要开启 DFLAGGEMS_BUILD_C_EXTENSIONS），源码安装参考文档：[FlagGems 安装](https://flagos-ai.github.io/FlagGems/getting-started/install/)
-  - 注意：Ascend 平台上 FlagGems 为可选依赖
+- FlagGems（5.0.2 版本以上）
+  - CUDA 平台：从 [FlagGems 官方仓库](https://github.com/FlagOpen/FlagGems) 安装，需开启 `FLAGGEMS_BUILD_C_EXTENSIONS`
+  - Ascend 平台：从 [Hchnr/FlagGems](https://github.com/Hchnr/FlagGems) 的 `torch_fl` 分支安装，需指定 `FLAGGEMS_BACKEND=FLAGOS`（详见下方 Ascend 安装步骤）
 
 ### 从源码安装（CUDA 平台）
 
@@ -61,16 +62,92 @@ ACCELERATOR=metax pip install -e . --no-build-isolation
 
 ### 从源码安装（Ascend 平台）
 
+#### 1. 安装 FlagGems（FLAGOS 后端）
+
+Ascend 平台上 FlagGems 需要使用我们 fork 的 `torch_fl` 分支，并以 `FLAGGEMS_BACKEND=FLAGOS` 编译。这样 FlagGems 不依赖 `torch_npu` / `libtorch_npu.so`，而是通过 `torch_fl` 提供的 `GetCurrentStream` C API 获取 ACL stream。
+
 ```bash
-# 确保 CANN toolkit 已安装并已 source 环境
-# （通常: source /usr/local/Ascend/ascend-toolkit/set_env.sh）
+# 克隆 FlagGems（torch_fl 分支）
+git clone -b torch_fl https://github.com/Hchnr/FlagGems.git
+cd FlagGems
+
+# 确保 CANN toolkit 环境已激活
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+
+# 安装 FlagGems（指定 FLAGOS 后端，跳过 C++ 扩展编译）
+pip install --no-build-isolation -e . \
+  --config-settings=cmake.define.FLAGGEMS_BACKEND=FLAGOS \
+  --config-settings=cmake.define.FLAGGEMS_BUILD_C_EXTENSIONS=OFF
+
+cd ..
+```
+
+> **为什么用 FLAGOS 后端？**
+> FlagGems 的 `ascend/npu` 后端会链接 `libtorch_npu.so`，而我们的环境没有 `torch_npu`（`torch_fl` 本身就是 PrivateUse1 后端）。
+> `FLAGOS` 后端通过 `extern "C" void* GetCurrentStream(int)` 获取 stream，由 `torch_fl` 的 `libstream_api.so` 提供实现，完全绕开 `torch_npu` 依赖。
+
+#### 2. 安装 torch_fl
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+
+# 确保 CANN toolkit 环境已激活
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
 
 ACCELERATOR=ascend FLAGGEMS_KERNEL=0 FLAGGEMS_PYTHON=1 \
   CUDA_KERNEL=0 ASCEND_KERNEL=1 \
   pip install --no-build-isolation -vvv -e .
 ```
 
-Ascend 平台上禁用 FlagGems C++ kernel 和 CUDA kernel，仅编译 Ascend kernel 后端（ACL NN API），同时启用 FlagGems Python 封装用于路由到 FlagGems 的算子。
+说明：
+- `FLAGGEMS_KERNEL=0`：禁用 FlagGems C++ kernel 封装（FLAGOS 后端暂不编译 `liboperators.so`）
+- `FLAGGEMS_PYTHON=1`：启用 FlagGems Python 封装，通过 `python_wrapper` 机制调用 FlagGems Triton kernel
+- `ASCEND_KERNEL=1`：编译 Ascend C++ 算子后端（ACL NN API）
+
+#### 3. Patch triton-ascend
+
+原版 triton-ascend 依赖 `torch_npu` / `libtorch_npu.so`。由于 `torch_fl` 替代了 `torch_npu` 作为 PrivateUse1 后端，需要 patch triton-ascend 使其使用 `flagos` 设备接口：
+
+```bash
+python scripts/patch_triton_ascend.py
+```
+
+脚本会自动检测 triton 安装路径并应用修改。脚本幂等，可重复执行。patch 后请清理 kernel 缓存：
+
+```bash
+rm -rf ~/.triton/cache/
+```
+
+#### 4. 验证安装
+
+```bash
+python -c "
+import torch_fl
+print('device count:', torch_fl.flagos.device_count())
+print('FlagGems enabled:', torch_fl.is_flaggems_enabled())
+print('registered ops:', len(torch_fl.get_registered_ops()))
+"
+```
+
+#### 5. 运行推理测试
+
+```bash
+pytest tests/integration/test_qwen3_infer.py -v -s --model /path/to/Qwen3-0.6B
+```
+
+#### 6. 运行训练测试
+
+```bash
+pytest tests/integration/test_qwen3_train.py -v -s --model /path/to/Qwen3-0.6B
+```
+
+> **常见问题：`libtorch_npu.so: cannot open shared object file`**
+>
+> 如果遇到此错误，说明 triton-ascend 仍在尝试加载 `torch_npu`。请确认：
+> 1. 安装 triton-ascend 后执行了 `python scripts/patch_triton_ascend.py`
+> 2. FlagGems 是从 `https://github.com/Hchnr/FlagGems` 的 `torch_fl` 分支安装的
+> 3. 安装时指定了 `FLAGGEMS_BACKEND=FLAGOS`
+> 4. 已清理 triton kernel 缓存（`rm -rf ~/.triton/cache/`）
 
 ### 构建环境变量
 

--- a/scripts/patch_triton_ascend.py
+++ b/scripts/patch_triton_ascend.py
@@ -21,11 +21,11 @@ def find_triton_path():
     """Auto-detect triton installation path."""
     try:
         import triton
+
         return os.path.dirname(triton.__file__)
     except ImportError:
         print(
-            "ERROR: triton not found. "
-            "Specify --triton-path explicitly.",
+            "ERROR: triton not found. Specify --triton-path explicitly.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -71,23 +71,19 @@ def get_torch_npu_path(triton_path):
 
 def patch_driver(triton_path):
     """Patch backends/ascend/driver.py"""
-    fp = os.path.join(
-        triton_path, "backends", "ascend", "driver.py"
-    )
+    fp = os.path.join(triton_path, "backends", "ascend", "driver.py")
 
     replacements = [
         # --- Python API patches ---
         # get_current_device
         (
-            "        import torch_npu\n"
-            "        return torch.npu.current_device()",
+            "        import torch_npu\n        return torch.npu.current_device()",
             "        # import torch_npu  # patched for torch_fl\n"
             "        return torch.flagos.current_device()",
         ),
         # set_current_device
         (
-            "        import torch_npu\n"
-            "        return torch.npu.set_device(device)",
+            "        import torch_npu\n        return torch.npu.set_device(device)",
             "        # import torch_npu  # patched for torch_fl\n"
             "        return torch.flagos.set_device(device)",
         ),
@@ -117,8 +113,7 @@ def patch_driver(triton_path):
         # --- C++ template patches ---
         # Remove NPUWorkspaceAllocator.h
         (
-            "#include <torch_npu/csrc/core/npu/"
-            "NPUWorkspaceAllocator.h>",
+            "#include <torch_npu/csrc/core/npu/NPUWorkspaceAllocator.h>",
             "// torch_npu removed: workspace allocated via rtMalloc",
         ),
         # Replace at_npu allocator with rtMalloc
@@ -145,39 +140,38 @@ def patch_driver(triton_path):
 
 def patch_utils(triton_path):
     """Patch backends/ascend/utils.py"""
-    fp = os.path.join(
-        triton_path, "backends", "ascend", "utils.py"
-    )
+    fp = os.path.join(triton_path, "backends", "ascend", "utils.py")
     npu_path = get_torch_npu_path(triton_path)
 
     replacements = [
         # Remove -ltorch_npu linker flag
         (
-            "        \"-ltorch_npu\",",
-            "        # \"-ltorch_npu\",  # removed for torch_fl",
+            '        "-ltorch_npu",',
+            '        # "-ltorch_npu",  # removed for torch_fl',
         ),
         # _npu_version_hash: hardcode version
         # (import torch_npu is not adjacent to torch_npu_version)
         (
-            "    torch_npu_version = "
-            "torch_npu.version.git_version",
-            "    torch_npu_version = \"torch_fl_shim\"",
+            "    torch_npu_version = torch_npu.version.git_version",
+            '    torch_npu_version = "torch_fl_shim"',
         ),
         # Replace dynamic torch_npu path with hardcoded
         # (import torch_npu is not adjacent to torch_npu_path)
         (
             "    torch_npu_path = os.path.dirname("
             "os.path.realpath(torch_npu.__file__))",
-            "    torch_npu_path = \"" + npu_path + "\"",
+            '    torch_npu_path = "' + npu_path + '"',
         ),
     ]
 
     # Comment out all bare `import torch_npu` lines
     # (they appear after `import torch` in several functions)
-    replacements.append((
-        "    import torch_npu\n",
-        "    # import torch_npu  # patched for torch_fl\n",
-    ))
+    replacements.append(
+        (
+            "    import torch_npu\n",
+            "    # import torch_npu  # patched for torch_fl\n",
+        )
+    )
 
     return patch_file(fp, replacements)
 
@@ -189,20 +183,16 @@ def main():
     parser.add_argument(
         "--triton-path",
         default=None,
-        help="Path to triton package directory. "
-        "Auto-detected if not specified.",
+        help="Path to triton package directory. Auto-detected if not specified.",
     )
     args = parser.parse_args()
 
     triton_path = args.triton_path or find_triton_path()
     print(f"Triton path: {triton_path}")
 
-    if not os.path.isdir(
-        os.path.join(triton_path, "backends", "ascend")
-    ):
+    if not os.path.isdir(os.path.join(triton_path, "backends", "ascend")):
         print(
-            "ERROR: backends/ascend/ not found. "
-            "Is this triton-ascend?",
+            "ERROR: backends/ascend/ not found. Is this triton-ascend?",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -214,10 +204,7 @@ def main():
     patch_utils(triton_path)
 
     print("\nDone. triton-ascend is now compatible with torch_fl.")
-    print(
-        "NOTE: Clear triton kernel cache if you had previously"
-        " compiled kernels:"
-    )
+    print("NOTE: Clear triton kernel cache if you had previously compiled kernels:")
     print("  rm -rf ~/.triton/cache/")
 
 

--- a/scripts/patch_triton_ascend.py
+++ b/scripts/patch_triton_ascend.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Patch triton-ascend to work with torch_fl (without torch_npu dependency).
+
+Original triton-ascend is designed to work with torch_npu. This script
+patches it to use the torch_fl (flagos) device interface instead,
+removing all hard dependencies on libtorch_npu.so.
+
+Usage:
+    python scripts/patch_triton_ascend.py [--triton-path /path/to/triton]
+
+    If --triton-path is not given, auto-detects from `import triton`.
+"""
+
+import argparse
+import os
+import sys
+
+
+def find_triton_path():
+    """Auto-detect triton installation path."""
+    try:
+        import triton
+        return os.path.dirname(triton.__file__)
+    except ImportError:
+        print(
+            "ERROR: triton not found. "
+            "Specify --triton-path explicitly.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def patch_file(filepath, replacements):
+    """Apply (old, new) replacements to a file. Returns True if changed."""
+    if not os.path.exists(filepath):
+        print(f"  SKIP (not found): {filepath}")
+        return False
+
+    with open(filepath, "r") as f:
+        content = f.read()
+
+    original = content
+    applied = 0
+
+    for old, new in replacements:
+        if old not in content:
+            if new in content:
+                continue  # already patched
+            print("  WARNING: pattern not found:")
+            print(f"    {repr(old[:80])}")
+            continue
+        content = content.replace(old, new)
+        applied += 1
+
+    if content == original:
+        print(f"  OK (already patched): {filepath}")
+        return False
+
+    with open(filepath, "w") as f:
+        f.write(content)
+    print(f"  PATCHED ({applied} changes): {filepath}")
+    return True
+
+
+def get_torch_npu_path(triton_path):
+    """Determine torch_npu path for include headers."""
+    site_packages = os.path.dirname(triton_path)
+    return os.path.join(site_packages, "torch_npu")
+
+
+def patch_driver(triton_path):
+    """Patch backends/ascend/driver.py"""
+    fp = os.path.join(
+        triton_path, "backends", "ascend", "driver.py"
+    )
+
+    replacements = [
+        # --- Python API patches ---
+        # get_current_device
+        (
+            "        import torch_npu\n"
+            "        return torch.npu.current_device()",
+            "        # import torch_npu  # patched for torch_fl\n"
+            "        return torch.flagos.current_device()",
+        ),
+        # set_current_device
+        (
+            "        import torch_npu\n"
+            "        return torch.npu.set_device(device)",
+            "        # import torch_npu  # patched for torch_fl\n"
+            "        return torch.flagos.set_device(device)",
+        ),
+        # get_current_stream: remove native _C import
+        (
+            "        import torch_npu\n"
+            "        from torch_npu._C import"
+            " _npu_getCurrentRawStream",
+            "        # import torch_npu  # patched for torch_fl\n"
+            "        # from torch_npu._C import"
+            " _npu_getCurrentRawStream  # patched",
+        ),
+        (
+            "        return _npu_getCurrentRawStream(device)",
+            "        return 0  # default stream for torch_fl",
+        ),
+        # get_device_interface
+        (
+            "        return torch.npu\n",
+            "        return torch.flagos\n",
+        ),
+        # get_empty_cache_for_benchmark
+        (
+            "device='npu')",
+            "device='flagos')",
+        ),
+        # --- C++ template patches ---
+        # Remove NPUWorkspaceAllocator.h
+        (
+            "#include <torch_npu/csrc/core/npu/"
+            "NPUWorkspaceAllocator.h>",
+            "// torch_npu removed: workspace allocated via rtMalloc",
+        ),
+        # Replace at_npu allocator with rtMalloc
+        (
+            "    at::Tensor syncBlockLock_tensor = "
+            "at_npu::native::allocate_workspace"
+            "(syncBlockLockSize, stream);\n"
+            "    syncBlockLock_ptr = const_cast<void *>"
+            "(syncBlockLock_tensor.storage().data());",
+            "    ret = rtMalloc(&syncBlockLock_ptr,"
+            " syncBlockLockSize, RT_MEMORY_HBM);\n"
+            "    ",
+        ),
+        # TRITON_ENABLE_TASKQUEUE default: true -> false
+        # (taskqueue requires torch_npu OpCommand.h)
+        (
+            "\"TRITON_ENABLE_TASKQUEUE\", 'true'",
+            "\"TRITON_ENABLE_TASKQUEUE\", 'false'",
+        ),
+    ]
+
+    return patch_file(fp, replacements)
+
+
+def patch_utils(triton_path):
+    """Patch backends/ascend/utils.py"""
+    fp = os.path.join(
+        triton_path, "backends", "ascend", "utils.py"
+    )
+    npu_path = get_torch_npu_path(triton_path)
+
+    replacements = [
+        # Remove -ltorch_npu linker flag
+        (
+            "        \"-ltorch_npu\",",
+            "        # \"-ltorch_npu\",  # removed for torch_fl",
+        ),
+        # _npu_version_hash: hardcode version
+        # (import torch_npu is not adjacent to torch_npu_version)
+        (
+            "    torch_npu_version = "
+            "torch_npu.version.git_version",
+            "    torch_npu_version = \"torch_fl_shim\"",
+        ),
+        # Replace dynamic torch_npu path with hardcoded
+        # (import torch_npu is not adjacent to torch_npu_path)
+        (
+            "    torch_npu_path = os.path.dirname("
+            "os.path.realpath(torch_npu.__file__))",
+            "    torch_npu_path = \"" + npu_path + "\"",
+        ),
+    ]
+
+    # Comment out all bare `import torch_npu` lines
+    # (they appear after `import torch` in several functions)
+    replacements.append((
+        "    import torch_npu\n",
+        "    # import torch_npu  # patched for torch_fl\n",
+    ))
+
+    return patch_file(fp, replacements)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Patch triton-ascend for torch_fl compatibility"
+    )
+    parser.add_argument(
+        "--triton-path",
+        default=None,
+        help="Path to triton package directory. "
+        "Auto-detected if not specified.",
+    )
+    args = parser.parse_args()
+
+    triton_path = args.triton_path or find_triton_path()
+    print(f"Triton path: {triton_path}")
+
+    if not os.path.isdir(
+        os.path.join(triton_path, "backends", "ascend")
+    ):
+        print(
+            "ERROR: backends/ascend/ not found. "
+            "Is this triton-ascend?",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("\n[1/2] Patching backends/ascend/driver.py ...")
+    patch_driver(triton_path)
+
+    print("\n[2/2] Patching backends/ascend/utils.py ...")
+    patch_utils(triton_path)
+
+    print("\nDone. triton-ascend is now compatible with torch_fl.")
+    print(
+        "NOTE: Clear triton kernel cache if you had previously"
+        " compiled kernels:"
+    )
+    print("  rm -rf ~/.triton/cache/")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add scripts/patch_triton_ascend.py to remove torch_npu/libtorch_npu.so dependency from triton-ascend (replaces with flagos device API and rtMalloc)
- Update README.md and README_zh.md: add "Patch triton-ascend" as step 3 in Ascend installation, update troubleshooting section