### PR TITLE
test(ops): full FlagGems routing consistency + main_ops CI subset

### DIFF
--- a/.github/workflows/integration-test-cuda.yml
+++ b/.github/workflows/integration-test-cuda.yml
@@ -48,13 +48,16 @@ jobs:
           pip install -e . --no-build-isolation
           pip install pytest
 
-      - name: Run ops tests (vendor backend)
-        run: pytest tests/integration/ops/ -v -s --tb=short
+      - name: Check FlagGems routing consistency (conf <-> codegen)
+        run: pytest tests/integration/ops/test_flaggems_conf_consistency.py -v --tb=short
 
-      - name: Run ops tests (FlagGems runtime path)
+      - name: Run ops tests (vendor backend, main ops)
+        run: pytest tests/integration/ops/ -m main_ops -v -s --tb=short
+
+      - name: Run ops tests (FlagGems runtime path, main ops)
         env:
           FLAGOS_USE_FLAGGEMS: "1"
-        run: pytest tests/integration/ops/ -m flaggems -v -s --tb=short
+        run: pytest tests/integration/ops/ -m "flaggems and main_ops" -v -s --tb=short
 
       - name: Run general tests
         run: pytest tests/integration/test_factory_ops.py -v --device cuda --tb=short

--- a/.github/workflows/integration-test-metax.yml
+++ b/.github/workflows/integration-test-metax.yml
@@ -61,6 +61,11 @@ jobs:
           ACCELERATOR=metax pip install -e . --no-build-isolation
           pip install pytest
 
+      - name: Check FlagGems routing consistency (conf <-> codegen)
+        run: |
+          export LD_LIBRARY_PATH=/opt/maca-3.3.0/tools/cu-bridge/lib:$LD_LIBRARY_PATH
+          pytest tests/integration/ops/test_flaggems_conf_consistency.py -v --tb=short
+
       - name: Run ops tests
         run: |
           export LD_LIBRARY_PATH=/opt/maca-3.3.0/tools/cu-bridge/lib:$LD_LIBRARY_PATH

--- a/tests/integration/ops/conftest.py
+++ b/tests/integration/ops/conftest.py
@@ -104,3 +104,8 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "flaggems_python: requires FlagGems Python wrapper backend"
     )
+    config.addinivalue_line(
+        "markers",
+        "main_ops: representative operator in the CI smoke subset "
+        "(select with -m main_ops); orthogonal to the backend markers",
+    )

--- a/tests/integration/ops/test_abs_dispatch.py
+++ b/tests/integration/ops/test_abs_dispatch.py
@@ -129,7 +129,18 @@ class TestAbsDispatch:
         )
         assert "[flagos dispatch] abs -> flagos_python" in result.stderr
 
