### PR TITLE
fix(comm): add missing base collectives + FlagCX plain-signature fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,41 @@ FLAGOS_DISABLE_CUDA_ASSETS=1 FLAGOS_USE_FLAGGEMS=1 python -c "import torch_fl, t
 > with `[Errno 18]`. Fetch the wheel the shim reports (`Guessing wheel URL: ...`)
 > with `curl` and `pip install` the file directly.
 
+**Optional: FlagCX on PPU.** Distributed training works out of the box on the
+NCCL fallback — `PPU_SDK` ships a vendor-adapted `libnccl.so.2` and the PPU torch
+wheel is built with `USE_NCCL=1`, so `ProcessGroupNCCL` exists natively and
+`ProcessGroupFlagOS` uses it on the zero-copy CUDA view. To use FlagCX
+(heterogeneous unified comm) instead, build it from source:
+
+```bash
+git clone https://github.com/FlagOpen/FlagCX.git && cd FlagCX
+# --depth 1 skips submodules; without third-party/json the build fails on
+# "nlohmann/json.hpp: No such file or directory".
+git submodule update --init --depth 1 third-party/json
+
+make -j16 USE_PPU=1 \
+  DEVICE_HOME=/usr/local/PPU_SDK/CUDA_SDK \
+  CCL_HOME=/usr/local/PPU_SDK/CUDA_SDK
+
+# Build the torch plugin with the *nvidia* adaptor, not the auto-detected `ppu`
+# one. Both produce identical torch-side code (PPU is CUDA-ABI: same
+# CUDAStreamGuard, CUDAEvent, devName="cuda"), but FlagCX only compiles its
+# extended_api creator for the NVIDIA and MetaX adaptors, so `nvidia` gets the
+# richer ProcessGroupFlagCX binding. `ppu` currently also fails to compile —
+# PPU is missing from the plugin's per-adaptor #ifdef chains.
+cd plugin/torch && FLAGCX_ADAPTOR=nvidia FLAGCX_HOME=$(git rev-parse --show-toplevel) \
+  python setup.py install
+```
+
+`import torch_fl` then prefers FlagCX automatically (`_try_build_flagcx` runs
+before the NCCL fallback); no env var is needed beyond putting `libflagcx.so` on
+the loader path:
+
+```bash
+LD_LIBRARY_PATH=/path/to/FlagCX/build/lib:$LD_LIBRARY_PATH \
+  python tests/manual/test_flagos_dist_live.py --world-size 4
+```
+
 **Run tests:**
 
 ```bash
@@ -271,6 +306,9 @@ FLAGOS_DISABLE_CUDA_ASSETS=1 pytest tests/unit tests/integration/ops \
 
 # FlagGems path (first run is slow: Triton compiles/autotunes every kernel)
 FLAGOS_DISABLE_CUDA_ASSETS=1 FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/ops -q
+
+# Distributed (collectives + DDP). Works on NCCL; add LD_LIBRARY_PATH for FlagCX.
+python tests/manual/test_flagos_dist_live.py --world-size 4
 ```
 
 ### Build from Source (Hygon DCU Platform)

--- a/README_zh.md
+++ b/README_zh.md
@@ -234,6 +234,38 @@ FLAGOS_DISABLE_CUDA_ASSETS=1 FLAGOS_USE_FLAGGEMS=1 python -c "import torch_fl, t
 > `[Errno 18]` 失败。此时用 `curl` 手动下载它打印的 wheel 地址
 > （`Guessing wheel URL: ...`），再对该文件执行 `pip install` 即可。
 
