### PR TITLE
test(ops): rewrite flaggems dispatch tests for runtime-switch semantics

### DIFF
--- a/tests/integration/ops/conftest.py
+++ b/tests/integration/ops/conftest.py
@@ -35,10 +35,27 @@ def _detect_platform() -> str:
 
 # Markers to skip per platform (tests for other backends are not compiled/available).
 _PLATFORM_SKIP_MARKERS: dict[str, tuple[str, ...]] = {
-    "metax": ("cuda", "ascend", "flaggems"),
+    "metax": ("cuda", "ascend"),
     "ascend": ("cuda", "metax"),
     "default": ("metax", "ascend"),
 }
+
+
+def _flaggems_enabled() -> bool:
+    """True when the FlagGems runtime path is switched on (FLAGOS_USE_FLAGGEMS=1).
+
+    FlagGems and the vendor kernels are BOTH compiled into every wheel; which one
+    an op runs on is chosen at runtime by this env var (see torch_fl.__init__
+    ._select_backend_config -> backends_flaggems.conf). Tests marked ``flaggems``
+    assert a ``-> flagos_python`` (or vendor-fallback) routing that only holds
+    when the switch is on, so they are skipped otherwise.
+    """
+    return os.environ.get("FLAGOS_USE_FLAGGEMS", "0").lower() not in (
+        "0",
+        "",
+        "off",
+        "false",
+    )
 
 
 def pytest_collection_modifyitems(
@@ -51,7 +68,17 @@ def pytest_collection_modifyitems(
     # Tests asserting a `-> metax` dispatch (mark.metax) cannot pass, so skip them.
     if platform == "metax" and os.environ.get("FLAGOS_METAX_BOXING", "0") == "1":
         markers_to_skip.append("metax")
+    flaggems_on = _flaggems_enabled()
     for item in items:
+        # The flaggems runtime path is a runtime switch, not a build/platform gate:
+        # skip its tests only when the switch is off, on any platform.
+        if item.get_closest_marker("flaggems") and not flaggems_on:
+            item.add_marker(
+                pytest.mark.skip(
+                    reason="FlagGems runtime path is off (set FLAGOS_USE_FLAGGEMS=1)"
+                )
+            )
+            continue
         for marker_name in markers_to_skip:
             if item.get_closest_marker(marker_name):
                 item.add_marker(
@@ -70,7 +97,10 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "cuda: requires CUDA platform")
     config.addinivalue_line("markers", "metax: requires MetaX platform")
     config.addinivalue_line("markers", "ascend: requires Ascend platform")
-    config.addinivalue_line("markers", "flaggems: requires FlagGems (Triton) backend")
+    config.addinivalue_line(
+        "markers",
+        "flaggems: requires the FlagGems runtime path on (FLAGOS_USE_FLAGGEMS=1)",
+    )
     config.addinivalue_line(
         "markers", "flaggems_python: requires FlagGems Python wrapper backend"
     )

--- a/tests/integration/ops/test_bitwise_and_dispatch.py
+++ b/tests/integration/ops/test_bitwise_and_dispatch.py
@@ -114,15 +114,6 @@ class TestBitwiseAndDispatch:
         assert result.returncode == 0, f"Failed:\n{result.stderr}"
         assert "[flagos dispatch] bitwise_and.Tensor -> metax" in result.stderr
 
-    @pytest.mark.anyplatform
-    def test_flaggems_backend_raises_error(self):
-        result = _run_subprocess(
-            {"FLAGOS_OP_bitwise_and__Tensor": "flaggems"},
-            check=False,
-        )
-        assert result.returncode != 0
-        assert "backend not registered" in result.stderr
-
 
 class TestBitwiseAndAscendDispatch:
     """Verify Ascend backend correctness."""

--- a/tests/integration/ops/test_bmm_dispatch.py
+++ b/tests/integration/ops/test_bmm_dispatch.py
@@ -253,13 +253,13 @@ class TestBmmDispatchLog:
         )
 
     @pytest.mark.flaggems
-    def test_dispatch_log_flagos_default(self):
-        """Default config routes bmm to flagos."""
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, bmm routes to flagos_python."""
         result = _run_bmm_subprocess(
-            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_bmm": "flaggems"}
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
         )
-        assert "[flagos dispatch] bmm -> flagos" in result.stderr, (
-            f"Expected flagos dispatch log, got:\n{result.stderr}"
+        assert "[flagos dispatch] bmm -> flagos_python" in result.stderr, (
+            f"Expected flagos_python dispatch log, got:\n{result.stderr}"
         )
 
     @pytest.mark.cuda
@@ -273,14 +273,14 @@ class TestBmmDispatchLog:
         )
 
     @pytest.mark.flaggems
-    def test_dispatch_log_bmm_out_flagos_default(self):
-        """Default config routes bmm.out to flagos."""
+    def test_dispatch_log_bmm_out_flaggems_runtime(self):
+        """With the FlagGems runtime path on, bmm.out routes to flagos_python."""
         result = _run_bmm_subprocess(
-            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_bmm__out": "flaggems"},
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"},
             use_out=True,
         )
-        assert "[flagos dispatch] bmm.out -> flagos" in result.stderr, (
-            f"Expected flagos dispatch log, got:\n{result.stderr}"
+        assert "[flagos dispatch] bmm.out -> flagos_python" in result.stderr, (
+            f"Expected flagos_python dispatch log, got:\n{result.stderr}"
         )
 
     @pytest.mark.cuda

--- a/tests/integration/ops/test_cat_dispatch.py
+++ b/tests/integration/ops/test_cat_dispatch.py
@@ -476,13 +476,18 @@ class TestCatDispatchLog:
         )
 
     @pytest.mark.flaggems
-    def test_dispatch_log_flagos_default(self):
-        """Default config routes cat to flagos."""
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, cat falls back to the vendor kernel.
+
+        FlagGems has no Triton kernel for cat, so backends_flaggems.conf keeps it
+        on cuda: this verifies the runtime switch degrades gracefully per-op
+        rather than forcing an unavailable backend.
+        """
         result = _run_cat_subprocess(
-            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_cat": "flaggems"}
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
         )
-        assert "[flagos dispatch] cat -> flagos" in result.stderr, (
-            f"Expected flagos dispatch log, got:\n{result.stderr}"
+        assert "[flagos dispatch] cat -> cuda" in result.stderr, (
+            f"Expected cuda fallback dispatch log, got:\n{result.stderr}"
         )
 
     @pytest.mark.cuda

--- a/tests/integration/ops/test_cos_dispatch.py
+++ b/tests/integration/ops/test_cos_dispatch.py
@@ -124,16 +124,6 @@ class TestCosDispatch:
         assert result.returncode == 0, f"Failed:\n{result.stderr}"
         assert "[flagos dispatch] cos -> metax" in result.stderr
 
-    @pytest.mark.anyplatform
-    def test_flaggems_backend_raises_error(self):
-        """Selecting flaggems backend must fail — not implemented."""
-        result = _run_cos_subprocess(
-            {"FLAGOS_OP_cos": "flaggems"},
-            check=False,
-        )
-        assert result.returncode != 0
-        assert "backend not registered" in result.stderr
-
 
 class TestCosAscendDispatch:
     """Verify Ascend backend correctness."""

--- a/tests/integration/ops/test_embedding_dispatch.py
+++ b/tests/integration/ops/test_embedding_dispatch.py
@@ -168,13 +168,18 @@ class TestEmbeddingDispatchLog:
         assert "[flagos dispatch] embedding -> flagos_python" in result.stderr
 
     @pytest.mark.flaggems
-    def test_dispatch_log_flagos_default(self):
-        """Default routes embedding to flagos."""
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, embedding routes to flagos_python.
+
+        FlagGems and the vendor kernels are both compiled in; FLAGOS_USE_FLAGGEMS=1
+        selects backends_flaggems.conf at import, where embedding has a FlagGems
+        Triton kernel and thus routes to flagos_python.
+        """
         result = _run_embedding_subprocess(
-            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_embedding": "flaggems"}
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
         )
-        assert "[flagos dispatch] embedding -> flagos" in result.stderr, (
-            f"Expected flagos log, got:\n{result.stderr}"
+        assert "[flagos dispatch] embedding -> flagos_python" in result.stderr, (
+            f"Expected flagos_python log, got:\n{result.stderr}"
         )
 
     @pytest.mark.cuda

--- a/tests/integration/ops/test_mm_dispatch.py
+++ b/tests/integration/ops/test_mm_dispatch.py
@@ -195,13 +195,13 @@ class TestMmDispatchLog:
         )
 
     @pytest.mark.flaggems
-    def test_dispatch_log_flagos_flaggems_override(self):
-        """FLAGOS_OP_mm=flaggems routes mm to flagos backend."""
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, mm routes to flagos_python."""
         result = _run_mm_subprocess(
-            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_mm": "flaggems"}
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
         )
-        assert "[flagos dispatch] mm -> flagos" in result.stderr, (
-            f"Expected flagos dispatch log, got:\n{result.stderr}"
+        assert "[flagos dispatch] mm -> flagos_python" in result.stderr, (
+            f"Expected flagos_python dispatch log, got:\n{result.stderr}"
         )
 
     @pytest.mark.cuda
@@ -224,16 +224,19 @@ class TestMmDispatchLog:
             f"Expected ascend dispatch log, got:\n{result.stderr}"
         )
 
-    @pytest.mark.cuda
     @pytest.mark.flaggems
-    def test_dispatch_log_mm_out_flagos_flaggems_override(self):
-        """FLAGOS_OP_mm__out=flaggems routes mm.out to flagos backend."""
+    def test_dispatch_log_mm_out_flaggems_runtime(self):
+        """With the FlagGems runtime path on, mm.out falls back to the vendor kernel.
+
+        FlagGems has no Triton kernel for mm.out, so backends_flaggems.conf keeps
+        it on cuda: verifies per-op graceful fallback under the runtime switch.
+        """
         result = _run_mm_subprocess(
-            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_mm__out": "flaggems"},
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"},
             use_out=True,
         )
-        assert "[flagos dispatch] mm.out -> flagos" in result.stderr, (
-            f"Expected flagos dispatch log, got:\n{result.stderr}"
+        assert "[flagos dispatch] mm.out -> cuda" in result.stderr, (
+            f"Expected cuda fallback dispatch log, got:\n{result.stderr}"
         )
 
     @pytest.mark.cuda

--- a/tests/integration/ops/test_new_ones_dispatch.py
+++ b/tests/integration/ops/test_new_ones_dispatch.py
@@ -105,15 +105,6 @@ class TestNewOnesDispatch:
         assert result.returncode == 0, f"Failed:\n{result.stderr}"
         assert "[flagos dispatch] new_ones -> metax" in result.stderr
 
-    @pytest.mark.anyplatform
-    def test_flaggems_backend_raises_error(self):
-        result = _run_subprocess(
-            {"FLAGOS_OP_new_ones": "flaggems"},
-            check=False,
-        )
-        assert result.returncode != 0
-        assert "backend not registered" in result.stderr
-
 
 class TestNewOnesAscendDispatch:
     """Verify Ascend backend correctness."""

--- a/tests/integration/ops/test_ones_like_dispatch.py
+++ b/tests/integration/ops/test_ones_like_dispatch.py
@@ -90,15 +90,6 @@ class TestOnesLikeDispatch:
         assert result.returncode == 0
         assert "[flagos dispatch] ones_like -> cuda" in result.stderr
 
-    @pytest.mark.cuda
-    def test_flaggems_backend_raises_error(self):
-        result = _run_subprocess(
-            {"FLAGOS_OP_ones_like": "flaggems"},
-            check=False,
-        )
-        assert result.returncode != 0
-        assert "backend not registered" in result.stderr
-
 
 class TestOnesLikeAscendDispatch:
     """Verify Ascend backend correctness."""

--- a/tests/integration/ops/test_scalar_tensor_dispatch.py
+++ b/tests/integration/ops/test_scalar_tensor_dispatch.py
@@ -91,15 +91,6 @@ class TestScalarTensorDispatch:
         assert result.returncode == 0, f"Failed:\n{result.stderr}"
         assert "[flagos dispatch] scalar_tensor -> metax" in result.stderr
 
-    @pytest.mark.anyplatform
-    def test_flaggems_backend_raises_error(self):
-        result = _run_subprocess(
-            {"FLAGOS_OP_scalar_tensor": "flaggems"},
-            check=False,
-        )
-        assert result.returncode != 0
-        assert "backend not registered" in result.stderr
-
 
 class TestScalarTensorAscendDispatch:
     """Verify Ascend backend correctness."""

--- a/tests/integration/ops/test_sin_dispatch.py
+++ b/tests/integration/ops/test_sin_dispatch.py
@@ -124,16 +124,6 @@ class TestSinDispatch:
         assert result.returncode == 0, f"Failed:\n{result.stderr}"
         assert "[flagos dispatch] sin -> metax" in result.stderr
 
-    @pytest.mark.anyplatform
-    def test_flaggems_backend_raises_error(self):
-        """Selecting flaggems backend must fail — not implemented."""
-        result = _run_sin_subprocess(
-            {"FLAGOS_OP_sin": "flaggems"},
-            check=False,
-        )
-        assert result.returncode != 0
-        assert "backend not registered" in result.stderr
-
 
 class TestSinAscendDispatch:
     """Verify Ascend backend correctness."""

--- a/tests/integration/ops/test_softmax_dispatch.py
+++ b/tests/integration/ops/test_softmax_dispatch.py
@@ -113,12 +113,13 @@ class TestSoftmaxDispatch:
         assert "[flagos dispatch] _softmax -> flagos_python" in result.stderr
 
     @pytest.mark.flaggems
-    def test_dispatch_log_flagos(self):
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, _softmax routes to flagos_python."""
         result = _run_softmax_subprocess(
-            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP__softmax": "flaggems"}
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
         )
         assert result.returncode == 0, f"Failed:\n{result.stderr}"
-        assert "[flagos dispatch] _softmax -> flagos" in result.stderr
+        assert "[flagos dispatch] _softmax -> flagos_python" in result.stderr
 
     @pytest.mark.cuda
     def test_dispatch_log_cuda(self):

--- a/tests/integration/ops/test_where_dispatch.py
+++ b/tests/integration/ops/test_where_dispatch.py
@@ -126,15 +126,6 @@ class TestWhereDispatch:
         assert result.returncode == 0, f"Failed:\n{result.stderr}"
         assert "[flagos dispatch] where.self -> metax" in result.stderr
 
-    @pytest.mark.anyplatform
-    def test_flaggems_backend_raises_error(self):
-        result = _run_subprocess(
-            {"FLAGOS_OP_where__self": "flaggems"},
-            check=False,
-        )
-        assert result.returncode != 0
-        assert "backend not registered" in result.stderr
-
 
 class TestWhereAscendDispatch:
     """Verify Ascend backend correctness."""

--- a/tests/integration/ops/test_zeros_dispatch.py
+++ b/tests/integration/ops/test_zeros_dispatch.py
@@ -85,15 +85,6 @@ class TestZerosDispatch:
         assert result.returncode == 0
         assert "[flagos dispatch] zeros -> cuda" in result.stderr
 
-    @pytest.mark.cuda
-    def test_flaggems_backend_raises_error(self):
-        result = _run_subprocess(
-            {"FLAGOS_OP_zeros": "flaggems"},
-            check=False,
-        )
-        assert result.returncode != 0
-        assert "backend not registered" in result.stderr
-
 
 class TestZerosAscendDispatch:
     """Verify Ascend backend correctness."""


### PR DESCRIPTION
# Rewrite flaggems dispatch tests for runtime-switch semantics

## Problem

Integration test suite had 8 failures (7 stable, 1 flaky allocator):
- **7 stable failures**: `mm/bmm/cat/embedding/softmax` dispatch-log tests asserted `FLAGOS_OP_xxx=flaggems` (C++ `kFlagOs` path) should succeed → failed with `RuntimeError: backend not registered`.
- **Root cause**: C++ FlagGems path (`FLAGGEMS_KERNEL=ON` + `liboperators.so`) is **not built** in current wheels (`FLAGGEMS_KERNEL=OFF`). Two batches of tests contradicted each other on the same `FLAGOS_OP_xxx=flaggems` value:
  - mm/bmm/cat/embedding/softmax: asserted it succeeds
  - sin/zeros/cos/where/...: asserted it fails (`test_flaggems_backend_raises_error`)

This mismatch broke CI's integration-test-cuda workflow.

## Design

The correct model (confirmed with user):
- FlagGems **and** vendor kernels are **both compiled** into every wheel
- Runtime switch `FLAGOS_USE_FLAGGEMS=1` selects which backend config to load:
  - ON → `backends_flaggems.conf` → ops with FlagGems Triton kernels route to `flagos_python` (kFlagOsPython); ops without kernels fall back to vendor (cuda/metax/ascend)
  - OFF (default) → `backends_cuda.conf` → vendor backend
- C++ `kFlagOs` path (`FLAGOS_OP_xxx=flaggems`) is obsolete for testing purposes

## Changes

1. **conftest marker semantics**: `flaggems` marker redefined as "requires `FLAGOS_USE_FLAGGEMS=1`". Tests with this marker are now skipped when the switch is off (any platform).

2. **Rewrote 7 failing tests** (mm/bmm/cat/embedding/softmax dispatch-log):
   - Before: `FLAGOS_OP_xxx=flaggems` + assert `-> flagos`
   - After: `FLAGOS_USE_FLAGGEMS=1` + assert actual routing:
     - mm/bmm/bmm.out/_softmax/embedding → `-> flagos_python`
     - mm.out/cat → `-> cuda` (no FlagGems kernel, vendor fallback)

3. **Removed 8 obsolete tests** (`test_flaggems_backend_raises_error` in sin/zeros/cos/where/new_ones/ones_like/scalar_tensor/bitwise_and): these encoded the now-obsolete C++ `kFlagOs` "not implemented" semantics.

## Verification

Local (NVIDIA A100, default platform):
```bash
# Switch OFF (default): flaggems marker tests skipped, others pass
pytest tests/integration/ops/test_{mm,bmm,cat,embedding,softmax}_dispatch.py -q
# → 76 passed, 19 skipped, 0 failed

# Switch ON: flaggems marker tests run and pass
FLAGOS_USE_FLAGGEMS=1 pytest ... -m flaggems -q
# → 7 passed

# Files with removed raises_error: all pass
pytest tests/integration/ops/test_{sin,zeros,cos,where,...}_dispatch.py -q
# → 57 passed, 0 failed
```

Full ops suite (437 tests, conv1d deselected): *(pending completion)*

## Impact

- **CI**: integration-test-cuda will now pass (`flaggems` marker tests skipped by default)
- **Runtime testing**: use `FLAGOS_USE_FLAGGEMS=1` to test FlagGems Python path + fallback behavior
- **C++ kFlagOs path**: tests no longer assert this path; it remains in C++ code but is untested (can be removed in future cleanup if truly obsolete)
