### PR TITLE
feat: Hygon DCU support via DTK CUDA compatibility layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
-set(ACCELERATOR "cuda" CACHE STRING "Accelerator platform: cuda, metax, ascend, or tsingmicro")
+set(ACCELERATOR "cuda" CACHE STRING "Accelerator platform: cuda, metax, ascend, tsingmicro, or dcu")
 
 # Kernel build options (can be overridden via -D flags from setup.py)
 option(CUDA_KERNEL "Build CUDA kernel implementations" ON)
@@ -45,6 +45,17 @@ elseif(ACCELERATOR STREQUAL "metax")
   project(TORCH_FLAGOS CXX C)
 elseif(ACCELERATOR STREQUAL "tsingmicro")
   project(TORCH_FLAGOS CXX C)
+elseif(ACCELERATOR STREQUAL "dcu")
+  # Hygon DCU (DTK). The vendor torch wheel is a hipified build that registers
+  # its HIP kernels under the CUDA dispatch key (tensors report device type
+  # kCUDA), so the generated PrivateUse1 -> CUDA boxing kernels dispatch into
+  # libtorch_hip.so unchanged. DTK also ships a CUDA compatibility toolkit whose
+  # libcudart.so.12 is a thin shim over libgalaxyhip.so, so the runtime sources
+  # under csrc/runtime/accelerator/cuda/ compile as-is against host g++.
+  # No nvcc and no CUDA language: nothing outside backends/metax/ is a .cu.
+  set(CUDA_KERNEL OFF CACHE BOOL "Build CUDA kernel implementations" FORCE)
+  set(FLAGGEMS_KERNEL OFF CACHE BOOL "Build FlagGems kernel implementations" FORCE)
+  project(TORCH_FLAGOS CXX C)
 else()
   # project(... CUDA) runs nvcc compiler-id before find_package(CUDAToolkit); conda
   # layouts need CUDAToolkit_ROOT (headers under targets/x86_64-linux/include).
@@ -72,7 +83,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if(NOT ACCELERATOR STREQUAL "metax" AND NOT ACCELERATOR STREQUAL "ascend" AND NOT ACCELERATOR STREQUAL "tsingmicro")
+if(NOT ACCELERATOR STREQUAL "metax" AND NOT ACCELERATOR STREQUAL "ascend"
+   AND NOT ACCELERATOR STREQUAL "tsingmicro" AND NOT ACCELERATOR STREQUAL "dcu")
   set(CMAKE_CUDA_STANDARD 17)
   set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 endif()
@@ -144,6 +156,56 @@ elseif(ACCELERATOR STREQUAL "tsingmicro")
   if(NOT TARGET CUDA::nvToolsExt)
     add_library(CUDA::nvToolsExt INTERFACE IMPORTED)
   endif()
+elseif(ACCELERATOR STREQUAL "dcu")
+  # Hygon DTK. DTK_ROOT defaults to /opt/dtk (ROCM_PATH is what env.sh exports).
+  if(NOT DTK_ROOT)
+    set(DTK_ROOT "$ENV{DTK_ROOT}")
+  endif()
+  if(NOT DTK_ROOT)
+    set(DTK_ROOT "$ENV{ROCM_PATH}")
+  endif()
+  if(NOT DTK_ROOT)
+    set(DTK_ROOT "/opt/dtk")
+  endif()
+  message(STATUS "Hygon DTK path: ${DTK_ROOT}")
+
+  # DTK's CUDA compatibility toolkit. Its libcudart.so.12 is a shim over
+  # libgalaxyhip.so -- the same runtime libtorch_hip.so uses -- so there is one
+  # driver state, not two.
+  file(GLOB _DCU_CUDA_CANDIDATES "${DTK_ROOT}/cuda/cuda-*")
+  set(DCU_CUDA_ROOT "")
+  foreach(_cand IN LISTS _DCU_CUDA_CANDIDATES)
+    if(EXISTS "${_cand}/include/cuda_runtime.h")
+      set(DCU_CUDA_ROOT "${_cand}")
+      break()
+    endif()
+  endforeach()
+  if(NOT DCU_CUDA_ROOT)
+    message(FATAL_ERROR
+        "ACCELERATOR=dcu selected, but the DTK CUDA compatibility toolkit was "
+        "not found under ${DTK_ROOT}/cuda/. Set DTK_ROOT (or ROCM_PATH) to a "
+        "DTK installation that provides cuda-*/include/cuda_runtime.h.")
+  endif()
+  message(STATUS "DTK CUDA compatibility toolkit: ${DCU_CUDA_ROOT}")
+
+  add_library(cuda_runtime_compat INTERFACE IMPORTED)
+  set_target_properties(cuda_runtime_compat PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${DCU_CUDA_ROOT}/include"
+  )
+  target_link_directories(cuda_runtime_compat INTERFACE "${DCU_CUDA_ROOT}/lib64")
+  target_link_libraries(cuda_runtime_compat INTERFACE cudart)
+
+  set(CUDA_RUNTIME_LIB cuda_runtime_compat)
+
+  # Embed the compat + DTK library paths so LD_LIBRARY_PATH is not needed.
+  list(APPEND CMAKE_INSTALL_RPATH "${DCU_CUDA_ROOT}/lib64" "${DTK_ROOT}/lib")
+
+  # Pre-create torch::cudart so PyTorch's cuda.cmake is skipped entirely
+  # (guard: if(TARGET torch::cudart) return()).
+  add_library(torch::cudart INTERFACE IMPORTED)
+  if(NOT TARGET CUDA::nvToolsExt)
+    add_library(CUDA::nvToolsExt INTERFACE IMPORTED)
+  endif()
 elseif(ACCELERATOR STREQUAL "metax")
   # MetaX SDK: use cu-bridge headers and runtime_cu library
   if(NOT METAX_PATH)
