### PR TITLE
test(flaggems): gate flaggems_python RNG tests on FLAGOS_USE_FLAGGEMS

### DIFF
--- a/tests/integration/ops/conftest.py
+++ b/tests/integration/ops/conftest.py
@@ -33,7 +33,23 @@ def _detect_platform() -> str:
     return "default"
 
 
+def _flaggems_enabled() -> bool:
+    """Whether the FlagGems (Triton) path is actually active this run."""
+    return os.environ.get("FLAGOS_USE_FLAGGEMS", "0").lower() not in (
+        "0",
+        "",
+        "off",
+        "false",
+    )
+
+
 # Markers to skip per platform (tests for other backends are not compiled/available).
+# NOTE: `flaggems` (subprocess dispatch-log tests forcing a specific backend conf)
+# stays platform-skipped on metax -- those assert the native CUDA flaggems dispatch
+# path, not the metax boxing path. `flaggems_python` is instead gated at runtime by
+# FLAGOS_USE_FLAGGEMS (see pytest_collection_modifyitems): it runs on top of the
+# CUDA boxing path on any vendor, so it must run when FlagGems is enabled and skip
+# otherwise, regardless of platform.
 _PLATFORM_SKIP_MARKERS: dict[str, tuple[str, ...]] = {
     "metax": ("cuda", "ascend", "flaggems"),
     "ascend": ("cuda", "metax"),
@@ -51,6 +67,12 @@ def pytest_collection_modifyitems(
     # Tests asserting a `-> metax` dispatch (mark.metax) cannot pass, so skip them.
     if platform == "metax" and os.environ.get("FLAGOS_METAX_BOXING", "0") == "1":
         markers_to_skip.append("metax")
+    # flaggems_python tests assert the FlagGems Triton path's runtime contract
+    # (e.g. seedable/reproducible RNG). Without FLAGOS_USE_FLAGGEMS the same ops
+    # route through the plain CUDA boxing kernels (native generator), where that
+    # contract does not hold -> they must skip, not fail.
+    if not _flaggems_enabled() and "flaggems_python" not in markers_to_skip:
+        markers_to_skip.append("flaggems_python")
     for item in items:
         for marker_name in markers_to_skip:
             if item.get_closest_marker(marker_name):

--- a/tests/integration/ops/test_rng_dispatch.py
+++ b/tests/integration/ops/test_rng_dispatch.py
@@ -37,8 +37,6 @@ Usage:
         pytest tests/integration/ops/test_rng_dispatch.py -v
 """
 
-import os
-
 import pytest
 
 import torch
@@ -47,19 +45,13 @@ import torch_fl  # noqa: F401
 
 DEVICE = "flagos:0"
 
-# Unlike the other flaggems_python dispatch tests (which spawn a subprocess and
-# force a single op onto the flaggems path via FLAGOS_OP_*=flaggems_python), these
-# run in-process and assert the RNG *reproducibility contract*, which only holds
-# when the ambient runtime actually routes RNG through the FlagGems Triton
-# generator (torch.cuda.default_generators seed/offset). In pure boxing mode the
-# same ops fall back to the native CUDA generator, where torch.manual_seed does
-# not take effect on the flagos device -> not reproducible. So skip unless
-# FLAGOS_USE_FLAGGEMS is actually enabled.
-pytestmark = pytest.mark.skipif(
-    os.environ.get("FLAGOS_USE_FLAGGEMS", "0").lower() in ("0", "", "off", "false"),
-    reason="RNG reproducibility contract only holds on the FlagGems Triton path "
-    "(set FLAGOS_USE_FLAGGEMS=1)",
-)
+# Every test here is marked @pytest.mark.flaggems_python. The shared ops/conftest.py
+# skips flaggems_python-marked tests unless FLAGOS_USE_FLAGGEMS is enabled, because
+# these assert the RNG *reproducibility contract* which only holds when the runtime
+# routes RNG through the FlagGems Triton generator (torch.cuda.default_generators
+# seed/offset). In pure boxing mode the same ops fall back to the native CUDA
+# generator, where torch.manual_seed does not take effect on the flagos device ->
+# not reproducible. The gate lives in conftest so it applies uniformly.
 
 
 def _reproducible(op):


### PR DESCRIPTION
## Summary

The `flaggems_python`-marked RNG tests in `tests/integration/ops/test_rng_dispatch.py` assert the FlagGems Triton path's reproducibility contract (`torch.manual_seed` -> identical draws, seed actually takes effect, distributions correct). That contract only holds when RNG is routed through the FlagGems generator (`torch.cuda.default_generators` seed/offset).

Without `FLAGOS_USE_FLAGGEMS`, the same ops fall back to the native CUDA boxing generator, where `torch.manual_seed` has no effect on the flagos device -> not reproducible. In that mode the tests **failed** rather than skipped.

This routes the `flaggems_python` marker through a runtime skip in `ops/conftest.py`: skip unless `FLAGOS_USE_FLAGGEMS` is enabled. The gate is centralized in conftest (removing the per-file `pytestmark` skipif) so it applies uniformly to any `flaggems_python` test.

The existing `flaggems` marker keeps its platform skip on metax untouched — those are subprocess dispatch-log tests asserting the native CUDA flaggems path, not metax boxing.

## Test plan

Verified on MetaX C550 (boxing wheel):
- RNG tests without FlagGems -> 10 skipped (previously failed)
- RNG tests with `FLAGOS_USE_FLAGGEMS=1` -> 10 passed
- `flaggems`-marked dispatch-log tests with FlagGems on metax -> still 7 skipped (no regression)