+**可选：PPU 上启用 FlagCX。** 分布式训练默认即可用，走 NCCL 兜底：`PPU_SDK` 自带
+厂商适配的 `libnccl.so.2`，PPU 的 torch wheel 是 `USE_NCCL=1` 构建，因此
+`ProcessGroupNCCL` 原生存在，`ProcessGroupFlagOS` 直接在零拷贝 CUDA view 上使用它。
+若要改用 FlagCX（异构统一通信库），需从源码构建：
+
+```bash
+git clone https://github.com/FlagOpen/FlagCX.git && cd FlagCX
+# --depth 1 不会拉取 submodule；缺少 third-party/json 会导致构建失败：
+# "nlohmann/json.hpp: No such file or directory"
+git submodule update --init --depth 1 third-party/json
+
+make -j16 USE_PPU=1 \
+  DEVICE_HOME=/usr/local/PPU_SDK/CUDA_SDK \
+  CCL_HOME=/usr/local/PPU_SDK/CUDA_SDK
+
+# torch plugin 用 *nvidia* adaptor 构建，而非自动探测出的 `ppu`。两者生成的 torch
+# 侧代码完全一致（PPU 是 CUDA-ABI：同样的 CUDAStreamGuard、CUDAEvent、
+# devName="cuda"），但 FlagCX 只为 NVIDIA 和 MetaX adaptor 编译 extended_api
+# creator，所以 `nvidia` 能拿到更完整的 ProcessGroupFlagCX 绑定。而 `ppu` 目前
+# 还编不过 —— PPU 未被加入 plugin 的各 adaptor #ifdef 分支。
+cd plugin/torch && FLAGCX_ADAPTOR=nvidia FLAGCX_HOME=$(git rev-parse --show-toplevel) \
+  python setup.py install
+```
+
+之后 `import torch_fl` 会自动优先使用 FlagCX（`_try_build_flagcx` 在 NCCL 兜底之前
+执行）；除了把 `libflagcx.so` 放到加载路径上，无需额外环境变量：
+
+```bash
+LD_LIBRARY_PATH=/path/to/FlagCX/build/lib:$LD_LIBRARY_PATH \
+  python tests/manual/test_flagos_dist_live.py --world-size 4
+```
+
 **运行测试：**
 
 ```bash
@@ -243,6 +275,9 @@ FLAGOS_DISABLE_CUDA_ASSETS=1 pytest tests/unit tests/integration/ops \
 
 # FlagGems 路线（首次很慢：Triton 需要逐个编译并 autotune）
 FLAGOS_DISABLE_CUDA_ASSETS=1 FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/ops -q
+
+# 分布式（collectives + DDP）。默认走 NCCL；用 FlagCX 时加上 LD_LIBRARY_PATH。
+python tests/manual/test_flagos_dist_live.py --world-size 4
 ```
 
 ### 从源码安装（海光 DCU 平台）

--- a/tests/manual/test_flagos_dist_live.py
+++ b/tests/manual/test_flagos_dist_live.py
@@ -76,6 +76,29 @@ def worker(rank: int, world_size: int):
     ok_ag = vals == [float(i + 1) for i in range(world_size)]
     print(f"[rank {rank}] all_gather -> {vals} {'OK' if ok_ag else 'FAIL'}")
 
+    # --- all_gather_into_tensor (_allgather_base) ---
+    # Separate virtual from allgather(); the FSDP/ZeRO parameter-gather path.
+    agb = torch.empty(world_size, device=dev)
+    dist.all_gather_into_tensor(agb, torch.full((1,), float(rank), device=dev))
+    ok_agb = agb.cpu().tolist() == [float(i) for i in range(world_size)]
+    print(
+        f"[rank {rank}] all_gather_into_tensor -> {agb.cpu().tolist()} "
+        f"{'OK' if ok_agb else 'FAIL'}"
+    )
+
+    # --- reduce_scatter_tensor (_reduce_scatter_base) ---
+    # FSDP gradient-reduction path. Every rank contributes the same arange, so
+    # rank r's shard is world_size * arange[2r : 2r+2].
+    rs_in = torch.arange(2 * world_size, dtype=torch.float32, device=dev)
+    rs_out = torch.empty(2, device=dev)
+    dist.reduce_scatter_tensor(rs_out, rs_in)
+    exp_rs = [float(world_size) * (2 * rank), float(world_size) * (2 * rank + 1)]
+    ok_rs = rs_out.cpu().tolist() == exp_rs
+    print(
+        f"[rank {rank}] reduce_scatter_tensor -> {rs_out.cpu().tolist()} "
+        f"(expect {exp_rs}) {'OK' if ok_rs else 'FAIL'}"
+    )
+
     # --- DDP forward/backward ---
     torch.manual_seed(0)
     model = nn.Sequential(nn.Linear(8, 8), nn.ReLU(), nn.Linear(8, 1)).to(dev)

