### PR TITLE
feat(metax): MetaX hybrid backend config, abs kernel, and platform-aware ops tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,22 +234,23 @@ export FLAGOS_OP_mm__out=cuda
 | File | Purpose |
 |------|---------|
 | `torch_fl/backends_metax.conf` | All listed ops → `metax` C++ kernels. Default when pytest detects MetaX (`/dev/mxcd`) and `FLAGOS_BACKEND_CONFIG` is unset. |
-| `torch_fl/backends_metax_flagos_py.conf` | **Recommended for integration tests.** Hybrid routing: Triton-incompatible ops (e.g. `add`, `mm`, `cos`, `abs`) → `metax`; a few ops remain on `flagos_python`. |
+| `torch_fl/backends_metax_flagos_py.conf` | **Recommended for integration tests.** Hybrid routing: most compute ops → `flagos_python`; keep Triton-incompatible ops (`mm`/`bmm`/`mean.dim`) and factory/allocation ops (`zeros`, `scalar_tensor`, `embedding`, …) on `metax`. |
 
 Example (`backends_metax_flagos_py.conf`):
 
-```ini
-# allclose chain
-abs = metax
-le.Tensor = metax
-all = metax
+     # elementwise / inference-path ops
+     abs = flagos_python
+     add.Tensor = flagos_python
+     cos = flagos_python
+     sin = flagos_python
 
-# PTX / autotune failures on generic Triton
-add.Tensor = metax
-mm = metax
-cos = metax
-sin = metax
-```
+     # Triton-incompatible
+     mm = metax
+     bmm = metax
+     mean.dim = metax
+     # factory/allocation
+     zeros = metax
+     scalar_tensor = metax
 
 ### Debug Dispatch
 
