### PR TITLE
bench: FlagGems Python vs vendor dispatch-overhead microbenchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,65 @@
+# Benchmarks
+
+## FlagGems dispatch-overhead microbenchmark
+
+Quantifies the **host-side cost** of the Python FlagGems path (`kFlagOsPython`,
+`FLAGOS_USE_FLAGGEMS=1`) versus the vendor path (`kCuda`, pure C++ dispatch), to
+estimate how much a hypothetical C++ FlagGems dispatch (`kFlagOs`) could recover.
+
+```bash
+python benchmarks/flaggems_dispatch_bench.py            # defaults: submit=300 e2e=100
+python benchmarks/flaggems_dispatch_bench.py --submit 500 --e2e 150
+```
+
+The driver runs `flaggems_dispatch_overhead.py` once per backend in its own
+subprocess (routing is fixed at import) and prints a side-by-side table.
+
+### Metrics
+
+- **submit** — issue N ops back-to-back, synchronize once at the end. The async
+  queue hides kernel time, so this isolates host dispatch cost: GIL acquire +
+  pybind tensor/arg marshalling + a CPython frame (Python path) vs a thin C++
+  dispatcher (cuda path).
+- **e2e** — synchronize after every op: full per-op wall time including kernel.
+- **host_delta** = `gems_submit − cuda_submit`. This is the realistic ceiling on
+  what a C++ FlagGems dispatch could save, since both paths then launch the same
+  class of GPU work.
+
+Inputs are built on CPU and moved to `flagos:0` to sidestep the RNG shim (a
+CPU-torch build cannot create a CUDA generator directly).
+
+### Measured (NVIDIA A100, torch 2.10.0+cpu + flagos PrivateUse1, µs/op)
+
+| op | cat | cuda_sub | gems_sub | host_delta | cuda_e2e | gems_e2e |
+|---|---|---:|---:|---:|---:|---:|
+| add[512×512] | elementwise | 8 | 96 | **88** | 17 | 101 |
+| add[4096×4096] | elementwise | 149 | 149 | **0** | 162 | 242 |
+| mul[512×512] | elementwise | 8 | 91 | **83** | 17 | 96 |
+| abs[512×512] | elementwise | 9 | 80 | **71** | 18 | 87 |
+| neg[512×512] | elementwise | 8 | 80 | **72** | 17 | 87 |
+| sum.dim[1024×1024] | reduction | 10 | 51 | **41** | 23 | 56 |
+| softmax[1024×1024] | reduction | 11 | 39 | **29** | 24 | 48 |
+| mm[512×512] | matmul | 35 | 68 | **32** | 54 | 120 |
+| mm[4096×4096] | matmul | 7220 | 8063 | **843** | 7320 | 8155 |
+
+### Reading the numbers
+
+- **Python dispatch tax is ~70–90 µs/op, roughly fixed.** On small elementwise
+  ops the vendor path submits in ~8 µs; the Python path needs ~80–100 µs. That
+  ~10× host gap is exactly what C++ dispatch would erase.
+- **The tax only matters when the kernel is short.** `add[4096×4096]` has a
+  ~150 µs kernel that fully hides the host cost (`host_delta ≈ 0` in the async
+  submit column) — but it still shows up end-to-end (242 vs 162) because per-op
+  sync stops the pipeline from hiding it.
+- **Compute-bound ops see almost nothing.** `mm[4096×4096]`: 843 µs delta on a
+  7.2 ms kernel is ~11% of submit and <1% relative once the pipeline runs.
+- **e2e also reflects kernel quality, not just dispatch.** flaggems Triton
+  kernels here are not faster than cuBLAS/vendor for these shapes, so gems_e2e
+  > cuda_e2e; C++ dispatch removes the host tax but not a kernel-speed deficit.
+
+**Takeaway:** C++ FlagGems dispatch is worth it precisely for **host-bound
+small/elementwise/small-reduction ops** in eager, per-op hot loops (and more so
+under GIL contention: multi-stream, DataLoader workers). For matmul and large
+reductions the async pipeline already hides the Python cost, so C++ dispatch
+buys little. This matches the estimate that ~150–200 of the 319 flagos_python
+ops (the small/host-bound ones) are the ones actually worth C++-dispatching.