--- a/tests/unit/test_vendor_routing.py
+++ b/tests/unit/test_vendor_routing.py
@@ -24,6 +24,7 @@ Run: pytest tests/unit/test_vendor_routing.py
 
 import sys
 import types
+import warnings
 
 import pytest
 
@@ -58,10 +59,73 @@ def test_unknown_vendor_falls_back_to_default_profile():
 
 
 def test_known_cuda_vendors():
-    for v in ("nvidia", "metax", "iluvatar", "kunlunxin", "du"):
+    for v in ("nvidia", "metax", "iluvatar", "kunlunxin", "du", "thead"):
         prof = pg._get_profile(v)
         assert prof.flagcx_dev == "cuda"
         assert prof.view == "_flagos_to_cuda_view"
+
+
+def test_thead_ppu_routes_without_warning():
+    """PPU reports GEMS_VENDOR=thead from FlagGems' own detection (PPU_SDK set),
+    while torch_fl sets nvidia. Both must resolve to the same CUDA-ABI profile,
+    and thead must not trip the unknown-vendor warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning fails the test
+        prof = pg._get_profile("thead")
+    assert prof.flagcx_dev == "cuda"
+    assert prof.native == "_try_build_nccl"
+    assert prof.view == pg._VENDOR_PROFILES["nvidia"].view
+
+
+# ---------------------------------------------------------------------------
+# Collective virtual coverage
+# ---------------------------------------------------------------------------
+
+
+def test_single_tensor_base_collectives_are_overridden():
+    """_allgather_base / _reduce_scatter_base are separate virtuals from
+    allgather / reduce_scatter. If they are not overridden, ProcessGroup's C++
+    base tries to resolve a Backend for the tensor's device and raises
+    "No backend type associated with device type flagos" -- which breaks
+    dist.all_gather_into_tensor / reduce_scatter_tensor, i.e. the FSDP and ZeRO
+    hot paths. Guard against silently dropping them again."""
+    for name in ("_allgather_base", "_reduce_scatter_base"):
+        assert name in pg.ProcessGroupFlagOS.__dict__, (
+            f"{name} not overridden on ProcessGroupFlagOS; "
+            f"dist.{'all_gather_into_tensor' if 'allgather' in name else 'reduce_scatter_tensor'}"
+            f" will fail on flagos tensors"
+        )
+
+
+def test_base_collectives_delegate_with_converted_views(monkeypatch):
+    """Both new virtuals must pass the flagos->cuda view through, not the raw
+    privateuseone tensor."""
+
+    class _FakeInner:
+        def __init__(self):
+            self.seen = {}
+
+        def _allgather_base(self, out, inp, opts):
+            self.seen["allgather"] = (out, inp)
+            return "work-ag"
+
+        def _reduce_scatter_base(self, out, inp, opts):
+            self.seen["rs"] = (out, inp)
+            return "work-rs"
+
+    obj = pg.ProcessGroupFlagOS.__new__(pg.ProcessGroupFlagOS)
+    obj._inner = _FakeInner()
+    # view_fn tags anything it converts so we can assert it was applied
+    obj._view_fn = lambda t: ("viewed", t)
+
+    class _FlagosTensor:
+        device = types.SimpleNamespace(type="flagos")
+
+    a, b = _FlagosTensor(), _FlagosTensor()
+    assert obj._allgather_base(a, b) == "work-ag"
+    assert obj._inner.seen["allgather"] == (("viewed", a), ("viewed", b))
+    assert obj._reduce_scatter_base(a, b) == "work-rs"
+    assert obj._inner.seen["rs"] == (("viewed", a), ("viewed", b))
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +218,47 @@ def test_musa_flagcx_ok_but_no_view_raises(monkeypatch):
     )
     with pytest.raises(NotImplementedError, match="no flagos->device view"):
         obj._build_inner(None, 0, 1, None)
+
+
+def test_flagcx_plain_signature_is_accepted(monkeypatch):
+    """FlagCX only compiles the extended_api creator for the NVIDIA and MetaX
+    adaptors; ppu/du/kunlunxin/ascend/enflame export the plain
+    (store, rank, size, timeout) form. Calling the extended form on those
+    raises TypeError ("incompatible function arguments"), which must be retried
+    as the plain form -- otherwise FlagCX silently degrades to NCCL."""
+    sentinel = object()
+    seen = {}
+
+    def creator(*args):
+        # extended form is (opts, extra) or (opts,); reject like pybind11 does
+        if len(args) < 3:
+            raise TypeError("createFlagcxBackend(): incompatible function arguments")
+        seen["args"] = args
+        return sentinel
+
+    fake_flagcx = types.ModuleType("flagcx")
+    fake_flagcx.createFlagcxBackend = creator
+    monkeypatch.setitem(sys.modules, "flagcx", fake_flagcx)
+
+    obj = pg.ProcessGroupFlagOS.__new__(pg.ProcessGroupFlagOS)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # must not warn on the expected retry
+        assert obj._try_build_flagcx("store", 1, 4, None) is True
+    assert obj._inner is sentinel
+    assert seen["args"] == ("store", 1, 4, None)
+
+
+def test_flagcx_both_signatures_failing_warns_and_falls_back(monkeypatch):
+    def creator(*args):
+        raise RuntimeError("boom")
+
+    fake_flagcx = types.ModuleType("flagcx")
+    fake_flagcx.createFlagcxBackend = creator
+    monkeypatch.setitem(sys.modules, "flagcx", fake_flagcx)
+
+    obj = pg.ProcessGroupFlagOS.__new__(pg.ProcessGroupFlagOS)
+    with pytest.warns(UserWarning, match="FlagCX init failed"):
+        assert obj._try_build_flagcx("store", 0, 1, None) is False
 
 
 def test_ascend_uses_hccl_native(monkeypatch):

--- a/torch_fl/comm/process_group.py
+++ b/torch_fl/comm/process_group.py
@@ -28,7 +28,7 @@ For every vendor the inner-backend priority is FlagCX first, then the vendor's
 native backend (NCCL for CUDA-ABI vendors, HCCL for Ascend).
 
 View conversion
-    flagos tensors on CUDA-ABI vendors (nvidia/metax/iluvatar/kunlunxin/du)
+    flagos tensors on CUDA-ABI vendors (nvidia/metax/iluvatar/kunlunxin/du/thead)
     share physical GPU memory with CUDA, so they are reinterpreted as CUDA
     tensors via a zero-copy shared-storage view (``_C._flagos_to_cuda_view``)
     before being handed to NCCL / FlagCX-cuda. The underlying buffer is the
@@ -91,6 +91,12 @@ _VENDOR_PROFILES = {
     "iluvatar": _VendorProfile("cuda", "_flagos_to_cuda_view", "_try_build_nccl"),
     "kunlunxin": _VendorProfile("cuda", "_flagos_to_cuda_view", "_try_build_nccl"),
     "du": _VendorProfile("cuda", "_flagos_to_cuda_view", "_try_build_nccl"),
+    # T-Head PPU (Zhenwu ZW810E). FlagGems reports vendor "thead" when PPU_SDK is
+    # set, while torch_fl sets GEMS_VENDOR=nvidia; list it so either value routes
+    # the same instead of going through the unknown-vendor warning. PPU_SDK ships
+    # a vendor-adapted libnccl.so.2 and its torch wheel is a real CUDA build, so
+    # ProcessGroupNCCL works on the zero-copy cuda view unchanged.
+    "thead": _VendorProfile("cuda", "_flagos_to_cuda_view", "_try_build_nccl"),
     # Ascend: flagos is NOT a cuda alias; native fallback is HCCL. The flagos->
     # npu view is not implemented yet, so only the FlagCX(cann) path is viable.
     "ascend": _VendorProfile("cann", None, "_try_build_hccl"),
@@ -230,7 +236,7 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
         """Build a ProcessGroupNCCL (native binding, else _flagos_nccl ext).
 
         Returns True and sets self._inner on success. Covers all CUDA-ABI