+    @pytest.mark.flaggems
+    @pytest.mark.main_ops
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, abs routes to flagos_python."""
+        result = _run_abs_subprocess(
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
+        )
+        assert result.returncode == 0, f"Failed:\n{result.stderr}"
+        assert "[flagos dispatch] abs -> flagos_python" in result.stderr
+
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         result = _run_abs_subprocess(
             {

--- a/tests/integration/ops/test_add_dispatch.py
+++ b/tests/integration/ops/test_add_dispatch.py
@@ -114,7 +114,18 @@ class TestAddTensorDispatch:
         )
         assert "[flagos dispatch] add.Tensor -> flagos_python" in result.stderr
 
+    @pytest.mark.flaggems
+    @pytest.mark.main_ops
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, add.Tensor routes to flagos_python."""
+        result = _run_add_subprocess(
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
+        )
+        assert result.returncode == 0, f"Failed:\n{result.stderr}"
+        assert "[flagos dispatch] add.Tensor -> flagos_python" in result.stderr
+
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         result = _run_add_subprocess(
             {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_add__Tensor": "cuda"}

--- a/tests/integration/ops/test_bmm_dispatch.py
+++ b/tests/integration/ops/test_bmm_dispatch.py
@@ -253,6 +253,7 @@ class TestBmmDispatchLog:
         )
 
     @pytest.mark.flaggems
+    @pytest.mark.main_ops
     def test_dispatch_log_flaggems_runtime(self):
         """With the FlagGems runtime path on, bmm routes to flagos_python."""
         result = _run_bmm_subprocess(
@@ -263,6 +264,7 @@ class TestBmmDispatchLog:
         )
 
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         """FLAGOS_OP_bmm=cuda overrides to cuda backend."""
         result = _run_bmm_subprocess(

--- a/tests/integration/ops/test_cat_dispatch.py
+++ b/tests/integration/ops/test_cat_dispatch.py
@@ -476,6 +476,7 @@ class TestCatDispatchLog:
         )
 
     @pytest.mark.flaggems
+    @pytest.mark.main_ops
     def test_dispatch_log_flaggems_runtime(self):
         """With the FlagGems runtime path on, cat falls back to the vendor kernel.
 
@@ -491,6 +492,7 @@ class TestCatDispatchLog:
         )
 
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         """FLAGOS_OP_cat=cuda overrides to cuda backend."""
         result = _run_cat_subprocess(

--- a/tests/integration/ops/test_embedding_dispatch.py
+++ b/tests/integration/ops/test_embedding_dispatch.py
@@ -168,6 +168,7 @@ class TestEmbeddingDispatchLog:
         assert "[flagos dispatch] embedding -> flagos_python" in result.stderr
 
     @pytest.mark.flaggems
+    @pytest.mark.main_ops
     def test_dispatch_log_flaggems_runtime(self):
         """With the FlagGems runtime path on, embedding routes to flagos_python.
 
@@ -183,6 +184,7 @@ class TestEmbeddingDispatchLog:
         )
 
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         result = _run_embedding_subprocess(
             {

--- a/tests/integration/ops/test_flaggems_conf_consistency.py
+++ b/tests/integration/ops/test_flaggems_conf_consistency.py
@@ -1,0 +1,172 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FlagGems routing consistency (full coverage)
+
+Every op that ``backends_flaggems.conf`` routes to ``flagos_python`` must have a
+real ``Backend::kFlagOsPython`` kernel generated in the C++ layer, and vice
+versa. This guards the whole FlagGems Python surface (currently ~319 ops)
+against drift between the runtime config and the codegen output -- if someone
+adds a ``= flagos_python`` line without a kernel (or regenerates kernels without
+updating the conf), this test fails and names the offending ops.
+
+This is a pure text/parse check: it reads the shipped config and generated
+sources, so it needs no GPU, no ``flag_gems`` install, and runs in
+milliseconds on any platform.
+
+The op-name -> kernel bridge is:
+
+    conf ``op = flagos_python``
+      -> register.inc  ``m.impl("op", WrapperFoo);``
+      -> WrapperFoo body ``... foo_dispatcher(...)``
+      -> flaggems_python_kernels.cc
+         ``REGISTER_IMPL_TO_DISPATCHER(_, foo_dispatcher, Backend::kFlagOsPython, _)``
+
+so we compare the set of ``*_dispatcher`` names on each side.
+
+Usage:
+    pytest tests/integration/ops/test_flaggems_conf_consistency.py -v
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+# tests/integration/ops/<this file> -> repo root is three levels up.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CONF = _REPO_ROOT / "torch_fl" / "configs" / "backends_flaggems.conf"
+_REGISTER_INC = _REPO_ROOT / "csrc" / "aten" / "generated" / "register.inc"
+_KERNELS_CC = _REPO_ROOT / "csrc" / "aten" / "generated" / "flaggems_python_kernels.cc"
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"expected generated/config file is missing: {path}"
+    return path.read_text()
+
+
+def _conf_flagos_python_ops() -> set[str]:
+    """Op names that backends_flaggems.conf routes to the flagos_python slot."""
+    ops: set[str] = set()
+    for raw in _read(_CONF).splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        op, backend = (part.strip() for part in line.split("=", 1))
+        if backend == "flagos_python":
+            ops.add(op)
+    return ops
+
+
+def _op_to_wrapper() -> dict[str, str]:
+    """``m.impl("op", WrapperFoo);`` -> {op: WrapperFoo} from register.inc."""
+    return dict(re.findall(r'm\.impl\("([^"]+)",\s*(\w+)\);', _read(_REGISTER_INC)))
+
+
+def _wrapper_to_dispatcher() -> dict[str, str]:
+    """WrapperFoo(...) { ... foo_dispatcher(...) } -> {WrapperFoo: foo_dispatcher}."""
+    return dict(
+        re.findall(
+            r"(\w+)\([^;{]*\)\s*\{\s*(?:return\s+)?"
+            r"(?:at::native::flagos::)?(\w+_dispatcher)\(",
+            _read(_REGISTER_INC),
+        )
+    )
+
+
+def _cc_flagos_python_dispatchers() -> set[str]:
+    """Dispatcher names registered with Backend::kFlagOsPython in the kernels cc."""
+    return set(
+        re.findall(
+            r"REGISTER_IMPL_TO_DISPATCHER\(\s*\w+\s*,\s*(\w+)\s*,"
+            r"\s*Backend::kFlagOsPython",
+            _read(_KERNELS_CC),
+        )
+    )
+
+
+def _conf_dispatchers() -> tuple[set[str], list[str]]:
+    """Map conf flagos_python ops to their dispatcher names via register.inc.
+
+    Returns (dispatcher_names, unmapped_ops).
+    """
+    op2wrap = _op_to_wrapper()
+    wrap2disp = _wrapper_to_dispatcher()
+    dispatchers: set[str] = set()
+    unmapped: list[str] = []
+    for op in _conf_flagos_python_ops():
+        wrapper = op2wrap.get(op)
+        dispatcher = wrap2disp.get(wrapper) if wrapper else None
+        if dispatcher:
+            dispatchers.add(dispatcher)
+        else:
+            unmapped.append(op)
+    return dispatchers, sorted(unmapped)
+
+
+class TestFlagGemsConfConsistency:
+    """backends_flaggems.conf <-> generated kFlagOsPython kernels must agree."""
+
+    @pytest.mark.anyplatform
+    def test_conf_has_flagos_python_ops(self):
+        """Sanity: the conf actually routes a meaningful number of ops here."""
+        ops = _conf_flagos_python_ops()
+        assert len(ops) > 100, (
+            f"expected many flagos_python ops in {_CONF.name}, got {len(ops)}"
+        )
+
+    @pytest.mark.anyplatform
+    def test_every_conf_op_maps_to_a_dispatcher(self):
+        """Every flagos_python op resolves through register.inc to a dispatcher."""
+        _, unmapped = _conf_dispatchers()
+        assert not unmapped, (
+            "conf routes these ops to flagos_python but register.inc has no "
+            f"m.impl/dispatcher for them: {unmapped}"
+        )
+
+    @pytest.mark.anyplatform
+    def test_conf_ops_have_flagos_python_kernels(self):
+        """Each flagos_python op must have a real kFlagOsPython C++ kernel."""
+        conf_disp, _ = _conf_dispatchers()
+        cc_disp = _cc_flagos_python_dispatchers()
+        missing = sorted(conf_disp - cc_disp)
+        assert not missing, (
+            "these ops are routed to flagos_python in "
+            f"{_CONF.name} but have NO kFlagOsPython kernel in "
+            f"{_KERNELS_CC.name} (conf/codegen drift): {missing}"
+        )
+
+    @pytest.mark.anyplatform
+    def test_no_orphan_flagos_python_kernels(self):
+        """No kFlagOsPython kernel exists without a conf route pointing at it."""
+        conf_disp, _ = _conf_dispatchers()
+        cc_disp = _cc_flagos_python_dispatchers()
+        orphans = sorted(cc_disp - conf_disp)
+        assert not orphans, (
+            f"these kFlagOsPython kernels in {_KERNELS_CC.name} are not routed "
+            f"to flagos_python by any op in {_CONF.name} (orphan kernels): "
+            f"{orphans}"
+        )
+
+    @pytest.mark.anyplatform
+    def test_counts_match(self):
+        """Both sides expose the exact same number of flagos_python routes."""
+        conf_disp, _ = _conf_dispatchers()
+        cc_disp = _cc_flagos_python_dispatchers()
+        assert len(conf_disp) == len(cc_disp), (
+            f"flagos_python route count mismatch: conf={len(conf_disp)} "
+            f"kernels={len(cc_disp)}"
+        )

--- a/tests/integration/ops/test_mean_dispatch.py
+++ b/tests/integration/ops/test_mean_dispatch.py
@@ -116,7 +116,18 @@ class TestMeanDimDispatch:
         )
         assert "[flagos dispatch] mean.dim -> flagos_python" in result.stderr
 
+    @pytest.mark.flaggems
+    @pytest.mark.main_ops
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, mean.dim routes to flagos_python."""
+        result = _run_mean_subprocess(
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
+        )
+        assert result.returncode == 0, f"Failed:\n{result.stderr}"
+        assert "[flagos dispatch] mean.dim -> flagos_python" in result.stderr
+
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         result = _run_mean_subprocess(
             {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_mean__dim": "cuda"}

--- a/tests/integration/ops/test_mm_dispatch.py
+++ b/tests/integration/ops/test_mm_dispatch.py
@@ -195,6 +195,7 @@ class TestMmDispatchLog:
         )
 
     @pytest.mark.flaggems
+    @pytest.mark.main_ops
     def test_dispatch_log_flaggems_runtime(self):
         """With the FlagGems runtime path on, mm routes to flagos_python."""
         result = _run_mm_subprocess(
@@ -205,6 +206,7 @@ class TestMmDispatchLog:
         )
 
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         """FLAGOS_OP_mm=cuda overrides to cuda backend."""
         result = _run_mm_subprocess(

--- a/tests/integration/ops/test_mul_dispatch.py
+++ b/tests/integration/ops/test_mul_dispatch.py
@@ -105,7 +105,18 @@ class TestMulTensorDispatch:
         )
         assert "[flagos dispatch] mul.Tensor -> flagos_python" in result.stderr
 
+    @pytest.mark.flaggems
+    @pytest.mark.main_ops
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, mul.Tensor routes to flagos_python."""
+        result = _run_mul_subprocess(
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
+        )
+        assert result.returncode == 0, f"Failed:\n{result.stderr}"
+        assert "[flagos dispatch] mul.Tensor -> flagos_python" in result.stderr
+
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         result = _run_mul_subprocess(
             {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_mul__Tensor": "cuda"}

--- a/tests/integration/ops/test_neg_dispatch.py
+++ b/tests/integration/ops/test_neg_dispatch.py
@@ -121,7 +121,18 @@ class TestNegDispatch:
         )
         assert "[flagos dispatch] neg -> flagos_python" in result.stderr
 
+    @pytest.mark.flaggems
+    @pytest.mark.main_ops
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, neg routes to flagos_python."""
+        result = _run_neg_subprocess(
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
+        )
+        assert result.returncode == 0, f"Failed:\n{result.stderr}"
+        assert "[flagos dispatch] neg -> flagos_python" in result.stderr
+
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         result = _run_neg_subprocess(
             {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_neg": "cuda"}

--- a/tests/integration/ops/test_silu_dispatch.py
+++ b/tests/integration/ops/test_silu_dispatch.py
@@ -101,7 +101,18 @@ class TestSiluDispatch:
         )
         assert "[flagos dispatch] silu -> flagos_python" in result.stderr
 
+    @pytest.mark.flaggems
+    @pytest.mark.main_ops
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, silu routes to flagos_python."""
+        result = _run_silu_subprocess(
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
+        )
+        assert result.returncode == 0, f"Failed:\n{result.stderr}"
+        assert "[flagos dispatch] silu -> flagos_python" in result.stderr
+
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         result = _run_silu_subprocess(
             {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_silu": "cuda"}

--- a/tests/integration/ops/test_softmax_dispatch.py
+++ b/tests/integration/ops/test_softmax_dispatch.py
@@ -113,6 +113,7 @@ class TestSoftmaxDispatch:
         assert "[flagos dispatch] _softmax -> flagos_python" in result.stderr
 
     @pytest.mark.flaggems
+    @pytest.mark.main_ops
     def test_dispatch_log_flaggems_runtime(self):
         """With the FlagGems runtime path on, _softmax routes to flagos_python."""
         result = _run_softmax_subprocess(
@@ -122,6 +123,7 @@ class TestSoftmaxDispatch:
         assert "[flagos dispatch] _softmax -> flagos_python" in result.stderr
 
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda(self):
         result = _run_softmax_subprocess(
             {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP__softmax": "cuda"}

--- a/tests/integration/ops/test_sum_dispatch.py
+++ b/tests/integration/ops/test_sum_dispatch.py
@@ -134,7 +134,18 @@ class TestSumDimDispatch:
         )
         assert "[flagos dispatch] sum.dim_IntList -> flagos_python" in result.stderr
 
+    @pytest.mark.flaggems
+    @pytest.mark.main_ops
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, sum.dim_IntList routes to flagos_python."""
+        result = _run_subprocess(
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
+        )
+        assert result.returncode == 0, f"Failed:\n{result.stderr}"
+        assert "[flagos dispatch] sum.dim_IntList -> flagos_python" in result.stderr
+
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         result = _run_subprocess(
             {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_sum__dim_IntList": "cuda"}

--- a/tests/integration/ops/test_where_dispatch.py
+++ b/tests/integration/ops/test_where_dispatch.py
@@ -108,7 +108,18 @@ class TestWhereDispatch:
         )
         assert "[flagos dispatch] where.self -> flagos_python" in result.stderr
 
+    @pytest.mark.flaggems
+    @pytest.mark.main_ops
+    def test_dispatch_log_flaggems_runtime(self):
+        """With the FlagGems runtime path on, where.self routes to flagos_python."""
+        result = _run_subprocess(
+            {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
+        )
+        assert result.returncode == 0, f"Failed:\n{result.stderr}"
+        assert "[flagos dispatch] where.self -> flagos_python" in result.stderr
+
     @pytest.mark.cuda
+    @pytest.mark.main_ops
     def test_dispatch_log_cuda_override(self):
         result = _run_subprocess(
             {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_OP_where__self": "cuda"}


### PR DESCRIPTION
## Problem

The ops dispatch tests only had 7 hand-written FlagGems point-tests (mm/bmm/cat/embedding/softmax), while `backends_flaggems.conf` routes **319** ops to `flagos_python`. If someone adds a `= flagos_python` line without a kernel (or regenerates kernels without updating the conf), nothing catches the drift. CI also had no way to run a curated "main operators" subset across both the vendor and FlagGems paths.

## Changes

**1. Full routing consistency test** (`test_flaggems_conf_consistency.py`)
A pure parse/set-comparison check that guards the entire FlagGems Python surface:
- every op `backends_flaggems.conf` routes to `flagos_python` must have a real `Backend::kFlagOsPython` kernel in generated C++;
- no orphan `kFlagOsPython` kernel may exist without a conf route;
- counts on both sides must match (currently 319 == 319).

It bridges `op -> WrapperFoo -> foo_dispatcher` via `register.inc` and compares the dispatcher-name sets against `flaggems_python_kernels.cc`. No GPU, no `flag_gems` install, ~0.2s, `@pytest.mark.anyplatform`.

**2. `main_ops` marker + expanded point-tests**
New `main_ops` marker selects a representative operator subset for CI (orthogonal to backend markers): matrix (mm/bmm), elementwise (add/mul/abs/neg), reduction (sum/mean), index/structural (embedding/cat), activation (silu/softmax), condition (where). Tagged existing flaggems-runtime + cuda-override tests, and added missing flaggems-runtime tests to add/mul/abs/neg/sum/mean/silu/where.

**3. CI: main-ops subset across both paths**
`integration-test-cuda.yml` now runs three focused ops steps:
- routing consistency;
- vendor main ops (`-m main_ops`);
- FlagGems main ops (`FLAGOS_USE_FLAGGEMS=1 -m "flaggems and main_ops"`).

`integration-test-metax.yml` gains the platform-agnostic consistency check. Its ops run stays full because `backends_metax_flaggems.conf` routes several main ops differently (mm/bmm/mul/mean -> cuda), so the cuda-tuned subset does not apply there.

## Verification

Local (NVIDIA A100, default platform):
```
pytest tests/integration/ops/test_flaggems_conf_consistency.py -q   # 5 passed in 0.17s
pytest tests/integration/ops/ -m main_ops -q                        # 13 passed, 13 skipped
FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/ops/ -m "flaggems and main_ops" -q  # 13 passed
pytest tests/integration/ops/ -q  (conv1d deselected)               # 361 passed, 70 skipped, 0 failed
ruff check + format --check tests/integration/ops/                  # clean
```
