### PR TITLE
ci: exercise FlagGems runtime path in integration-test-cuda

### DIFF
--- a/.github/workflows/integration-test-cuda.yml
+++ b/.github/workflows/integration-test-cuda.yml
@@ -48,8 +48,13 @@ jobs:
           pip install -e . --no-build-isolation
           pip install pytest
 
-      - name: Run ops tests
+      - name: Run ops tests (vendor backend)
         run: pytest tests/integration/ops/ -v -s --tb=short
+
+      - name: Run ops tests (FlagGems runtime path)
+        env:
+          FLAGOS_USE_FLAGGEMS: "1"
+        run: pytest tests/integration/ops/ -m flaggems -v -s --tb=short
 
       - name: Run general tests
         run: pytest tests/integration/test_factory_ops.py -v --device cuda --tb=short


### PR DESCRIPTION
## Problem

The CUDA integration workflow ran ops tests only with the default vendor backend. Under that config the `flaggems`-marked dispatch tests are skipped by conftest (they require `FLAGOS_USE_FLAGGEMS=1`), so CI never exercised the FlagGems Python runtime path.

## Change

Split the ops test step into two:
1. **Vendor backend** (unchanged): `pytest tests/integration/ops/ -v -s` — runs the full suite on the default vendor path.
2. **FlagGems runtime path** (new): `FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/ops/ -m flaggems -v -s` — runs the 7 flaggems-marked dispatch tests, exercising routing to `flagos_python` (mm/bmm/bmm.out/_softmax/embedding) and vendor fallback (mm.out/cat).

Now CI covers both vendor and FlagGems operator paths.

## Verification

Local (NVIDIA A100):
```
FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/ops/ -m flaggems -q
# -> 7 passed, 422 deselected
```