-        vendors (nvidia/metax/iluvatar/kunlunxin/du).
+        vendors (nvidia/metax/iluvatar/kunlunxin/du/thead).
         """
         nccl_cls = getattr(torch.distributed, "ProcessGroupNCCL", None)
         if nccl_cls is not None:
@@ -290,6 +296,19 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
         Returns True and sets ``self._inner`` on success, False if flagcx is
         unavailable. Any hard failure is surfaced as a
         warning and treated as unavailable so we fall through to NCCL/HCCL.
+
+        Two creator signatures exist upstream. FlagCX only compiles the
+        extended_api form for the NVIDIA and MetaX adaptors (see the
+        ``#if (defined(USE_NVIDIA_ADAPTOR) || defined(USE_METAX_ADAPTOR)) &&
+        defined(TORCH_VER_GE_250)`` guards in backend_flagcx.cpp); every other
+        adaptor -- ppu, du, kunlunxin, ascend, enflame, ... -- exports the plain
+        c10d form instead:
+
+            extended: createFlagcxBackend(_DistributedBackendOptions, Options)
+            plain:    createFlagcxBackend(store, rank, size, timeout)
+
+        We try extended first and fall back to plain, otherwise those adaptors
+        raise "incompatible function arguments" and silently degrade to NCCL.
         """
         try:
             import flagcx  # noqa: F401 — self-registers "flagcx" backend