@@ -317,7 +318,7 @@ export FLAGGEMS_SOURCE_DIR=$(python -c "import os,flag_gems;print(os.path.dirnam
 pytest tests/integration/test_ops.py -v
 
 # Per-op dispatch tests (hybrid config)
-pytest tests/integration/ops/ -v -m "anyplatform"
+pytest tests/integration/ops/ -v
 
 # Qwen3 inference
 pytest tests/integration/test_qwen3_infer.py -v -s --model /path/to/Qwen3-0.6B

--- a/README.md
+++ b/README.md
@@ -43,12 +43,27 @@ ACCELERATOR=cuda FLAGGEMS_DIR=/path/to/FlagGems/build/cpython-312/ \
 
 ### Build from Source (MetaX Platform)
 
-```bash
-# Set MetaX cu-bridge library path, depending on the actual cu-bridge path in your environment
-export LD_LIBRARY_PATH=/opt/maca/tools/cu-bridge/lib:$LD_LIBRARY_PATH
+MetaX builds compile device kernels with `mxcc`/`cucc` from `csrc/aten/backends/metax/*.cu` and link them into `libtorch_fl.so`. Runtime goes through MetaX cu-bridge (`runtime/accelerator/metax`); it does **not** use PyTorch's `at::cuda` path.
 
-ACCELERATOR=metax pip install -e . --no-build-isolation
+**Prerequisites**
+
+- MetaX MACA SDK (default `/opt/maca`), with cu-bridge and `mxcc`/`cucc` available
+- PyTorch wheel compatible with your MetaX stack (see [Runtime notes](#metax-runtime-notes) below)
+- FlagGems 5.0.2+ (optional; required only when routing ops to `flagos_python`)
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+
+# MetaX SDK paths (adjust if MACA is installed elsewhere)
+export METAX_PATH=/opt/maca
+export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:/opt/maca/mxgpu_llvm/bin:$PATH
+export LD_LIBRARY_PATH=/opt/maca/lib:/opt/maca/tools/cu-bridge/lib:/opt/maca/mxgpu_llvm/lib:$LD_LIBRARY_PATH
+
+ACCELERATOR=metax METAX_KERNEL=ON FLAGGEMS_PYTHON=1 FLAGGEMS_KERNEL=0 CUDA_KERNEL=0 \
+  pip install --no-build-isolation -vvv -e .
 ```
+
+> On MetaX, generic PyPI Triton (`nvidia` backend) cannot JIT kernels for MetaX hardware. Use `torch_fl/backends_metax.conf` or `torch_fl/backends_metax_flagos_py.conf` to route incompatible ops to metax C++ kernels (see [MetaX backend configs](#metax-backend-configs)).
 
 ### Build from Source (Ascend Platform)
 
@@ -69,7 +84,9 @@ On Ascend, FlagGems C++ kernels and CUDA kernels are disabled. Only the Ascend k
 |----------|-------------|
 | `ACCELERATOR` | Hardware platform: `cuda` (default), `metax`, or `ascend` |
 | `CUDA_HOME` | CUDA toolkit path |
-| `METAX_PATH` | MetaX SDK path (default `/opt/maca`) |
+| `METAX_PATH` | MetaX SDK path (default `/opt/maca`; required for MetaX build) |
+| `METAX_ARCH` / `METAX_MXCC` | Optional GPU arch or `mxcc`/`cucc` compiler path |
+| `METAX_KERNEL` | Enable MetaX C++ kernel build (`ON`/`OFF`; auto-enabled when `ACCELERATOR=metax`) |
 | `ASCEND_HOME` | CANN toolkit path (default `/usr/local/Ascend/ascend-toolkit/latest`) |
 | `FLAGGEMS_DIR` | FlagGems C++ library path (enables low-overhead C++ dispatch) |
 | `FLAGGEMS_KERNEL` | Enable FlagGems C++ kernel wrappers (`ON`/`OFF`, default `ON`; set `0` for Ascend) |
@@ -81,8 +98,13 @@ On Ascend, FlagGems C++ kernels and CUDA kernels are disabled. Only the Ascend k
 
 | Variable | Description |
 |----------|-------------|
-| `FLAGGEMS_SOURCE_DIR` | FlagGems source directory (required when C++ native API ops route to `flaggems` backend) |
-| `FLAGOS_BACKEND_CONFIG` | Override path for `backends.conf` (use `torch_fl/backends_ascend.conf` on Ascend) |
+| `FLAGOS_METAX_CUDART_SHIM` | Set to `1` to preload libcudart compatibility shim before `import torch` (often needed with generic PyTorch wheels) |
+| `FLAGOS_METAX_COMPAT` | Set to `1` to patch FlagGems `torch.cuda` device queries for MetaX |
+| `GEMS_VENDOR` | FlagGems vendor name; set to `metax` on MetaX |
+| `LD_PRELOAD` | Often set to `/opt/maca/lib/libsymbol_cu.so` for cu-bridge symbol resolution |
+| `FLAGGEMS_SOURCE_DIR` | FlagGems source directory (required when ops route to `flaggems` or `flagos_python`) |
+| `FLAGOS_BACKEND_CONFIG` | Override backend routing config (MetaX: `backends_metax.conf` or `backends_metax_flagos_py.conf`) |
+| `FLAGOS_DISABLE_FLAGGEMS_PY` | Set to `1` to disable FlagGems Python-layer registration (C++ stub-only mode) |
 | `FLAGOS_LOG_DISPATCH` | Set to `1` to print backend selection for each operator dispatch |
 | `FLAGOS_OP_<name>` | Per-operator backend override (replace `.` with `__` in op names) |
 
@@ -131,6 +153,29 @@ import torch
 Reason: PyTorch's bundled CUDA 12.x runtime is ABI-incompatible with MetaX's cu-bridge (CUDA 11.6 compatibility layer). `torch_fl` preloads a shim library to provide the required symbol versions.
 
 This restriction does not apply to CUDA platforms.
+
+### MetaX Runtime Setup
+
+Before running tests or inference on MetaX, source the SDK paths and hybrid backend config:
+
+```bash
+export METAX_PATH=/opt/maca
+export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:/opt/maca/mxgpu_llvm/bin:$PATH
+export LD_LIBRARY_PATH=/opt/maca/tools/cu-bridge/lib:/opt/maca/lib:/opt/maca/mxgpu_llvm/lib:/opt/mxdriver/lib:$LD_LIBRARY_PATH
+export LD_PRELOAD=/opt/maca/lib/libsymbol_cu.so
+
+export FLAGOS_METAX_CUDART_SHIM=1
+export FLAGOS_METAX_COMPAT=1
+export GEMS_VENDOR=metax
+export FLAGOS_BACKEND_CONFIG=torch_fl/backends_metax_flagos_py.conf
+export FLAGGEMS_SOURCE_DIR=$(python -c "import os,flag_gems;print(os.path.dirname(flag_gems.__file__))")
+```
+
+#### MetaX runtime notes
+
+- **PyTorch + Triton stack**: Official `maca-pytorch` images ship `torch+metax` and `triton+metax` (outputs `mcfatbin`). A generic PyTorch wheel plus PyPI Triton uses the NVIDIA backend and will fail with `PTX JIT compilation failed` on MetaX unless affected ops are routed to metax C++ kernels.
+- **`flash_attn`**: Prebuilt MetaX `flash_attn` wheels may ABI-mismatch newer PyTorch versions. Disable or patch before loading Qwen3/transformers if import fails.
+- **`relu` / `sigmoid`**: Not registered via `m.impl` in the current tree; they fall back to CPU. Do not list them as `metax` in config unless GPU kernels are enabled in `MetaxKernels.cmake`.
 
 ### C++ Stub-Only Mode
 
@@ -184,6 +229,28 @@ export FLAGOS_OP_mm=cuda
 export FLAGOS_OP_mm__out=cuda
 ```
 
+### MetaX backend configs
+
+| File | Purpose |
+|------|---------|
+| `torch_fl/backends_metax.conf` | All listed ops → `metax` C++ kernels. Default when pytest detects MetaX (`/dev/mxcd`) and `FLAGOS_BACKEND_CONFIG` is unset. |
+| `torch_fl/backends_metax_flagos_py.conf` | **Recommended for integration tests.** Hybrid routing: Triton-incompatible ops (e.g. `add`, `mm`, `cos`, `abs`) → `metax`; a few ops remain on `flagos_python`. |
+
+Example (`backends_metax_flagos_py.conf`):
+
+```ini
+# allclose chain
+abs = metax
+le.Tensor = metax
+all = metax
+
+# PTX / autotune failures on generic Triton
+add.Tensor = metax
+mm = metax
+cos = metax
+sin = metax
+```
+
 ### Debug Dispatch
 
 ```bash
@@ -231,6 +298,40 @@ pytest tests/integration/ops/ -v -m anyplatform
 FLAGOS_BACKEND_CONFIG=torch_fl/backends_flagos_py.conf \
   pytest tests/integration/ops/ -v
 ```
+
+### MetaX Platform
+
+```bash
+# Runtime (see "MetaX Runtime Setup" above)
+export METAX_PATH=/opt/maca
+export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:$PATH
+export LD_LIBRARY_PATH=/opt/maca/tools/cu-bridge/lib:/opt/maca/lib:$LD_LIBRARY_PATH
+export LD_PRELOAD=/opt/maca/lib/libsymbol_cu.so
+export FLAGOS_METAX_CUDART_SHIM=1
+export FLAGOS_METAX_COMPAT=1
+export GEMS_VENDOR=metax
+export FLAGOS_BACKEND_CONFIG=torch_fl/backends_metax_flagos_py.conf
+export FLAGGEMS_SOURCE_DIR=$(python -c "import os,flag_gems;print(os.path.dirname(flag_gems.__file__))")
+
+# Basic op tests (includes Qwen3 inference-path ops: cos/sin/rsqrt/silu/...)
+pytest tests/integration/test_ops.py -v
+
+# Per-op dispatch tests (hybrid config)
+pytest tests/integration/ops/ -v -m "anyplatform"
+
+# Qwen3 inference
+pytest tests/integration/test_qwen3_infer.py -v -s --model /path/to/Qwen3-0.6B
+
+# Qwen3 training (single device)
+pytest tests/integration/test_qwen3_train.py -v -s --steps 10
+
+# All-metax C++ kernel mode (no flagos_python)
+FLAGOS_BACKEND_CONFIG=torch_fl/backends_metax.conf \
+  FLAGOS_DISABLE_FLAGGEMS_PY=1 \
+  pytest tests/integration/test_ops.py -v
+```
+
+If `FLAGOS_BACKEND_CONFIG` is not set, `tests/integration/conftest.py` auto-selects `torch_fl/backends_metax.conf` on MetaX hardware.
 
 ### Ascend Platform
 
@@ -302,8 +403,11 @@ PyTorch-Plugin-FL/
 │   ├── __init__.py           # Plugin entry point: register device, load FlagGems operators
 │   ├── flagos/               # Python device module (stream, event, RNG, AMP)
 │   ├── accelerator/          # Python accelerator module (MACA shim loader)
-│   ├── backends.conf         # Default backend routing config (CUDA/FlagGems)
-│   ├── backends_ascend.conf  # Ascend backend routing config (all ops → ascend)
+│   ├── backends.conf              # Default backend routing config (CUDA/FlagGems)
+│   ├── backends_metax.conf        # MetaX: all listed ops → metax
+│   ├── backends_metax_flagos_py.conf  # MetaX hybrid: metax + flagos_python
+│   ├── backends_flagos_py.conf    # FlagGems Python wrapper routing
+│   ├── backends_ascend.conf       # Ascend backend routing (all ops → ascend)
 │   ├── distributed.py        # Distributed training support (DDP patch)
 │   ├── integration.py        # FlagGems operator registration logic
 │   ├── csrc/                 # C extension (module.cc, stub.c)

--- a/README_zh.md
+++ b/README_zh.md
@@ -45,19 +45,27 @@ ACCELERATOR=cuda FLAGGEMS_DIR=/path/to/FlagGems/build/cpython-312/ \
 
 ### 从源码安装（MetaX 平台）
 
-MetaX 构建与 NPU 模式类似：**主工程仅 CXX**，设备算子由 `mxcc/cucc` 编译 `backends/metax/*.cu` 后以 object 链入 `libtorch_fl.so`；运行时走 `runtime/accelerator/metax`（cu-bridge），**不**使用 `cmake_metax`、不委托 `at::cuda`/`at::maca`。
+MetaX 构建与 Ascend 类似：**主工程仅 CXX**，设备算子由 `mxcc`/`cucc` 编译 `csrc/aten/backends/metax/*.cu` 后以 object 链入 `libtorch_fl.so`；运行时走 `runtime/accelerator/metax`（cu-bridge），**不**委托 `at::cuda`/`at::maca`。
+
+**前置依赖**
+
+- MetaX MACA SDK（默认 `/opt/maca`），含 cu-bridge 与 `mxcc`/`cucc`
+- 与 MetaX 栈匹配的 PyTorch wheel（见下方[运行时说明](#metax-运行时说明)）
+- FlagGems 5.0.2+（可选；仅当算子路由到 `flagos_python` 时需要）
 
 ```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+
+# MetaX SDK 路径（按实际安装位置调整）
 export METAX_PATH=/opt/maca
 export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:/opt/maca/mxgpu_llvm/bin:$PATH
 export LD_LIBRARY_PATH=/opt/maca/lib:/opt/maca/tools/cu-bridge/lib:/opt/maca/mxgpu_llvm/lib:$LD_LIBRARY_PATH
-export FLAGOS_BACKEND_CONFIG=/path/to/torch_fl/backends_metax.conf
-export FLAGOS_DISABLE_FLAGGEMS_PY=1   # 仅测 C++ metax 算子时建议开启
 
-ACCELERATOR=metax pip install -e . --no-build-isolation
+ACCELERATOR=metax METAX_KERNEL=ON FLAGGEMS_PYTHON=1 FLAGGEMS_KERNEL=0 CUDA_KERNEL=0 \
+  pip install --no-build-isolation -vvv -e .
 ```
 
-> 算子路由示例见 `torch_fl/backends_metax.conf`（`add.Tensor` / `mul.Tensor` / `le.Tensor` / `all` → `metax`）。若 PyTorch wheel 加载报 `libcudart.so.12` 版本符号，可设 `FLAGOS_METAX_CUDART_SHIM=1`；若需 FlagGems 与 MetaX 设备名兼容，可设 `FLAGOS_METAX_COMPAT=1`。
+> 在 MetaX 上，PyPI 通用版 Triton（`nvidia` 后端）无法为 MetaX 硬件 JIT 内核。请使用 `torch_fl/backends_metax.conf` 或 `torch_fl/backends_metax_flagos_py.conf`，将不兼容算子路由到 metax C++ kernel（见[MetaX 后端配置](#metax-后端配置)）。
 
 ### 从源码安装（Ascend 平台）
 
@@ -81,6 +89,7 @@ Ascend 平台上禁用 FlagGems C++ kernel 和 CUDA kernel，仅编译 Ascend ke
 | `CUDA_HOME` | CUDA toolkit 路径 |
 | `METAX_PATH` | MetaX SDK 路径（默认 `/opt/maca`，metax 构建必需） |
 | `METAX_ARCH` / `METAX_MXCC` | 可选：GPU 架构或 mxcc/cucc 编译器路径 |
+| `METAX_KERNEL` | 启用 MetaX C++ kernel 构建（`ON`/`OFF`；`ACCELERATOR=metax` 时自动开启） |
 | `ASCEND_HOME` | CANN toolkit 路径（默认 `/usr/local/Ascend/ascend-toolkit/latest`） |
 | `FLAGGEMS_DIR` | FlagGems C++ 库路径（启用低开销 C++ dispatch） |
 | `FLAGGEMS_KERNEL` | 启用 FlagGems C++ kernel 封装（`ON`/`OFF`，默认 `ON`；Ascend 设为 `0`） |
@@ -93,10 +102,12 @@ Ascend 平台上禁用 FlagGems C++ kernel 和 CUDA kernel，仅编译 Ascend ke
 | 变量 | 说明 |
 |------|------|
 | `FLAGOS_DISABLE_FLAGGEMS_PY` | 设为 `1` 关闭 FlagGems Python 层注册（C++ stub-only 模式） |
-| `FLAGOS_METAX_CUDART_SHIM` | 设为 `1` 在 import 前加载 libcudart 兼容 shim（少数 PyTorch wheel 需要） |
+| `FLAGOS_METAX_CUDART_SHIM` | 设为 `1` 在 import 前加载 libcudart 兼容 shim（通用 PyTorch wheel 常需） |
 | `FLAGOS_METAX_COMPAT` | 设为 `1` 为 FlagGems 修补 `torch.cuda` 设备属性查询 |
-| `FLAGGEMS_SOURCE_DIR` | FlagGems 源码目录（当 C++ native API 算子路由到 `flaggems` 后端时必须设置） |
-| `FLAGOS_BACKEND_CONFIG` | 覆盖 `backends.conf` 路径（Ascend 使用 `torch_fl/backends_ascend.conf`） |
+| `GEMS_VENDOR` | FlagGems 厂商名；MetaX 上设为 `metax` |
+| `LD_PRELOAD` | 常设为 `/opt/maca/lib/libsymbol_cu.so`，用于 cu-bridge 符号解析 |
+| `FLAGGEMS_SOURCE_DIR` | FlagGems 源码目录（算子路由到 `flaggems` 或 `flagos_python` 时需设置） |
+| `FLAGOS_BACKEND_CONFIG` | 覆盖后端路由配置（MetaX：`backends_metax.conf` 或 `backends_metax_flagos_py.conf`） |
 | `FLAGOS_LOG_DISPATCH` | 设为 `1` 打印每次算子 dispatch 的后端选择 |
 | `FLAGOS_OP_<name>` | 按算子覆盖后端（算子名中的 `.` 替换为 `__`） |
 
@@ -145,6 +156,29 @@ import torch
 原因：PyTorch 自带的 CUDA 12.x 运行时与 MetaX 的 cu-bridge（CUDA 11.6 兼容层）ABI 不兼容。`torch_fl` 会预加载一个 shim 库来提供所需的符号版本。
 
 CUDA 平台无此限制。
+
+### MetaX 运行时环境
+
+运行测试或推理前，配置 SDK 路径与混合后端：
+
+```bash
+export METAX_PATH=/opt/maca
+export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:/opt/maca/mxgpu_llvm/bin:$PATH
+export LD_LIBRARY_PATH=/opt/maca/tools/cu-bridge/lib:/opt/maca/lib:/opt/maca/mxgpu_llvm/lib:/opt/mxdriver/lib:$LD_LIBRARY_PATH
+export LD_PRELOAD=/opt/maca/lib/libsymbol_cu.so
+
+export FLAGOS_METAX_CUDART_SHIM=1
+export FLAGOS_METAX_COMPAT=1
+export GEMS_VENDOR=metax
+export FLAGOS_BACKEND_CONFIG=torch_fl/backends_metax_flagos_py.conf
+export FLAGGEMS_SOURCE_DIR=$(python -c "import os,flag_gems;print(os.path.dirname(flag_gems.__file__))")
+```
+
+#### MetaX 运行时说明
+
+- **PyTorch + Triton 栈**：官方 `maca-pytorch` 镜像自带 `torch+metax` 与 `triton+metax`（输出 `mcfatbin`）。通用 PyTorch wheel + PyPI Triton 走 NVIDIA 后端，在 MetaX 上会报 `PTX JIT compilation failed`，需将相关算子路由到 metax C++ kernel。
+- **`flash_attn`**：预编译 MetaX `flash_attn` wheel 可能与较新 PyTorch ABI 不兼容；加载 Qwen3/transformers 前需禁用或 patch。
+- **`relu` / `sigmoid`**：当前树中未通过 `m.impl` 注册，走 cpu_fallback；除非已在 `MetaxKernels.cmake` 中启用 GPU kernel，否则不要在配置里写 `metax`。
 
 ### C++ Stub-Only 模式
 
@@ -198,6 +232,28 @@ export FLAGOS_OP_mm=cuda
 export FLAGOS_OP_mm__out=cuda
 ```
 
+### MetaX 后端配置
+
+| 文件 | 用途 |
+|------|------|
+| `torch_fl/backends_metax.conf` | 所列算子全部 → `metax` C++ kernel。pytest 检测到 MetaX（`/dev/mxcd`）且未设置 `FLAGOS_BACKEND_CONFIG` 时自动选用。 |
+| `torch_fl/backends_metax_flagos_py.conf` | **集成测试推荐。** 混合路由：Triton 不兼容算子（如 `add`、`mm`、`cos`、`abs`）→ `metax`；少量算子仍走 `flagos_python`。 |
+
+示例（`backends_metax_flagos_py.conf`）：
+
+```ini
+# allclose 依赖链
+abs = metax
+le.Tensor = metax
+all = metax
+
+# 通用 Triton 在 MetaX 上会 PTX / autotune 失败
+add.Tensor = metax
+mm = metax
+cos = metax
+sin = metax
+```
+
 ### 调试 dispatch
 
 ```bash
@@ -245,6 +301,40 @@ pytest tests/integration/ops/ -v -m anyplatform
 FLAGOS_BACKEND_CONFIG=torch_fl/backends_flagos_py.conf \
   pytest tests/integration/ops/ -v
 ```
+
+### MetaX 平台
+
+```bash
+# 运行时环境（见上文「MetaX 运行时环境」）
+export METAX_PATH=/opt/maca
+export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:$PATH
+export LD_LIBRARY_PATH=/opt/maca/tools/cu-bridge/lib:/opt/maca/lib:$LD_LIBRARY_PATH
+export LD_PRELOAD=/opt/maca/lib/libsymbol_cu.so
+export FLAGOS_METAX_CUDART_SHIM=1
+export FLAGOS_METAX_COMPAT=1
+export GEMS_VENDOR=metax
+export FLAGOS_BACKEND_CONFIG=torch_fl/backends_metax_flagos_py.conf
+export FLAGGEMS_SOURCE_DIR=$(python -c "import os,flag_gems;print(os.path.dirname(flag_gems.__file__))")
+
+# 基础算子测试（含 Qwen3 推理路径：cos/sin/rsqrt/silu 等）
+pytest tests/integration/test_ops.py -v
+
+# 逐算子 dispatch 测试（混合配置）
+pytest tests/integration/ops/ -v -m "anyplatform"
+
+# Qwen3 推理
+pytest tests/integration/test_qwen3_infer.py -v -s --model /path/to/Qwen3-0.6B
+
+# Qwen3 训练（单卡）
+pytest tests/integration/test_qwen3_train.py -v -s --steps 10
+
+# 纯 metax C++ kernel 模式（不走 flagos_python）
+FLAGOS_BACKEND_CONFIG=torch_fl/backends_metax.conf \
+  FLAGOS_DISABLE_FLAGGEMS_PY=1 \
+  pytest tests/integration/test_ops.py -v
+```
+
+未设置 `FLAGOS_BACKEND_CONFIG` 时，`tests/integration/conftest.py` 会在 MetaX 硬件上自动选择 `torch_fl/backends_metax.conf`。
 
 ### Ascend 平台
 
@@ -310,8 +400,11 @@ PyTorch-Plugin-FL/
 │   ├── __init__.py           # 插件入口：注册设备、加载 FlagGems 算子
 │   ├── flagos/               # Python 设备模块（stream、event、RNG、AMP）
 │   ├── accelerator/          # Python accelerator 模块（MACA shim 加载器）
-│   ├── backends.conf         # 默认后端路由配置（CUDA/FlagGems）
-│   ├── backends_ascend.conf  # Ascend 后端路由配置（所有算子 → ascend）
+│   ├── backends.conf                  # 默认后端路由配置（CUDA/FlagGems）
+│   ├── backends_metax.conf            # MetaX：所列算子 → metax
+│   ├── backends_metax_flagos_py.conf  # MetaX 混合：metax + flagos_python
+│   ├── backends_flagos_py.conf        # FlagGems Python 封装路由
+│   ├── backends_ascend.conf           # Ascend 后端路由（所有算子 → ascend）
 │   ├── distributed.py        # 分布式训练支持（DDP patch）
 │   ├── integration.py        # FlagGems 算子注册逻辑
 │   ├── csrc/                 # C 扩展（module.cc、stub.c）

--- a/README_zh.md
+++ b/README_zh.md
@@ -237,22 +237,23 @@ export FLAGOS_OP_mm__out=cuda
 | 文件 | 用途 |
 |------|------|
 | `torch_fl/backends_metax.conf` | 所列算子全部 → `metax` C++ kernel。pytest 检测到 MetaX（`/dev/mxcd`）且未设置 `FLAGOS_BACKEND_CONFIG` 时自动选用。 |
-| `torch_fl/backends_metax_flagos_py.conf` | **集成测试推荐。** 混合路由：Triton 不兼容算子（如 `add`、`mm`、`cos`、`abs`）→ `metax`；少量算子仍走 `flagos_python`。 |
+| `torch_fl/backends_metax_flagos_py.conf` | **集成测试推荐。** 混合路由：多数计算算子 → `flagos_python`；将 Triton 不兼容算子（`mm`/`bmm`/`mean.dim`）以及分配/工厂算子（`zeros`、`scalar_tensor`、`embedding` 等）保留在 `metax`。 |
 
 示例（`backends_metax_flagos_py.conf`）：
 
-```ini
-# allclose 依赖链
-abs = metax
-le.Tensor = metax
-all = metax
-
-# 通用 Triton 在 MetaX 上会 PTX / autotune 失败
-add.Tensor = metax
-mm = metax
-cos = metax
-sin = metax
-```
+     # elementwise / inference-path ops
+     abs = flagos_python
+     add.Tensor = flagos_python
+     cos = flagos_python
+     sin = flagos_python     
+     
+     # Triton 不兼容
+     mm = metax
+     bmm = metax
+     mean.dim = metax
+     # 分配/工厂算子
+     zeros = metax
+     scalar_tensor = metax
 
 ### 调试 dispatch
 
@@ -320,7 +321,7 @@ export FLAGGEMS_SOURCE_DIR=$(python -c "import os,flag_gems;print(os.path.dirnam
 pytest tests/integration/test_ops.py -v
 
 # 逐算子 dispatch 测试（混合配置）
-pytest tests/integration/ops/ -v -m "anyplatform"
+pytest tests/integration/ops/ -v
 
 # Qwen3 推理
 pytest tests/integration/test_qwen3_infer.py -v -s --model /path/to/Qwen3-0.6B

--- a/cmake/MetaxKernels.cmake
+++ b/cmake/MetaxKernels.cmake
@@ -46,7 +46,7 @@ function(flagos_add_metax_kernel_objects out_var)
 
   set(_flags -std=c++17 -fPIC -O3 -DMETAX_ARCH=${_arch})
 
-  set(_kernels add mul le all neg embedding mean mm bmm cos sin rsqrt silu pow sum ones_like softmax where bitwise_and)
+  set(_kernels add mul le all abs neg embedding mean mm bmm cos sin rsqrt silu pow sum ones_like softmax where bitwise_and)
   set(_objs)
   set(_obj_dir "${CMAKE_CURRENT_BINARY_DIR}/metax_kernels")
   file(MAKE_DIRECTORY "${_obj_dir}")

--- a/csrc/aten/backends/metax/abs.cu
+++ b/csrc/aten/backends/metax/abs.cu
@@ -1,0 +1,11 @@
+// Copyright (c) 2026, BAAI. All rights reserved.
+
+#include "../../abs.h"
+
+#include "abs_kernel.cuh"
+
+namespace at::native::flagos {
+
+REGISTER_IMPL_TO_DISPATCHER(AbsFn, abs_dispatcher, Backend::kMetax, AbsKernel)
+
+} // namespace at::native::flagos

--- a/csrc/aten/backends/metax/abs_kernel.cuh
+++ b/csrc/aten/backends/metax/abs_kernel.cuh
@@ -69,9 +69,7 @@ inline at::Tensor AbsKernel(const at::Tensor& self) {
     return iter.output();
   }
 
-  TORCH_CHECK(
-      iter.is_contiguous(),
-      "MetaX abs requires contiguous flagos tensors");
+  TORCH_INTERNAL_ASSERT(iter.is_contiguous());
 
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,

--- a/csrc/aten/backends/metax/abs_kernel.cuh
+++ b/csrc/aten/backends/metax/abs_kernel.cuh
@@ -71,10 +71,10 @@ inline at::Tensor AbsKernel(const at::Tensor& self) {
 
   TORCH_INTERNAL_ASSERT(iter.is_contiguous());
 
-  AT_DISPATCH_FLOATING_TYPES_AND2(
+  AT_DISPATCH_ALL_TYPES_AND2(
       at::ScalarType::Half,
       at::ScalarType::BFloat16,
-      iter.dtype(),
+      iter.common_dtype(),
       "abs_metax",
       [&]() {
         using opmath_t = at::opmath_type<scalar_t>;

--- a/csrc/aten/backends/metax/abs_kernel.cuh
+++ b/csrc/aten/backends/metax/abs_kernel.cuh
@@ -56,10 +56,10 @@ inline at::Tensor AbsKernel(const at::Tensor& self) {
 
   if (!iter.can_use_32bit_indexing()) {
     for (auto& sub_iter : iter.with_32bit_indexing()) {
-      AT_DISPATCH_FLOATING_TYPES_AND2(
+      AT_DISPATCH_ALL_TYPES_AND2(
           at::ScalarType::Half,
           at::ScalarType::BFloat16,
-          sub_iter.dtype(),
+          sub_iter.common_dtype(),
           "abs_metax",
           [&]() {
             using opmath_t = at::opmath_type<scalar_t>;

--- a/csrc/aten/backends/metax/abs_kernel.cuh
+++ b/csrc/aten/backends/metax/abs_kernel.cuh
@@ -1,0 +1,89 @@
+// Copyright (c) 2026, BAAI. All rights reserved.
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+#include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/native/TensorIterator.h>
+#include <c10/util/Exception.h>
+
+#include "metax_elementwise.cuh"
+
+namespace at::native::flagos {
+
+namespace {
+
+template <typename scalar_t, typename opmath_t>
+__global__ void AbsContigKernel(
+    int64_t n,
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ self) {
+  const int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= n) {
+    return;
+  }
+  const opmath_t x = static_cast<opmath_t>(self[idx]);
+  out[idx] = static_cast<scalar_t>(std::abs(x));
+}
+
+template <typename scalar_t, typename opmath_t>
+void LaunchAbsIter(at::TensorIteratorBase& iter) {
+  TORCH_INTERNAL_ASSERT(iter.is_contiguous());
+  const int64_t n = iter.numel();
+  scalar_t* out = static_cast<scalar_t*>(iter.data_ptr(0));
+  const scalar_t* self = static_cast<const scalar_t*>(iter.data_ptr(1));
+  metax::Launch1d(n, AbsContigKernel<scalar_t, opmath_t>, out, self);
+}
+
+} // namespace
+
+inline at::Tensor AbsKernel(const at::Tensor& self) {
+  at::Tensor output;
+  auto iter = at::TensorIteratorConfig()
+                  .add_output(output)
+                  .add_input(self)
+                  .build();
+
+  if (!iter.is_contiguous() && iter.numel() > 0) {
+    const auto shape = iter.output().sizes();
+    return AbsKernel(self.expand(shape).contiguous());
+  }
+
+  if (!iter.can_use_32bit_indexing()) {
+    for (auto& sub_iter : iter.with_32bit_indexing()) {
+      AT_DISPATCH_FLOATING_TYPES_AND2(
+          at::ScalarType::Half,
+          at::ScalarType::BFloat16,
+          sub_iter.dtype(),
+          "abs_metax",
+          [&]() {
+            using opmath_t = at::opmath_type<scalar_t>;
+            LaunchAbsIter<scalar_t, opmath_t>(sub_iter);
+          });
+    }
+    return iter.output();
+  }
+
+  TORCH_CHECK(
+      iter.is_contiguous(),
+      "MetaX abs requires contiguous flagos tensors");
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      iter.dtype(),
+      "abs_metax",
+      [&]() {
+        using opmath_t = at::opmath_type<scalar_t>;
+        LaunchAbsIter<scalar_t, opmath_t>(iter);
+      });
+
+  return iter.output();
+}
+
+} // namespace at::native::flagos

--- a/tests/integration/ops/conftest.py
+++ b/tests/integration/ops/conftest.py
@@ -3,41 +3,47 @@ import os
 import pytest
 
 
-def _is_metax_runtime() -> bool:
+def _detect_platform() -> str:
+    """Infer the active hardware/backend platform from env."""
     accelerator = os.environ.get("ACCELERATOR", "").lower()
-    if accelerator == "metax":
-        return True
+    if accelerator == "ascend":
+        return "ascend"
+    if accelerator in ("metax", "maca"):
+        return "metax"
 
     backend_cfg = os.environ.get("FLAGOS_BACKEND_CONFIG", "").lower()
-    return "metax" in backend_cfg
+    if "ascend" in backend_cfg:
+        return "ascend"
+    if "metax" in backend_cfg:
+        return "metax"
+    return "default"
+
+
+# Markers to skip per platform (tests for other backends are not compiled/available).
+_PLATFORM_SKIP_MARKERS: dict[str, tuple[str, ...]] = {
+    "metax": ("cuda", "ascend", "flaggems_python"),
+    "ascend": ("cuda", "metax"),
+    "default": ("metax", "ascend"),
+}
 
 
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    if _is_metax_runtime():
-        skip_cuda_flaggems = pytest.mark.skip(
-            reason="Skipped on metax runtime: test requires CUDA/flaggems backend"
-        )
-        cuda_keywords = (
-            "dispatch_log_cuda",
-            "flaggems",
-            "flagos_default",
-            "matches_cuda",
-            "cuda_ref",
-            "cuda_override",
-        )
-        for item in items:
-            nodeid = item.nodeid
-            if any(keyword in nodeid for keyword in cuda_keywords):
-                item.add_marker(skip_cuda_flaggems)
-    else:
-        skip_metax = pytest.mark.skip(
-            reason="Skipped off metax runtime: test requires MetaX backend"
-        )
-        for item in items:
-            if item.get_closest_marker("metax") or "dispatch_log_metax" in item.nodeid:
-                item.add_marker(skip_metax)
+    platform = _detect_platform()
+    markers_to_skip = _PLATFORM_SKIP_MARKERS.get(platform, ())
+    for item in items:
+        for marker_name in markers_to_skip:
+            if item.get_closest_marker(marker_name):
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason=(
+                            f"Skipped on {platform} runtime: "
+                            f"requires @{marker_name} backend"
+                        )
+                    )
+                )
+                break
 
 
 def pytest_configure(config):

--- a/tests/integration/ops/conftest.py
+++ b/tests/integration/ops/conftest.py
@@ -21,7 +21,7 @@ def _detect_platform() -> str:
 
 # Markers to skip per platform (tests for other backends are not compiled/available).
 _PLATFORM_SKIP_MARKERS: dict[str, tuple[str, ...]] = {
-    "metax": ("cuda", "ascend", "flaggems_python"),
+    "metax": ("cuda", "ascend", "flaggems"),
     "ascend": ("cuda", "metax"),
     "default": ("metax", "ascend"),
 }

--- a/tests/integration/ops/test_bmm_dispatch.py
+++ b/tests/integration/ops/test_bmm_dispatch.py
@@ -238,7 +238,7 @@ class TestBmmDispatchLog:
             f"Expected flagos_python dispatch log, got:\n{result.stderr}"
         )
 
-    @pytest.mark.anyplatform
+    @pytest.mark.flaggems
     def test_dispatch_log_flagos_default(self):
         """Default config routes bmm to flagos."""
         result = _run_bmm_subprocess(

--- a/tests/integration/ops/test_neg_dispatch.py
+++ b/tests/integration/ops/test_neg_dispatch.py
@@ -68,7 +68,7 @@ class TestNegCorrectness:
         ref = -a_view.cpu()
         torch.testing.assert_close(out.cpu(), ref, rtol=0, atol=0)
 
-    @pytest.mark.anyplatform
+    @pytest.mark.cuda
     def test_neg_matches_cuda(self):
         if not torch.cuda.is_available():
             pytest.skip("CUDA not available")

--- a/tests/integration/test_ops.py
+++ b/tests/integration/test_ops.py
@@ -321,9 +321,64 @@ class TestActivations:
         s = torch.softmax(x, dim=0)
         assert s.sum().item() == pytest.approx(1.0, abs=1e-5)
 
+    def test_silu(self, device):
+        x = torch.tensor([-1.0, 0.0, 1.0, 2.0], device=device)
+        assert torch.allclose(F.silu(x).cpu(), F.silu(x.cpu()), rtol=1e-4, atol=1e-4)
+
 
 # ---------------------------------------------------------------------------
-# 10. Device properties
+# 10. Unary / elementwise ops (Qwen3 inference path)
+# ---------------------------------------------------------------------------
+
+
+class TestInferencePathOps:
+    """Ops commonly hit in Qwen3 forward (RoPE, mask, activations)."""
+
+    def test_cos(self, device):
+        x = torch.tensor([0.0, 1.5708, 3.14159], device=device)
+        assert torch.allclose(torch.cos(x).cpu(), torch.cos(x.cpu()), rtol=1e-4, atol=1e-4)
+
+    def test_sin(self, device):
+        x = torch.tensor([0.0, 1.5708, 3.14159], device=device)
+        assert torch.allclose(torch.sin(x).cpu(), torch.sin(x.cpu()), rtol=1e-4, atol=1e-4)
+
+    def test_rsqrt(self, device):
+        x = torch.tensor([1.0, 4.0, 16.0], device=device)
+        assert torch.allclose(
+            torch.rsqrt(x).cpu(), torch.rsqrt(x.cpu()), rtol=1e-4, atol=1e-4
+        )
+
+    def test_pow_scalar(self, device):
+        x = torch.tensor([2.0, 3.0, 4.0], device=device)
+        assert torch.allclose(
+            torch.pow(x, 2).cpu(), torch.pow(x.cpu(), 2), rtol=1e-4, atol=1e-4
+        )
+
+    def test_mul_scalar(self, device):
+        x = torch.tensor([1.0, 2.0, 3.0], device=device)
+        assert torch.allclose((x * 2.0).cpu(), x.cpu() * 2.0, rtol=1e-4, atol=1e-4)
+
+    def test_bitwise_and(self, device):
+        a = torch.tensor([0b1010, 0b1100, 0b1111], dtype=torch.int32, device=device)
+        b = torch.tensor([0b1001, 0b0100, 0b1010], dtype=torch.int32, device=device)
+        assert torch.equal(a & b, torch.tensor([0b1000, 0b0100, 0b1010], device=device))
+
+    def test_where(self, device):
+        cond = torch.tensor([True, False, True, False], device=device)
+        a = torch.tensor([1.0, 2.0, 3.0, 4.0], device=device)
+        b = torch.tensor([5.0, 6.0, 7.0, 8.0], device=device)
+        out = torch.where(cond, a, b)
+        expected = torch.where(cond.cpu(), a.cpu(), b.cpu())
+        assert torch.allclose(out.cpu(), expected, rtol=1e-4, atol=1e-4)
+
+    def test_index_tensor(self, device):
+        x = torch.arange(10, device=device, dtype=torch.float32)
+        indices = torch.tensor([1, 3, 7], device=device)
+        assert torch.allclose(x[indices].cpu(), x.cpu()[indices.cpu()])
+
+
+# ---------------------------------------------------------------------------
+# 11. Device properties
 # ---------------------------------------------------------------------------
 
 
@@ -337,7 +392,7 @@ class TestDeviceProperties:
 
 
 # ---------------------------------------------------------------------------
-# 11. Autograd
+# 12. Autograd
 # ---------------------------------------------------------------------------
 
 
@@ -359,7 +414,7 @@ class TestAutograd:
 
 
 # ---------------------------------------------------------------------------
-# 12. Synchronization
+# 13. Synchronization
 # ---------------------------------------------------------------------------
 
 

--- a/tests/integration/test_ops.py
+++ b/tests/integration/test_ops.py
@@ -365,7 +365,10 @@ class TestInferencePathOps:
     def test_bitwise_and(self, device):
         a = torch.tensor([0b1010, 0b1100, 0b1111], dtype=torch.int32, device=device)
         b = torch.tensor([0b1001, 0b0100, 0b1010], dtype=torch.int32, device=device)
-        assert torch.equal(a & b, torch.tensor([0b1000, 0b0100, 0b1010], device=device))
+        assert torch.equal(
+             a & b,
+             torch.tensor([0b1000, 0b0100, 0b1010], dtype=torch.int32, device=device),
+        )
 
     def test_where(self, device):
         cond = torch.tensor([True, False, True, False], device=device)

--- a/tests/integration/test_ops.py
+++ b/tests/integration/test_ops.py
@@ -336,11 +336,15 @@ class TestInferencePathOps:
 
     def test_cos(self, device):
         x = torch.tensor([0.0, 1.5708, 3.14159], device=device)
-        assert torch.allclose(torch.cos(x).cpu(), torch.cos(x.cpu()), rtol=1e-4, atol=1e-4)
+        assert torch.allclose(
+            torch.cos(x).cpu(), torch.cos(x.cpu()), rtol=1e-4, atol=1e-4
+        )
 
     def test_sin(self, device):
         x = torch.tensor([0.0, 1.5708, 3.14159], device=device)
-        assert torch.allclose(torch.sin(x).cpu(), torch.sin(x.cpu()), rtol=1e-4, atol=1e-4)
+        assert torch.allclose(
+            torch.sin(x).cpu(), torch.sin(x.cpu()), rtol=1e-4, atol=1e-4
+        )
 
     def test_rsqrt(self, device):
         x = torch.tensor([1.0, 4.0, 16.0], device=device)

--- a/torch_fl/backends_metax.conf
+++ b/torch_fl/backends_metax.conf
@@ -22,6 +22,7 @@ cos = metax
 sin = metax
 neg = metax
 pow.Tensor_Scalar = metax
+abs = metax
 all = metax
 _softmax = metax
 bitwise_and.Tensor = metax

--- a/torch_fl/backends_metax_flagos_py.conf
+++ b/torch_fl/backends_metax_flagos_py.conf
@@ -1,0 +1,47 @@
+# metax + FlagGems hybrid config
+# With prefer_block_pointer=False (via _patch_flaggems_codegen_config), FlagGems
+# Triton kernels avoid the triton-metax block pointer compiler bug.
+#
+# NOTE: flagos_python backend requires FLAGGEMS_PYTHON=1 (or FLAGGEMS_KERNEL=1) at build time.
+# When both are 0, all ops must use 'metax' backend.
+
+# --- FlagGems Triton kernels (via python_op_caller) ---
+abs = flagos_python
+acos = flagos_python
+add.Tensor = flagos_python
+all = flagos_python
+bitwise_and.Tensor = flagos_python
+bmm = metax  # FlagGems uses SPLIT_K kwarg not supported by triton-metax
+bmm.out = metax  # same as bmm
+cat = flagos_python
+constant_pad_nd = flagos_python
+cos = flagos_python
+le.Tensor = flagos_python
+mean.dim = metax  # FlagGems non-inner dim path uses CUDA context, fails on metax
+mm = metax  # FlagGems uses SPLIT_K kwarg not supported by triton-metax
+mm.out = metax  # same as mm
+mul.Tensor = flagos_python
+mul.Scalar = flagos_python
+neg = flagos_python
+nll_loss_forward = flagos_python
+nll_loss_backward = flagos_python
+pow.Tensor_Scalar = flagos_python
+rsqrt = flagos_python
+silu = flagos_python
+silu_backward = flagos_python
+sin = flagos_python
+_softmax = flagos_python
+sum.dim_IntList = flagos_python
+where.self = flagos_python
+index.Tensor = flagos_python
+
+# --- Ops that must use metax C++ backend ---
+# Factory/allocation ops: FlagGems does not register these; they need
+# device-level memory allocation which only the C++ backend provides.
+embedding = metax
+embedding_dense_backward = metax
+new_ones = metax
+ones_like = metax
+scalar_tensor = metax
+zeros = metax
+slice_backward = metax


### PR DESCRIPTION
Summary
This change enables hybrid routing between MetaX C++ kernels and FlagGems Python wrappers (flagos_python) on MetaX hardware, so integration tests and the Qwen3 inference path can run reliably on real MetaX devices.

After triton-metax codegen fixes (prefer_block_pointer=False), most compute ops can be delegated to flagos_python, while ops that are incompatible with triton-metax or not covered by FlagGems continue to use metax C++ kernels.

Changes
1. Hybrid backend configuration
Add torch_fl/backends_metax_flagos_py.conf as the recommended config for MetaX integration tests.
Route most compute ops (e.g. add, cos, sin, silu, where) to flagos_python.
Keep these on metax C++ kernels:
Triton-incompatible ops: mm, bmm, mean.dim (SPLIT_K / CUDA context issues)
Factory/allocation ops: zeros, new_ones, ones_like, scalar_tensor, embedding, slice_backward
Add abs to torch_fl/backends_metax.conf.
2. MetaX abs kernel
Add csrc/aten/backends/metax/abs.cu and abs_kernel.cuh.
Enable the allclose dependency chain (abs → le → all) on MetaX.
Register abs in cmake/MetaxKernels.cmake.