@@ -196,6 +258,37 @@ else()
 endif()
 
 find_package(Torch REQUIRED)
+
+if(ACCELERATOR STREQUAL "dcu")
+  # DTK exports MIOpen with a build-machine absolute path baked into its link
+  # interface: /usr/lib/x86_64-linux-gnu/librt.so. glibc >= 2.34 folded librt
+  # into libc, so current distros ship only librt.a + librt.so.1 -- that .so
+  # symlink no longer exists and the generated makefiles die with
+  # "No rule to make target '/usr/lib/x86_64-linux-gnu/librt.so'".
+  # Rewrite any dangling absolute path to its bare -l name; the linker resolves
+  # `rt` against the stub archive. Nothing to do on hosts where the path exists.
+  foreach(_dcu_target MIOpen)
+    if(TARGET ${_dcu_target})
+      get_target_property(_dcu_libs ${_dcu_target} INTERFACE_LINK_LIBRARIES)
+      if(_dcu_libs)
+        set(_dcu_fixed_libs "")
+        foreach(_dcu_lib IN LISTS _dcu_libs)
+          if(IS_ABSOLUTE "${_dcu_lib}" AND NOT EXISTS "${_dcu_lib}")
+            get_filename_component(_dcu_name "${_dcu_lib}" NAME_WE)
+            string(REGEX REPLACE "^lib" "" _dcu_name "${_dcu_name}")
+            message(STATUS
+                "DCU: ${_dcu_target} links missing ${_dcu_lib}, using -l${_dcu_name}")
+            list(APPEND _dcu_fixed_libs "${_dcu_name}")
+          else()
+            list(APPEND _dcu_fixed_libs "${_dcu_lib}")
+          endif()
+        endforeach()
+        set_target_properties(${_dcu_target} PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${_dcu_fixed_libs}")
+      endif()
+    endif()
+  endforeach()
+endif()
 
 if(FLAGGEMS_KERNEL)
   # Allow override via cmake var or env var

--- a/README.md
+++ b/README.md
@@ -233,12 +233,86 @@ FLAGOS_DISABLE_CUDA_ASSETS=1 python -c "import torch_fl, torch; \
   print((x @ x).cpu())"
 ```
 
+### Build from Source (Hygon DCU Platform)
+
+Hygon DCU (DTK) reuses the **CUDA boxing route** with a dedicated
+`ACCELERATOR=dcu` branch. Two properties of the vendor stack make this work:
+
+- The DCU `torch` wheel is a **hipified** build: it registers its HIP kernels
+  under the `CUDA` dispatch key and its tensors report `DeviceType::CUDA`
+  (`torch.version.cuda is None`, `torch.version.hip == '6.3.x'`). So the
+  generated PrivateUse1 → CUDA boxing kernels
+  (`csrc/aten/generated/cuda_kernels.cc`) dispatch into `libtorch_hip.so`
+  unchanged.
+- DTK ships a **CUDA compatibility toolkit** at `$DTK_ROOT/cuda/cuda-*` whose
+  `libcudart.so.12` is a thin shim over `libgalaxyhip.so` — the same runtime
+  `libtorch_hip.so` uses, so there is one driver state, not two. The runtime
+  sources under `csrc/runtime/accelerator/cuda/` therefore compile as-is with
+  plain host `g++`; no `nvcc`, no `hipcc`, no hipify pass.
+
+The build is **pure boxing**: `CUDA_KERNEL`, `FLAGGEMS_KERNEL` and
+`FLAGGEMS_PYTHON` are all forced off (DTK ships its own Triton, so the
+NVIDIA-targeted PyPI `triton` wheel is the wrong artifact and is not pulled in).
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+
+source /opt/dtk/env.sh          # exports ROCM_PATH; DTK_ROOT also honored
+
+ACCELERATOR=dcu pip install --no-build-isolation -vvv -e .
+```
+
+`DTK_ROOT` resolves from `DTK_ROOT` → `ROCM_PATH` → `/opt/dtk`. Pass it
+explicitly if DTK lives elsewhere.
+
+**Verify:**
+
+```bash
+python -c "
+import torch, torch_fl
+print('device count:', torch.flagos.device_count())
+x = torch.randn(512, 512, device='flagos')
+print('mm matches .cuda():',
+      torch.allclose(torch.mm(x, x).cpu(), torch.mm(x.cpu().cuda(), x.cpu().cuda()).cpu()))
+"
+```
+
+**Run tests** (deselect the FlagGems markers — this is a pure-boxing build):
+
+```bash
+pytest tests/unit tests/integration/test_allocator.py tests/integration/test_factory_ops.py -q
+pytest tests/integration/ops -q -m "not flaggems and not flaggems_python"
+```
+
+Notes:
+
+- **Memory pool.** flagos tensors and the boxed kernels' outputs share one pool.
+  `dcu_memory.h` delegates caching to torch's own allocator through the
+  device-generic registry (`c10::getDeviceAllocator(kCUDA)`) rather than the
+  `c10::cuda::` namespace — the DCU wheel exports `c10::hip::HIPCachingAllocator`
+  and has zero `c10::cuda` symbols, and `cuda_runtime.h` cannot share a
+  translation unit with `hip/hip_runtime.h`. So `memory_allocated()` /
+  `memory_reserved()` / `empty_cache()` report and act on real usage.
+- **`record_stream` is a no-op** on DCU: building a `c10::Stream` from a raw
+  stream handle needs `c10::cuda::getStreamFromExternal`, which this wheel does
+  not export.
+- **`.cuda()` autograd and `torch_fl` cannot share a process.** PyTorch's
+  `register_privateuse1_backend` makes `at::getAccelerator()` return
+  `PrivateUse1`, so the autograd engine finds no stream metadata for a
+  pure-CUDA graph and asserts in `engine.cpp`. This is upstream PrivateUse1
+  behaviour, identical on CUDA/MetaX/Ascend — flagos-device autograd is
+  unaffected. Take `.cuda()` baselines in a separate process.
+- **DTK's exported MIOpen CMake config** bakes in `/usr/lib/x86_64-linux-gnu/librt.so`,
+  which no longer exists on glibc ≥ 2.34 (librt was folded into libc). The
+  `ACCELERATOR=dcu` branch rewrites that dangling absolute path to `-lrt`.
+
 ### Build Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `ACCELERATOR` | Hardware platform: `cuda` (default), `metax`, or `ascend` |
+| `ACCELERATOR` | Hardware platform: `cuda` (default), `metax`, `ascend`, `tsingmicro`, or `dcu` |
 | `CUDA_HOME` | CUDA toolkit path |
+| `DTK_ROOT` | Hygon DTK path (falls back to `ROCM_PATH`, then `/opt/dtk`; required for DCU build) |
 | `METAX_PATH` | MetaX SDK path (default `/opt/maca`; required for MetaX build) |
 | `METAX_ARCH` / `METAX_MXCC` | Optional GPU arch or `mxcc`/`cucc` compiler path |
 | `METAX_KERNEL` | Enable MetaX C++ kernel build (`ON`/`OFF`; auto-enabled when `ACCELERATOR=metax`) |

--- a/README_zh.md
+++ b/README_zh.md
@@ -208,13 +208,82 @@ FLAGOS_DISABLE_CUDA_ASSETS=1 python -c "import torch_fl, torch; \
   print((x @ x).cpu())"
 ```
 
+### 从源码安装（海光 DCU 平台）
+
+海光 DCU（DTK）复用 **CUDA boxing 路线**，通过独立的 `ACCELERATOR=dcu` 分支支持。
+之所以可行，取决于厂商栈的两个特性：
+
+- DCU 的 `torch` wheel 是 **hipify 构建**：HIP 算子注册在 `CUDA` dispatch key 上，
+  张量的设备类型也报告为 `DeviceType::CUDA`（`torch.version.cuda is None`，
+  `torch.version.hip == '6.3.x'`）。因此生成的 PrivateUse1 → CUDA boxing 算子
+  （`csrc/aten/generated/cuda_kernels.cc`）无需改动即可分发进 `libtorch_hip.so`。
+- DTK 在 `$DTK_ROOT/cuda/cuda-*` 提供 **CUDA 兼容 toolkit**，其 `libcudart.so.12`
+  只是 `libgalaxyhip.so` 之上的一层薄壳——与 `libtorch_hip.so` 使用的是同一个
+  runtime，因此只有一份驱动状态，不会出现两套。`csrc/runtime/accelerator/cuda/`
+  下的 runtime 源码可以用普通 host `g++` 原样编译：不需要 `nvcc`、`hipcc`，也不
+  需要 hipify。
+
+该构建是 **纯 boxing**：`CUDA_KERNEL`、`FLAGGEMS_KERNEL`、`FLAGGEMS_PYTHON` 全部
+强制关闭（DTK 自带 Triton，PyPI 上面向 NVIDIA 的 `triton` wheel 是错误产物，因此
+不会被拉取）。
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+
+source /opt/dtk/env.sh          # 会导出 ROCM_PATH；DTK_ROOT 同样生效
+
+ACCELERATOR=dcu pip install --no-build-isolation -vvv -e .
+```
+
+`DTK_ROOT` 的解析顺序为 `DTK_ROOT` → `ROCM_PATH` → `/opt/dtk`。若 DTK 装在其他
+位置，显式传入即可。
+
+**验证：**
+
+```bash
+python -c "
+import torch, torch_fl
+print('device count:', torch.flagos.device_count())
+x = torch.randn(512, 512, device='flagos')
+print('mm matches .cuda():',
+      torch.allclose(torch.mm(x, x).cpu(), torch.mm(x.cpu().cuda(), x.cpu().cuda()).cpu()))
+"
+```
+
+**跑测试**（纯 boxing 构建，需要反选 FlagGems 相关 marker）：
+
+```bash
+pytest tests/unit tests/integration/test_allocator.py tests/integration/test_factory_ops.py -q
+pytest tests/integration/ops -q -m "not flaggems and not flaggems_python"
+```
+
+说明：
+
+- **内存池。** flagos 张量与 boxing 算子的输出共用一个池。`dcu_memory.h` 通过设备
+  无关的注册表（`c10::getDeviceAllocator(kCUDA)`）把 caching 委托给 torch 自己的
+  分配器，而不是走 `c10::cuda::` 命名空间——DCU wheel 导出的是
+  `c10::hip::HIPCachingAllocator`，完全没有 `c10::cuda` 符号，而且
+  `cuda_runtime.h` 与 `hip/hip_runtime.h` 无法出现在同一个编译单元里。因此
+  `memory_allocated()` / `memory_reserved()` / `empty_cache()` 统计与行为都是真实的。
+- **`record_stream` 在 DCU 上是 no-op**：从裸 stream 句柄构造 `c10::Stream` 需要
+  `c10::cuda::getStreamFromExternal`，该 wheel 未导出此符号。
+- **`.cuda()` 的反向与 `torch_fl` 不能在同一进程中共存。** PyTorch 的
+  `register_privateuse1_backend` 会让 `at::getAccelerator()` 返回 `PrivateUse1`，
+  于是 autograd 引擎在纯 CUDA 图上找不到 stream 元数据，在 `engine.cpp` 里断言失败。
+  这是上游 PrivateUse1 的既有行为，在 CUDA/MetaX/Ascend 上表现一致——flagos 设备
+  自身的反向不受影响。取 `.cuda()` 基准请放到独立进程里。
+- **DTK 导出的 MIOpen CMake 配置** 内嵌了 `/usr/lib/x86_64-linux-gnu/librt.so`
+  这个绝对路径，而 glibc ≥ 2.34 已把 librt 合并进 libc，该文件不再存在。
+  `ACCELERATOR=dcu` 分支会把这类悬空绝对路径改写为 `-lrt`。
+
 ### 构建环境变量
 
 | 变量 | 说明 |
 |------|------|
-| `ACCELERATOR` | 硬件平台：`cuda`（默认）、`metax` 或 `ascend` |
+| `ACCELERATOR` | 硬件平台：`cuda`（默认）、`metax`、`ascend`、`tsingmicro` 或 `dcu` |
 | `FLAGOS_BUILD_JOBS` | 原生库并行编译线程数（默认 CPU 核数）；日志过长可设 `1` |
 | `CUDA_HOME` | CUDA toolkit 路径 |
+| `DTK_ROOT` | 海光 DTK 路径（依次回退到 `ROCM_PATH`、`/opt/dtk`；DCU 构建必需） |
 | `METAX_PATH` | MetaX SDK 路径（默认 `/opt/maca`，metax 构建必需） |
 | `METAX_ARCH` / `METAX_MXCC` | 可选：GPU 架构或 mxcc/cucc 编译器路径 |
 | `METAX_KERNEL` | 启用 MetaX C++ kernel 构建（`ON`/`OFF`；`ACCELERATOR=metax` 时自动开启） |

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -135,6 +135,11 @@ if(ACCELERATOR STREQUAL "ascend")
 elseif(ACCELERATOR STREQUAL "tsingmicro")
   target_compile_definitions(${LIBRARY_NAME} PRIVATE USE_TSINGMICRO=1)
   target_link_libraries(${LIBRARY_NAME} PRIVATE ${_torch_fl_link_libs})
+elseif(ACCELERATOR STREQUAL "dcu")
+  # Selects backends/dcu_memory.h (CUDA-compat runtime, no c10::cuda caching
+  # delegation -- the DCU wheel exports c10::hip, not c10::cuda).
+  target_compile_definitions(${LIBRARY_NAME} PRIVATE USE_DCU=1)
+  target_link_libraries(${LIBRARY_NAME} PRIVATE ${_torch_fl_link_libs})
 else()
   target_link_libraries(${LIBRARY_NAME} PRIVATE ${_torch_fl_link_libs})
 endif()

--- a/csrc/runtime/accelerator/CMakeLists.txt
+++ b/csrc/runtime/accelerator/CMakeLists.txt
@@ -20,6 +20,8 @@ elseif(ACCELERATOR STREQUAL "metax")
   project(FLAGOS_RUNTIME CXX C)
 elseif(ACCELERATOR STREQUAL "tsingmicro")
   project(FLAGOS_RUNTIME CXX C)
+elseif(ACCELERATOR STREQUAL "dcu")
+  project(FLAGOS_RUNTIME CXX C)
 else()
   project(FLAGOS_RUNTIME CUDA CXX C)
 endif()
@@ -71,6 +73,16 @@ elseif(ACCELERATOR STREQUAL "tsingmicro")
   target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} /usr/local/kuiper/include)
   target_link_directories(${LIBRARY_NAME} PRIVATE /usr/local/kuiper/lib)
   target_link_libraries(${LIBRARY_NAME} PRIVATE hpgr)