@@ -332,10 +351,27 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
 
             self._inner = creator(opts, extra) if extra is not None else creator(opts)
             return True
+        except TypeError:
+            # Non-NVIDIA/MetaX adaptor: plain (store, rank, size, timeout) form.
+            pass
         except Exception as e:
             warnings.warn(
                 f"[ProcessGroupFlagOS] FlagCX init failed ({e}); "
                 f"falling back to vendor-native backend."
+            )
+            return False
+
+        try:
+            # timeout must be a duration; c10d hands us a datetime.timedelta,
+            # which pybind converts to std::chrono automatically. Older flagcx
+            # builds ignore the value but still require the argument.
+            self._inner = creator(store, rank, world_size, timeout)
+            return True
+        except Exception as e:
+            warnings.warn(
+                f"[ProcessGroupFlagOS] FlagCX init failed for both the "
+                f"extended_api and plain createFlagcxBackend signatures "
+                f"({e}); falling back to vendor-native backend."
             )
             return False
 
@@ -383,6 +419,19 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
             opts,
         )
 
+    def _allgather_base(self, output_tensor, input_tensor, opts=None):
+        # Single-tensor allgather (dist.all_gather_into_tensor). Distinct virtual
+        # from allgather(): if it is not overridden, ProcessGroup's C++ base
+        # resolves a Backend for the tensor's device and raises "No backend type
+        # associated with device type flagos". FSDP / ZeRO go through this path.
+        if opts is None:
+            opts = _c10d.AllgatherOptions()
+        return self._inner._allgather_base(
+            _to_comm(output_tensor, self._view_fn),
+            _to_comm(input_tensor, self._view_fn),
+            opts,
+        )
+
     def allgather_into_tensor_coalesced(self, output_tensors, input_tensors, opts=None):
         if opts is None:
             opts = _c10d.AllgatherOptions()