--- a/benchmarks/flaggems_dispatch_bench.py
+++ b/benchmarks/flaggems_dispatch_bench.py
@@ -1,0 +1,115 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FlagGems dispatch-overhead microbenchmark -- driver.
+
+Runs the worker once per backend in its own subprocess (routing is fixed at
+import), then prints a side-by-side table. The key column is the host-side
+submit-time delta (flaggems_python - cuda): the ceiling on what a C++ (kFlagOs)
+dispatch could recover, since both launch the same class of GPU kernel.
+
+    cuda      : default vendor conf (backends_cuda.conf), pure C++ dispatch
+    flaggems  : FLAGOS_USE_FLAGGEMS=1 (backends_flaggems.conf), Python dispatch
+
+Usage:
+    python benchmarks/flaggems_dispatch_bench.py
+    python benchmarks/flaggems_dispatch_bench.py --submit 500 --e2e 200
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_WORKER = Path(__file__).resolve().parent / "flaggems_dispatch_overhead.py"
+
+
+def _run(backend, env_extra, submit, e2e, warmup):
+    env = os.environ.copy()
+    env.update(env_extra)
+    env.setdefault("CUDA_VISIBLE_DEVICES", "0")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(_WORKER),
+            "--backend",
+            backend,
+            "--submit",
+            str(submit),
+            "--e2e",
+            str(e2e),
+            "--warmup",
+            str(warmup),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(f"worker for backend={backend} failed")
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def _index(blob):
+    return {r["op"]: r for r in blob["results"]}
+
+
+def _fmt(v):
+    return f"{v:8.1f}" if isinstance(v, (int, float)) else f"{'ERR':>8}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--submit", type=int, default=300)
+    ap.add_argument("--e2e", type=int, default=100)
+    ap.add_argument("--warmup", type=int, default=20)
+    args = ap.parse_args()
+
+    cuda = _index(_run("cuda", {}, args.submit, args.e2e, args.warmup))
+    gems = _index(
+        _run(
+            "flaggems", {"FLAGOS_USE_FLAGGEMS": "1"}, args.submit, args.e2e, args.warmup
+        )
+    )
+
+    print()
+    print("Per-op host submit time and end-to-end latency (microseconds).")
+    print("submit = dispatch cost (kernel time hidden by async queue);")
+    print("host_delta = flaggems_submit - cuda_submit = C++ dispatch headroom.\n")
+    hdr = (
+        f"{'op':22} {'cat':11} {'cuda_sub':>9} {'gems_sub':>9} "
+        f"{'host_delta':>10} {'cuda_e2e':>9} {'gems_e2e':>9}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    for op in cuda:
+        c, g = cuda[op], gems.get(op, {})
+        cs, gs = c.get("submit_us"), g.get("submit_us")
+        delta = (
+            (gs - cs)
+            if isinstance(cs, (int, float)) and isinstance(gs, (int, float))
+            else "ERR"
+        )
+        print(
+            f"{op:22} {c.get('category', ''):11} {_fmt(cs)} {_fmt(gs)} "
+            f"{_fmt(delta)} {_fmt(c.get('e2e_us'))} {_fmt(g.get('e2e_us'))}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/flaggems_dispatch_overhead.py
+++ b/benchmarks/flaggems_dispatch_overhead.py
@@ -1,0 +1,164 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FlagGems dispatch-overhead microbenchmark -- worker process.
+
+Measures per-op HOST cost of the Python FlagGems path vs the vendor (cuda)
+path, to quantify how much a hypothetical C++ (kFlagOs) dispatch could save.
+
+Two timings per op:
+  * submit  -- issue N ops back-to-back, synchronize once at the end. With the
+               async queue hiding kernel time, this is dominated by host-side
+               dispatch cost (GIL + pybind tensor/arg marshalling + CPython
+               frame for the Python path; a thin C++ dispatcher for cuda).
+  * e2e     -- synchronize after every op: full per-op wall time incl. kernel.
+
+The submit-time gap (flaggems_python - cuda) is the realistic ceiling on what
+C++ dispatch could recover, since both then launch the same class of GPU work.
+
+Routing is fixed at import, so this worker benchmarks ONE backend and prints a
+JSON blob. The driver (flaggems_dispatch_bench.py) runs it once per backend.
+
+Usage (normally invoked by the driver):
+    FLAGOS_USE_FLAGGEMS=1 python flaggems_dispatch_overhead.py --backend flaggems
+    python flaggems_dispatch_overhead.py --backend cuda
+"""
+
+import argparse
+import json
+import sys
+import time
+
+import torch_fl
+import torch
+
+DEVICE = "flagos:0"
+_sync = torch_fl.flagos.synchronize
+
+
+def _t(*shape):
+    """Random tensor built on CPU then moved to flagos (avoids the RNG shim)."""
+    return torch.randn(*shape).to(DEVICE)
+
+
+# Each entry: (label, category, build-inputs -> fn, expected-flaggems-routing).
+# Sizes chosen to span host-bound (small elementwise) -> compute-bound (mm).
+def _ops():
+    small, big = 512, 4096
+    return [
+        (
+            "add[512x512]",
+            "elementwise",
+            lambda: (_t(small, small), _t(small, small)),
+            lambda a, b: torch.add(a, b),
+        ),
+        (
+            "add[4096x4096]",
+            "elementwise",
+            lambda: (_t(big, big), _t(big, big)),
+            lambda a, b: torch.add(a, b),
+        ),
+        (
+            "mul[512x512]",
+            "elementwise",
+            lambda: (_t(small, small), _t(small, small)),
+            lambda a, b: torch.mul(a, b),
+        ),
+        (
+            "abs[512x512]",
+            "elementwise",
+            lambda: (_t(small, small),),
+            lambda a: torch.abs(a),
+        ),
+        (
+            "neg[512x512]",
+            "elementwise",
+            lambda: (_t(small, small),),
+            lambda a: torch.neg(a),
+        ),
+        (
+            "sum.dim[1024x1024]",
+            "reduction",
+            lambda: (_t(1024, 1024),),
+            lambda a: torch.sum(a, dim=1),
+        ),
+        (
+            "softmax[1024x1024]",
+            "reduction",
+            lambda: (_t(1024, 1024),),
+            lambda a: torch.softmax(a, dim=-1),
+        ),
+        (
+            "mm[512x512]",
+            "matmul",
+            lambda: (_t(small, small), _t(small, small)),
+            lambda a, b: torch.mm(a, b),
+        ),
+        (
+            "mm[4096x4096]",
+            "matmul",
+            lambda: (_t(big, big), _t(big, big)),
+            lambda a, b: torch.mm(a, b),
+        ),
+    ]
+
+
+def _bench_one(build, fn, n_submit, n_e2e, warmup):
+    args = build()
+    for _ in range(warmup):
+        fn(*args)
+    _sync()
+    t0 = time.perf_counter()
+    for _ in range(n_submit):
+        fn(*args)
+    _sync()
+    submit_us = (time.perf_counter() - t0) / n_submit * 1e6
+    _sync()
+    t0 = time.perf_counter()
+    for _ in range(n_e2e):
+        fn(*args)
+        _sync()
+    e2e_us = (time.perf_counter() - t0) / n_e2e * 1e6
+    return submit_us, e2e_us
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--backend", required=True, help="label only; routing is env-driven"
+    )
+    ap.add_argument("--submit", type=int, default=300)
+    ap.add_argument("--e2e", type=int, default=100)
+    ap.add_argument("--warmup", type=int, default=20)
+    args = ap.parse_args()
+
+    results = []
+    for label, cat, build, fn in _ops():
+        try:
+            submit_us, e2e_us = _bench_one(
+                build, fn, args.submit, args.e2e, args.warmup
+            )
+            results.append(
+                {"op": label, "category": cat, "submit_us": submit_us, "e2e_us": e2e_us}
+            )
+        except Exception as e:  # noqa: BLE001
+            results.append({"op": label, "category": cat, "error": repr(e)})
+
+    print("BENCH_JSON_START", file=sys.stderr)
+    print(json.dumps({"backend": args.backend, "results": results}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A microbenchmark that measures the **host-side dispatch overhead** of the Python FlagGems path (`kFlagOsPython`, `FLAGOS_USE_FLAGGEMS=1`) versus the vendor C++ path (`kCuda`), to put real numbers on how much a hypothetical C++ FlagGems dispatch (`kFlagOs`) could recover.

## Why

The C++ FlagGems path (`FLAGGEMS_KERNEL`/`kFlagOs`) is scaffolded but never built (needs FlagGems' `liboperators.so`; pip `flag_gems` is pure Python/Triton). Before investing in it, we want to know **where** eliminating the Python dispatch tax actually helps.

## Method

- **submit**: issue N ops back-to-back, sync once at the end. The async queue hides kernel time, so this isolates host cost — GIL + pybind marshalling + CPython frame (Python path) vs a thin C++ dispatcher (cuda path).
- **e2e**: sync per op — full per-op wall time incl. kernel.
- **host_delta = gems_submit − cuda_submit** = the ceiling C++ dispatch could recover.
- Driver runs the worker once per backend in a subprocess (routing is import-time fixed). Inputs built on CPU then moved to `flagos:0` to sidestep the RNG shim on a CPU-torch build.

## Findings (NVIDIA A100, µs/op)

| op | cuda_sub | gems_sub | host_delta | cuda_e2e | gems_e2e |
|---|---:|---:|---:|---:|---:|
| add[512²] | 8 | 96 | **88** | 17 | 101 |
| add[4096²] | 149 | 149 | **0** | 162 | 242 |
| abs[512²] | 9 | 80 | **71** | 18 | 87 |
| sum.dim[1024²] | 10 | 51 | **41** | 23 | 56 |
| softmax[1024²] | 11 | 39 | **29** | 24 | 48 |
| mm[512²] | 35 | 68 | **32** | 54 | 120 |
| mm[4096²] | 7220 | 8063 | **843** | 7320 | 8155 |

- Python dispatch tax is **~70–90 µs/op, roughly fixed** → a ~10× host gap on small elementwise ops. That's exactly what C++ dispatch erases.
- The tax **only matters when the kernel is short**: `add[4096²]` hides it entirely behind a 150 µs kernel (`host_delta≈0`); `mm[4096²]` delta is <1% of a 7.2 ms kernel.
- e2e also reflects **kernel quality** — flaggems Triton isn't faster than cuBLAS here, so C++ dispatch removes the host tax but not a kernel-speed deficit.

**Takeaway**: C++ FlagGems dispatch pays off for host-bound small/elementwise/small-reduction ops in eager per-op hot loops (more so under GIL contention), not for matmul/large reductions — matching the estimate that ~150–200 of the 319 flagos_python ops are worth C++-dispatching.

## Run

```bash
python benchmarks/flaggems_dispatch_bench.py --submit 300 --e2e 100
```