+elseif(ACCELERATOR STREQUAL "dcu")
+  # DTK's CUDA compatibility toolkit provides cuda_runtime.h and a libcudart
+  # shim over libgalaxyhip, so the CUDA runtime sources build unchanged --
+  # no separate dcu/ directory, and no nvcc (plain host g++).
+  file(GLOB SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/cuda/*.cc")
+
+  add_library(${LIBRARY_NAME} SHARED ${SOURCE_FILES})
+
+  target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR})
+  target_link_libraries(${LIBRARY_NAME} PRIVATE ${CUDA_RUNTIME_LIB})
 else()
   file(GLOB SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/cuda/*.cc")
 

--- a/csrc/runtime/allocator/backends/dcu_memory.h
+++ b/csrc/runtime/allocator/backends/dcu_memory.h
@@ -1,0 +1,194 @@
+// Copyright (c) 2026, BAAI. All rights reserved.
+
+#pragma once
+
+#include "../device_memory_interface.h"
+
+#include <ATen/Context.h>
+#include <c10/core/CachingDeviceAllocator.h>
+
+#include <cuda_runtime.h>
+
+namespace c10::flagos {
+
+// DCU (Hygon, DTK) implementation of DeviceMemoryInterface.
+//
+// DTK ships a CUDA compatibility toolkit ($DTK_ROOT/cuda/cuda-12) whose
+// libcudart.so.12 is a thin shim over libgalaxyhip.so -- the very same runtime
+// libtorch_hip.so is built against. So the plain CUDA runtime calls below reach
+// the same driver state the vendor's HIP kernels use, and no hipify is needed
+// for raw memory ops.
+//
+// Caching is delegated to torch's own device allocator, exactly as on NVIDIA --
+// but reached through the device-type-generic registry rather than the
+// c10::cuda:: namespace. That indirection matters here: the DCU wheel exports
+// c10::hip::HIPCachingAllocator and has zero c10::cuda symbols, and we cannot
+// call the HIP API directly because cuda_runtime.h and hip/hip_runtime.h cannot
+// coexist in one translation unit (dim3, uchar1..char4 etc. collide).
+// c10::getDeviceAllocator(kCUDA) sidesteps both problems: it is a header-only
+// lookup in c10's allocator registry, where the hipified build registers its
+// HIPCachingAllocator under DeviceType::CUDA (the same reason the boxing
+// kernels work at all).
+//
+// Net effect: flagos tensors and the boxed kernels' outputs share ONE pool, so
+// memory_allocated()/memory_reserved()/empty_cache() report and act on real
+// usage -- matching backends/cuda_memory.h.
+class DcuDeviceMemory final : public DeviceMemoryInterface {
+ public:
+  Error_t device_malloc(void** ptr, size_t size) override {
+    // Ensure the allocation lands on the current process device (matters under
+    // DDP, where each rank sets its own device).
+    int device = 0;
+    cudaGetDevice(&device);
+    cudaError_t set_err = cudaSetDevice(device);
+    if (set_err != cudaSuccess) {
+      *ptr = nullptr;
+      return ErrorInvalidDevice;
+    }
+    cudaError_t err = cudaMalloc(ptr, size);
+    if (err != cudaSuccess) {
+      *ptr = nullptr;
+      return ErrorMemoryAllocation;
+    }
+    return Success;
+  }
+
+  Error_t device_free(void* ptr) override {
+    cudaError_t err = cudaFree(ptr);
+    return (err == cudaSuccess) ? Success : ErrorUnknown;
+  }
+
+  Error_t get_device_index(int* device) override {
+    cudaError_t err = cudaGetDevice(device);
+    return (err == cudaSuccess) ? Success : ErrorUnknown;
+  }
+
+  Error_t set_device(int device) override {
+    cudaError_t err = cudaSetDevice(device);
+    return (err == cudaSuccess) ? Success : ErrorInvalidDevice;
+  }
+
+  Error_t get_memory_info(size_t* free, size_t* total) override {
+    cudaError_t err = cudaMemGetInfo(free, total);
+    return (err == cudaSuccess) ? Success : ErrorUnknown;
+  }
+
+  Error_t event_create(Event_t* event) override {
+    cudaEvent_t cuda_event;
+    cudaError_t err =
+        cudaEventCreateWithFlags(&cuda_event, cudaEventDisableTiming);
+    if (err != cudaSuccess) {
+      return ErrorUnknown;
+    }
+    *event = reinterpret_cast<Event_t>(cuda_event);
+    return Success;
+  }
+
+  Error_t event_destroy(Event_t event) override {
+    cudaError_t err = cudaEventDestroy(reinterpret_cast<cudaEvent_t>(event));
+    return (err == cudaSuccess) ? Success : ErrorUnknown;
+  }
+
+  Error_t event_record(Event_t event, Stream_t stream) override {
+    cudaError_t err = cudaEventRecord(
+        reinterpret_cast<cudaEvent_t>(event),
+        reinterpret_cast<cudaStream_t>(stream));
+    return (err == cudaSuccess) ? Success : ErrorUnknown;
+  }
+
+  Error_t event_query(Event_t event) override {
+    cudaError_t err = cudaEventQuery(reinterpret_cast<cudaEvent_t>(event));
+    if (err == cudaSuccess) {
+      return Success;
+    } else if (err == cudaErrorNotReady) {
+      return ErrorNotReady;
+    }
+    return ErrorUnknown;
+  }
+
+  Error_t memcpy(void* dst, const void* src, size_t count, MemcpyKind kind)
+      override {
+    cudaMemcpyKind cuda_kind;
+    switch (kind) {
+      case MemcpyHostToHost:
+        cuda_kind = cudaMemcpyHostToHost;
+        break;
+      case MemcpyHostToDevice:
+        cuda_kind = cudaMemcpyHostToDevice;
+        break;
+      case MemcpyDeviceToHost:
+        cuda_kind = cudaMemcpyDeviceToHost;
+        break;
+      case MemcpyDeviceToDevice:
+        cuda_kind = cudaMemcpyDeviceToDevice;
+        break;
+      default:
+        return ErrorUnknown;
+    }
+    cudaError_t err = cudaMemcpy(dst, src, count, cuda_kind);
+    return (err == cudaSuccess) ? Success : ErrorUnknown;
+  }
+
+  // --- Caching delegation to torch's own (HIP) device allocator ---
+
+  bool provides_caching() const override { return true; }
+
+  void* caching_alloc(size_t nbytes, Stream_t stream) override {
+    // CachingDeviceAllocator only ever asks for the current stream (it passes
+    // nullptr), and the generic DeviceAllocator has no alloc-with-stream entry
+    // point, so there is nothing to honor here. raw_allocate() associates the
+    // block with the current stream, which is the one the boxed kernels run on.
+    (void)stream;
+    return allocator()->raw_allocate(nbytes);
+  }
+
+  void caching_free(void* ptr) override { allocator()->raw_deallocate(ptr); }
+
+  void caching_empty_cache() override { allocator()->emptyCache(); }
+
+  void caching_record_stream(void* /*ptr*/, Stream_t /*stream*/) override {
+    // No-op. DeviceAllocator::recordStream needs a c10::Stream on the CUDA
+    // device type, and the only way to build one from a raw stream handle is
+    // c10::cuda::getStreamFromExternal -- a symbol this wheel does not export.
+    // This is not a regression: flagos stream ids are raw device stream
+    // pointers, so before delegation the block lookup for a torch-pool pointer
+    // failed and record_stream returned without doing anything either.
+  }
+
+  bool caching_get_stats(int device, AllocatorStats* out) override {
+    auto st = allocator()->getDeviceStats(static_cast<c10::DeviceIndex>(device));
+    constexpr auto kAgg =
+        static_cast<size_t>(c10::CachingAllocator::StatType::AGGREGATE);
+    out->bytes_allocated =
+        static_cast<size_t>(st.allocated_bytes[kAgg].current);
+    out->bytes_reserved = static_cast<size_t>(st.reserved_bytes[kAgg].current);
+    out->peak_allocated = static_cast<size_t>(st.allocated_bytes[kAgg].peak);
+    out->peak_reserved = static_cast<size_t>(st.reserved_bytes[kAgg].peak);
+    out->num_alloc_calls = static_cast<size_t>(st.allocation[kAgg].allocated);
+    out->num_free_calls = static_cast<size_t>(st.allocation[kAgg].freed);
+    out->num_device_malloc = static_cast<size_t>(st.num_device_alloc);
+    out->num_device_free = static_cast<size_t>(st.num_device_free);
+    out->num_alloc_retries = static_cast<size_t>(st.num_alloc_retries);
+    return true;
+  }
+
+  void caching_reset_peak_stats(int device) override {
+    allocator()->resetPeakStats(static_cast<c10::DeviceIndex>(device));
+  }
+
+ private:
+  // The HIP caching allocator asserts unless its per-device tables are sized by
+  // init(device_count). PyTorch normally does that during torch.cuda lazy init;
+  // in the flagos external-libtorch scheme we may allocate before that runs, so
+  // drive it ourselves. lazyInitDevice is the device-generic entry point, so
+  // this needs no c10::cuda / c10::hip symbol.
+  static c10::DeviceAllocator* allocator() {
+    static c10::DeviceAllocator* alloc = []() {
+      at::globalContext().lazyInitDevice(c10::DeviceType::CUDA);
+      return c10::getDeviceAllocator(c10::DeviceType::CUDA);
+    }();
+    return alloc;
+  }
+};
+
+} // namespace c10::flagos