@@ -409,6 +458,18 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
         return self._inner.reduce_scatter(
             _tl(output_tensors, self._view_fn),
             _tll(input_tensors, self._view_fn),
+            opts,
+        )
+
+    def _reduce_scatter_base(self, output_tensor, input_tensor, opts=None):
+        # Single-tensor reduce_scatter (dist.reduce_scatter_tensor); same
+        # unoverridden-virtual trap as _allgather_base above. This is the hot
+        # path for FSDP gradient reduction.
+        if opts is None:
+            opts = _c10d.ReduceScatterOptions()
+        return self._inner._reduce_scatter_base(
+            _to_comm(output_tensor, self._view_fn),
+            _to_comm(input_tensor, self._view_fn),
             opts,
         )
 


### PR DESCRIPTION
## Summary

Validating distributed training on T-Head PPU (`PPU_SDK` v2.1.0, vendor-adapted `libnccl.so.2`, torch built with `USE_NCCL=1`) surfaced three defects in `ProcessGroupFlagOS`. **None are PPU-specific.**

## 1. `_allgather_base` / `_reduce_scatter_base` were not overridden

These are separate virtuals from `allgather` / `reduce_scatter`. Unoverridden, `ProcessGroup`'s C++ base resolves a Backend for the tensor's device and raises:

```
RuntimeError: No backend type associated with device type flagos
```

So `dist.all_gather_into_tensor` and `dist.reduce_scatter_tensor` failed outright on flagos tensors — the FSDP parameter-gather and gradient-reduction hot paths. DDP only uses `allreduce`, which is why the existing tests did not catch it.

## 2. FlagCX silently degraded to NCCL on every non-NVIDIA/MetaX adaptor

`_try_build_flagcx` only knew the `extended_api` creator signature. FlagCX compiles that form solely for the NVIDIA and MetaX adaptors (see the `USE_NVIDIA_ADAPTOR`/`USE_METAX_ADAPTOR` guards in `backend_flagcx.cpp`); `ppu`, `du`, `kunlunxin`, `ascend` and `enflame` export the plain `(store, rank, size, timeout)` form. Calling the extended form there raises `incompatible function arguments`, which we caught and fell back to NCCL — correct results, one warning, FlagCX never actually used. The plain signature is now retried before giving up.

## 3. `GEMS_VENDOR=thead` hit the unknown-vendor warning path

FlagGems' own detection reports vendor `thead` when `PPU_SDK` is set, while torch_fl sets `nvidia`. Added the `thead` row so both values route identically (`devName="cuda"`, NCCL fallback, zero-copy cuda view) instead of relying on the default-profile warning.

## Test plan

Verified on PPU (ZW810E):

| path | result |
| --- | --- |
| NCCL, 2 and 4 ranks | all_reduce / broadcast / all_gather / all_gather_into_tensor / reduce_scatter_tensor / DDP fwd+bwd all numerically correct |
| FlagCX, 4 ranks | same, with `inner.name() == "flagcx"` asserted (built `USE_PPU=1` core + nvidia-adaptor torch plugin) |
| `tests/unit` | 14 passed |

The two new collectives are also checked numerically in the live manual test, and both READMEs document the PPU FlagCX build.

## Note on the FlagCX build

No FlagCX source changes are required to run it on PPU: build the core with `USE_PPU=1` and the torch plugin with `FLAGCX_ADAPTOR=nvidia`. Both adaptors emit identical torch-side code (PPU is CUDA-ABI: same `CUDAStreamGuard`, `CUDAEvent`, `devName="cuda"`), and `nvidia` additionally gets the extended_api binding. The auto-detected `ppu` adaptor currently fails to compile because PPU is missing from the plugin's per-adaptor `#ifdef` chains — that is an upstream issue, and the README documents the working path around it.