--- a/csrc/runtime/allocator/caching_device_allocator.cc
+++ b/csrc/runtime/allocator/caching_device_allocator.cc
@@ -5,7 +5,10 @@
 #if defined(USE_ASCEND)
 #include "backends/ascend_memory.h"
 #endif
-#if !defined(USE_ASCEND) && !defined(USE_TSINGMICRO)
+#if defined(USE_DCU)
+#include "backends/dcu_memory.h"
+#endif
+#if !defined(USE_ASCEND) && !defined(USE_TSINGMICRO) && !defined(USE_DCU)
 #include "backends/cuda_memory.h"
 #endif
 #if defined(USE_TSINGMICRO)
@@ -514,13 +517,17 @@ CachingDeviceAllocator* GetCachingAllocator() {
   static std::once_flag flag;
   std::call_once(flag, []() {
     // Select backend based on build configuration.
-    // For now, we always create the CUDA backend when this code is compiled.
-    // Metax and Ascend backends will be added later.
 #if defined(USE_ASCEND)
     auto backend = std::make_unique<AscendDeviceMemory>();
     alloc = std::make_unique<CachingDeviceAllocator>(std::move(backend));
 #elif defined(USE_TSINGMICRO)
     auto backend = std::make_unique<TsingMicroDeviceMemory>();
+    alloc = std::make_unique<CachingDeviceAllocator>(std::move(backend));
+#elif defined(USE_DCU)
+    // DCU: DTK's CUDA compatibility layer supplies the runtime API, and caching
+    // delegates to torch's own allocator via the device-generic registry --
+    // c10::hip under the hood, no c10::cuda symbols (see backends/dcu_memory.h).
+    auto backend = std::make_unique<DcuDeviceMemory>();
     alloc = std::make_unique<CachingDeviceAllocator>(std::move(backend));
 #else
     // CUDA (and Metax, which uses CUDA-compatible API)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ name = "torch_fl"
 # Version is computed in setup.py: the MetaX self-contained build appends a
 # local segment (e.g. 0.1.0+metax3.8.1) via FLAGOS_WHEEL_LOCAL. A static value
 # here would override setup()'s version, so it must be declared dynamic.
-dynamic = ["version"]
 description = "FlagGems operators as a custom PyTorch device (flagos)"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -45,11 +44,11 @@ classifiers = [
 # runtime dependency (pure Python + Triton, installs cleanly from PyPI). It is
 # NOT vendored into the wheel — flag_gems iterates fast and pinning a copy would
 # only make upgrades harder. Versions match the validated 2.10 env.
-dependencies = [
-    "torch",
-    "flag_gems>=5.0.2",
-    "triton>=3.5.1",
-]
+#
+# Declared dynamic so setup.py can drop flag_gems/triton on platforms built in
+# pure-boxing mode (ACCELERATOR=dcu), where PyPI's NVIDIA-targeted triton wheel
+# is the wrong artifact — DTK ships its own. See _install_requires() in setup.py.
+dynamic = ["version", "dependencies"]
 
 [project.optional-dependencies]
 dev = [

--- a/setup.py
+++ b/setup.py
@@ -274,6 +274,22 @@ def _setup_metax_build_env(env: dict) -> str:
     return metax_path
 
 
+def _dtk_root() -> str:
+    """Hygon DTK install root. Honors DTK_ROOT, then ROCM_PATH (what DTK's
+    env.sh exports), then the default install location."""
+    for key in ("DTK_ROOT", "ROCM_PATH"):
+        path = os.environ.get(key)
+        if path and os.path.isdir(path):
+            return path
+    default = "/opt/dtk"
+    if not os.path.isdir(default):
+        raise RuntimeError(
+            "ACCELERATOR=dcu selected, but no DTK installation was found. "
+            "Source DTK's env.sh or set DTK_ROOT to the install root."
+        )
+    return default
+
+
 def _cmake_build_jobs() -> int:
     """Parallel compile jobs for cmake/ninja. Set FLAGOS_BUILD_JOBS=1 for serial logs."""
     for key in ("FLAGOS_BUILD_JOBS", "MAX_JOBS", "CMAKE_BUILD_PARALLEL_LEVEL"):
@@ -332,6 +348,22 @@ def build_deps():
                 "-DASCEND_KERNEL=OFF",
             ]
         )
+    elif ACCELERATOR == "dcu":
+        # Pure boxing build. The DCU torch wheel is a hipified build whose HIP
+        # kernels are registered under the CUDA dispatch key, so the generated
+        # PrivateUse1 -> CUDA boxing kernels reach them with no hand-written
+        # kernels of our own. FLAGGEMS_KERNEL needs liboperators.so (not built
+        # for DTK); FLAGGEMS_PYTHON needs a DTK triton, which is a separate
+        # install -- both stay off unless explicitly requested below.
+        cmake_args.extend(
+            [
+                "-DCUDA_KERNEL=OFF",
+                "-DFLAGGEMS_KERNEL=OFF",
+                "-DFLAGGEMS_PYTHON=OFF",
+                "-DMETAX_KERNEL=OFF",
+                "-DASCEND_KERNEL=OFF",
+            ]
+        )
 
     # Kernel build options from environment
     for kernel_opt in (
@@ -373,6 +405,8 @@ def build_deps():
         flaggems_dir = _find_flaggems_dir()
         if flaggems_dir:
             cmake_args.append(f"-DFLAGGEMS_DIR={flaggems_dir}")
+    elif ACCELERATOR == "dcu":
+        cmake_args.append(f"-DDTK_ROOT={_dtk_root()}")
 
     subprocess.check_call([cmake, BASE_DIR] + cmake_args, cwd=build_dir, env=build_env)
 
@@ -609,6 +643,14 @@ def _cuda_runtime_requires():
 
 def _install_requires():
     reqs = ["torch"]
+    # FlagGems (and its Triton) is the default operator source, so it is a hard
+    # runtime dep everywhere it can actually run. ACCELERATOR=dcu is the
+    # exception: it builds pure-boxing (FLAGGEMS_KERNEL/FLAGGEMS_PYTHON off) and
+    # DTK ships its own Triton, so pulling PyPI's NVIDIA-targeted triton wheel
+    # would install ~200 MB of the wrong artifact. All flag_gems imports in the
+    # Python layer are ImportError-guarded, so omitting it is safe.
+    if ACCELERATOR != "dcu":
+        reqs += ["flag_gems>=5.0.2", "triton>=3.5.1"]
     # For a CUDA wheel we bundle libtorch_cuda.so and preload it at import; it
     # needs the NVIDIA runtime libs present, so make them hard deps. Ascend/MetaX
     # builds do not (they supply their own runtime), so keep it CUDA-only.


### PR DESCRIPTION
## Summary

Adds Hygon DCU (DTK) support via the existing CUDA-boxing route, under a new
`ACCELERATOR=dcu` branch. No new kernels and no hipify pass — two properties of
the vendor stack make the existing boxing machinery work unchanged:

- The DCU `torch` wheel is a **hipified** build: HIP kernels are registered under
  the `CUDA` dispatch key and tensors report `DeviceType::CUDA`
  (`torch.version.cuda is None`, `torch.version.hip == '6.3.x'`). So the generated
  PrivateUse1 → CUDA boxing kernels (`csrc/aten/generated/cuda_kernels.cc`)
  dispatch into `libtorch_hip.so` as-is.
- DTK ships a **CUDA compatibility toolkit** at `$DTK_ROOT/cuda/cuda-*` whose
  `libcudart.so.12` is a thin shim over `libgalaxyhip.so` — the same runtime
  `libtorch_hip.so` uses, so there is one driver state, not two. The runtime
  sources under `csrc/runtime/accelerator/cuda/` compile with plain host `g++`;
  no `nvcc`, no `hipcc`.

The build is pure boxing: `CUDA_KERNEL`, `FLAGGEMS_KERNEL` and `FLAGGEMS_PYTHON`
are forced off.

## Changes

| File | Change |
|------|--------|
| `csrc/runtime/allocator/backends/dcu_memory.h` | **New.** `DeviceMemoryInterface` on DTK's CUDA-compat runtime, plus caching delegation |
| `CMakeLists.txt` | `ACCELERATOR=dcu` project branch, DTK/compat-toolkit discovery, `cuda_runtime_compat` target, RPATH, MIOpen `librt` fixup |
| `csrc/CMakeLists.txt` | `USE_DCU=1` |
| `csrc/runtime/accelerator/CMakeLists.txt` | Reuse `cuda/*.cc` for dcu (no separate `dcu/` dir) |
| `csrc/runtime/allocator/caching_device_allocator.cc` | Select `DcuDeviceMemory` under `USE_DCU` |
| `setup.py` | `_dtk_root()`, dcu cmake args, drop `flag_gems`/`triton` for dcu only |
| `pyproject.toml` | `dependencies` made dynamic so `setup.py` controls the list |
| `README.md` / `README_zh.md` | DCU build sections + env-var table entries |

### Memory pool

`dcu_memory.h` delegates caching to torch's own allocator, but reaches it through
the **device-generic registry** (`c10::getDeviceAllocator(kCUDA)` +
`at::globalContext().lazyInitDevice`) rather than the `c10::cuda::` namespace.
That indirection is required here: the DCU wheel exports
`c10::hip::HIPCachingAllocator` and has zero `c10::cuda` symbols, and
`cuda_runtime.h` cannot share a translation unit with `hip/hip_runtime.h`
(`dim3`, `uchar1..char4` collide). The registry lookup is header-only and the
hipified build registers its allocator under `DeviceType::CUDA` — the same reason
boxing works at all.

Result: flagos tensors and boxed-kernel outputs share **one** pool, so
`memory_allocated()` / `memory_reserved()` / `empty_cache()` report and act on
real usage. Verified: a 1 MiB flagos tensor shows as exactly 1 MiB in both
`torch_fl.flagos.memory_allocated(0)` and `torch.cuda.memory_allocated(0)`.

`record_stream` is a documented no-op on DCU — building a `c10::Stream` from a
raw stream handle needs `c10::cuda::getStreamFromExternal`, which this wheel does
not export. Not a regression: it was already effectively a no-op, since a
torch-pool pointer never resolved to a block in the local pool.

### DTK MIOpen CMake fixup

DTK's exported `miopen-targets.cmake` bakes
`/usr/lib/x86_64-linux-gnu/librt.so` into its link interface. glibc ≥ 2.34 folded
librt into libc, so that symlink no longer exists and the generated makefiles die
with `No rule to make target '/usr/lib/x86_64-linux-gnu/librt.so'`. The `dcu`
branch rewrites any dangling absolute path in that target to its bare `-l` name.

## Testing

Real hardware: Hygon DCU "BW", 8 devices, DTK 26.04-rc4,
`torch 2.10.0+das.opt1.dtk2604`, Python 3.10.

- **Build** — clean rebuild from an empty `build/` reproduces; `ACCELERATOR=dcu pip install --no-build-isolation -e .`
- **Numerics vs `.cuda()` — 11/11 bit-identical** (`max_err = 0.000e+00` on all):
  mm 512×512, add, mul, softmax(-1), relu, sum, bmm, mm bf16, mm fp16,
  mm+relu+pow backward, d2d roundtrip `flagos:0 ↔ flagos:1`
- **`tests/unit` + `test_allocator.py` + `test_factory_ops.py`** — 63 passed, 0 failed
- **`tests/integration/ops` + `test_ops.py` + `test_clone_dispatch_case.py`** —
  406 passed, 0 failed, 45 skipped, 44 deselected, 3 xpassed
  (with the repo-documented `-m "not flaggems and not flaggems_python"`, since
  this is a pure-boxing build)

Not verified: `test_fallback_trace*.py` and the Qwen3 tests need `transformers`,
which is not installed in this environment.

## Note for reviewers

`import torch_fl` makes `at::getAccelerator()` return `PrivateUse1`, so native
`.cuda()` autograd asserts in `engine.cpp` in the same process (the engine finds
no stream metadata for a pure-CUDA graph). This is upstream `register_privateuse1_backend`
behaviour, identical on CUDA/MetaX/Ascend — flagos-device autograd is unaffected.
The test above takes its `.cuda()` autograd baseline in a subprocess for this
reason; it is documented in both READMEs.
