### PR TITLE
fix(metax): FlagCX distributed path on MetaX (set_device + live test)

### DIFF
--- a/tests/manual/metax/test_flagos_dist_live_metax.py
+++ b/tests/manual/metax/test_flagos_dist_live_metax.py
@@ -72,10 +72,6 @@ from torch.nn.parallel import DistributedDataParallel
 
 def _describe_inner_backend(pg) -> str:
     """Best-effort name of the inner comm backend ProcessGroupFlagOS built."""
-    try:
-        from torch_fl.comm.process_group import ProcessGroupFlagOS
-    except Exception:
-        return "unknown (import failed)"
     # The default group's backend for privateuseone is our ProcessGroupFlagOS.
     inner = getattr(pg, "_inner", None)
     if inner is None:

--- a/tests/manual/metax/test_flagos_dist_live_metax.py
+++ b/tests/manual/metax/test_flagos_dist_live_metax.py
@@ -109,7 +109,9 @@ def worker(rank: int, world_size: int):
     expected = sum(range(1, world_size + 1))
     ok = torch.allclose(t.cpu(), torch.full((4,), float(expected)))
     failures.append(("all_reduce", ok))
-    print(f"[rank {rank}] all_reduce -> {t[0].item()} (expect {expected}) {'OK' if ok else 'FAIL'}")
+    print(
+        f"[rank {rank}] all_reduce -> {t[0].item()} (expect {expected}) {'OK' if ok else 'FAIL'}"
+    )
 
     # --- broadcast (src=0) ---
     b = torch.arange(4, device=dev, dtype=torch.float32) + rank * 10
@@ -136,7 +138,9 @@ def worker(rank: int, world_size: int):
     exp = base * world_size + sum(range(world_size))
     ok = torch.allclose(out.cpu(), exp)
     failures.append(("reduce_scatter_tensor", ok))
-    print(f"[rank {rank}] reduce_scatter -> {out.tolist()} (expect {exp.tolist()}) {'OK' if ok else 'FAIL'}")
+    print(
+        f"[rank {rank}] reduce_scatter -> {out.tolist()} (expect {exp.tolist()}) {'OK' if ok else 'FAIL'}"
+    )
 
     # --- DDP forward/backward ---
     torch.manual_seed(0)
@@ -165,7 +169,9 @@ def worker(rank: int, world_size: int):
     ok = all(abs(v - vals[0]) < 1e-4 for v in vals)
     failures.append(("ddp_grad_sync", ok))
     if rank == 0:
-        print(f"[rank 0] DDP grad.sum across ranks {vals} synced={'OK' if ok else 'FAIL'}")
+        print(
+            f"[rank 0] DDP grad.sum across ranks {vals} synced={'OK' if ok else 'FAIL'}"
+        )
 
     dist.barrier()
     if rank == 0:

--- a/tests/manual/metax/test_flagos_dist_live_metax.py
+++ b/tests/manual/metax/test_flagos_dist_live_metax.py
@@ -1,0 +1,187 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live multi-GPU test for ProcessGroupFlagOS on MetaX (run on the 8xC550 box).
+
+This is the MetaX counterpart of ../test_flagos_dist_live.py. It validates the
+metax comm path documented in docs/distributed_flagcx_plan.md:
+
+  * GEMS_VENDOR=metax  -> _VENDOR_PROFILES["metax"] = (flagcx_dev="cuda",
+    view="_flagos_to_cuda_view", native="_try_build_nccl").
+  * Inner backend priority: FlagCX first, else NCCL. On MetaX "NCCL" is the
+    maca fork's ProcessGroupNCCL, which links libmccl.so under the hood -- so
+    the native fallback here actually exercises MetaX's mccl collective library.
+  * flagos tensors are a zero-copy cuda alias (maca libtorch_cuda), so
+    _flagos_to_cuda_view hands the same physical buffer to mccl/flagcx.
+
+It launches N processes, each binding one flagos device, and exercises:
+  1. init_process_group("flagos")  (auto-selects ProcessGroupFlagOS)
+  2. all_reduce / broadcast / all_gather / reduce_scatter on flagos tensors
+  3. DistributedDataParallel forward/backward with the auto-patched python hook
+
+Which inner backend was chosen is printed by rank 0 so the run self-documents
+whether it went through FlagCX or the mccl(NCCL) fallback.
+
+Run (from repo root):
+    ACCELERATOR=metax FLAGOS_METAX_BOXING=1 \
+    MACA_PATH=/opt/maca METAX_PATH=/opt/maca \
+    LD_LIBRARY_PATH=/opt/maca/lib:/opt/maca/lib64:$LD_LIBRARY_PATH \
+    PYTHONPATH=$PWD \
+    python tests/manual/metax/test_flagos_dist_live_metax.py --world-size 2
+
+Force the mccl(NCCL) path (skip FlagCX even if installed):
+    ... FLAGOS_DIST_FORCE_NCCL=1 python .../test_flagos_dist_live_metax.py --world-size 2
+"""
+
+import argparse
+import os
+
+# torch_fl MUST be imported before torch: in boxing mode it preloads the maca
+# libtorch_cuda.so and sets GEMS_VENDOR=metax (which drives the vendor profile).
+import torch_fl  # noqa: F401
+import torch
+
+# FlagCX is optional. If FLAGOS_DIST_FORCE_NCCL=1 we deliberately do NOT import
+# it, so ProcessGroupFlagOS falls back to the native NCCL(mccl) backend -- the
+# path we most want to validate on MetaX today (flagcx metax adaptor may not be
+# built in every env).
+if os.environ.get("FLAGOS_DIST_FORCE_NCCL", "0") != "1":
+    try:
+        import flagcx  # noqa: F401  self-registers "flagcx" backend (metax adaptor)
+    except ImportError:
+        flagcx = None
+else:
+    flagcx = None
+
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel
+
+
+def _describe_inner_backend(pg) -> str:
+    """Best-effort name of the inner comm backend ProcessGroupFlagOS built."""
+    try:
+        from torch_fl.comm.process_group import ProcessGroupFlagOS
+    except Exception:
+        return "unknown (import failed)"
+    # The default group's backend for privateuseone is our ProcessGroupFlagOS.
+    inner = getattr(pg, "_inner", None)
+    if inner is None:
+        # dist.init_process_group wraps the backend; try the registered PG.
+        try:
+            backend = dist.get_backend()
+        except Exception:
+            backend = "?"
+        return f"flagos(backend={backend}, inner=?)"
+    return f"{type(inner).__module__}.{type(inner).__name__}"
+
+
+def worker(rank: int, world_size: int):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29537")
+
+    dev = torch.device(f"flagos:{rank}")
+    torch.cuda.set_device(rank)  # flagos:i shares physical MetaX GPU i
+
+    dist.init_process_group(backend="flagos", rank=rank, world_size=world_size)
+
+    if rank == 0:
+        vendor = os.environ.get("GEMS_VENDOR", "?")
+        forced = os.environ.get("FLAGOS_DIST_FORCE_NCCL", "0") == "1"
+        print(
+            f"[setup] GEMS_VENDOR={vendor} flagcx={'yes' if flagcx else 'no'} "
+            f"force_nccl={forced} world_size={world_size}"
+        )
+
+    failures = []
+
+    # --- all_reduce (SUM) ---
+    t = torch.ones(4, device=dev) * (rank + 1)
+    dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    expected = sum(range(1, world_size + 1))
+    ok = torch.allclose(t.cpu(), torch.full((4,), float(expected)))
+    failures.append(("all_reduce", ok))
+    print(f"[rank {rank}] all_reduce -> {t[0].item()} (expect {expected}) {'OK' if ok else 'FAIL'}")
+
+    # --- broadcast (src=0) ---
+    b = torch.arange(4, device=dev, dtype=torch.float32) + rank * 10
+    dist.broadcast(b, src=0)
+    ok = torch.allclose(b.cpu(), torch.arange(4, dtype=torch.float32))
+    failures.append(("broadcast", ok))
+    print(f"[rank {rank}] broadcast -> {b.tolist()} {'OK' if ok else 'FAIL'}")
+
+    # --- all_gather ---
+    src = torch.ones(2, device=dev) * (rank + 1)
+    gathered = [torch.zeros(2, device=dev) for _ in range(world_size)]
+    dist.all_gather(gathered, src)
+    vals = [g[0].item() for g in gathered]
+    ok = vals == [float(i + 1) for i in range(world_size)]
+    failures.append(("all_gather", ok))
+    print(f"[rank {rank}] all_gather -> {vals} {'OK' if ok else 'FAIL'}")
+
+    # --- reduce_scatter_tensor ---
+    inp = torch.arange(world_size * 2, device=dev, dtype=torch.float32) + rank
+    out = torch.zeros(2, device=dev)
+    dist.reduce_scatter_tensor(out, inp, op=dist.ReduceOp.SUM)
+    # rank r receives inp[2r:2r+2] summed over ranks: base + sum(ranks)
+    base = torch.tensor([2 * rank, 2 * rank + 1], dtype=torch.float32)
+    exp = base * world_size + sum(range(world_size))
+    ok = torch.allclose(out.cpu(), exp)
+    failures.append(("reduce_scatter_tensor", ok))
+    print(f"[rank {rank}] reduce_scatter -> {out.tolist()} (expect {exp.tolist()}) {'OK' if ok else 'FAIL'}")
+
+    # --- DDP forward/backward ---
+    torch.manual_seed(0)
+    model = nn.Sequential(nn.Linear(8, 8), nn.ReLU(), nn.Linear(8, 1)).to(dev)
+    ddp = DistributedDataParallel(model)
+    if rank == 0:
+        print(
+            f"[setup] DDP _use_python_reducer={getattr(ddp, '_use_python_reducer', '?')} "
+            f"accum_grad_hooks={len(getattr(ddp, '_accum_grad_hooks', []))}"
+        )
+
+    # Different input per rank -> grads differ pre-sync; after the all_reduce
+    # hook every rank must hold the identical averaged/summed grad.
+    torch.manual_seed(100 + rank)
+    x = torch.randn(16, 8, device=dev)
+    ddp(x).sum().backward()
+    g0 = next(ddp.parameters()).grad
+    gsum = g0.sum().item()
+    print(f"[rank {rank}] DDP backward grad.sum={gsum:.6f} dev={g0.device}")
+
+    # cross-rank grad identity check: gather each rank's grad.sum and compare
+    gsum_t = torch.tensor([gsum], device=dev)
+    all_gsum = [torch.zeros(1, device=dev) for _ in range(world_size)]
+    dist.all_gather(all_gsum, gsum_t)
+    vals = [v.item() for v in all_gsum]
+    ok = all(abs(v - vals[0]) < 1e-4 for v in vals)
+    failures.append(("ddp_grad_sync", ok))
+    if rank == 0:
+        print(f"[rank 0] DDP grad.sum across ranks {vals} synced={'OK' if ok else 'FAIL'}")
+
+    dist.barrier()
+    if rank == 0:
+        n_fail = sum(1 for _, ok in failures if not ok)
+        status = "ALL PASS" if n_fail == 0 else f"{n_fail} FAILED"
+        print(f"=== metax dist live: {status} ({[n for n, ok in failures]}) ===")
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--world-size", type=int, default=2)
+    args = ap.parse_args()
+    mp.set_start_method("spawn", force=True)
+    mp.spawn(worker, args=(args.world_size,), nprocs=args.world_size, join=True)

--- a/torch_fl/accelerator/metax/_metax_compat.py
+++ b/torch_fl/accelerator/metax/_metax_compat.py
@@ -349,6 +349,33 @@ def patch_torch_cuda_for_metax():
     if hasattr(torch.cuda, "_queued_calls"):
         torch.cuda._queued_calls.clear()
 
+    # Route torch.cuda.set_device / current_device to the maca runtime.
+    #
+    # Stock torch.cuda.set_device calls torch._C._cuda_setDevice, which on the
+    # CPU wheel only bumps torch's own device counter and never reaches maca's
+    # mcSetDevice -- so torch.cuda.set_device(rank) leaves the maca runtime on
+    # device 0. NCCL(mccl) hides this because ProcessGroupNCCL wraps every op in
+    # a CUDAGuard(tensor.device()); FlagCX does NOT -- it creates its collective
+    # stream (mcStreamCreateWithFlags) on the *current* maca device before
+    # setting the tensor's device, so on rank!=0 the stream lands on device 0
+    # while the communicator/tensor are on device r, giving
+    # "CUDA error: invalid resource handle". Make set_device actually move the
+    # maca runtime (via _flagos.set_device) and read the true current device
+    # back from it, so the FlagCX path binds a consistent device.
+    _orig_cuda_setDevice = getattr(torch._C, "_cuda_setDevice", None)
+
+    def _patched_set_device(device):
+        idx = _device_index(device)
+        if _orig_cuda_setDevice is not None:
+            try:
+                _orig_cuda_setDevice(idx)  # keep torch's own counter aligned
+            except Exception:
+                pass
+        _set_device(idx)  # actually move the maca runtime (mcSetDevice)
+
+    torch.cuda.set_device = _patched_set_device
+    torch.cuda.current_device = _current_device
+
     torch.cuda.synchronize = _metax_synchronize
     torch.cuda.current_stream = lambda device=None: _MetaxStreamShim(
         _device_index(device)

--- a/torch_fl/comm/process_group.py
+++ b/torch_fl/comm/process_group.py
@@ -392,6 +392,16 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
             opts,
         )
 
+    def _allgather_base(self, output_tensor, input_tensor, opts=None):
+        # Backs the functional all_gather_into_tensor (single flat tensor in/out).
+        if opts is None:
+            opts = _c10d.AllgatherOptions()
+        return self._inner._allgather_base(
+            _to_comm(output_tensor, self._view_fn),
+            _to_comm(input_tensor, self._view_fn),
+            opts,
+        )
+
     def broadcast(self, tensors, opts=None):
         if opts is None:
             opts = _c10d.BroadcastOptions()
@@ -418,6 +428,16 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
         return self._inner.reduce_scatter_tensor_coalesced(
             _tl(output_tensors, self._view_fn),
             _tl(input_tensors, self._view_fn),
+            opts,
+        )
+
+    def _reduce_scatter_base(self, output_tensor, input_tensor, opts=None):
+        # Backs the functional reduce_scatter_tensor (single flat tensor in/out).
+        if opts is None:
+            opts = _c10d.ReduceScatterOptions()
+        return self._inner._reduce_scatter_base(
+            _to_comm(output_tensor, self._view_fn),
+            _to_comm(input_tensor, self._view_fn),
             opts,
         )
 


### PR DESCRIPTION
## Summary

Two fixes and one new test surfaced while validating the MetaX (沐曦 C550)
FlagCX distributed path end-to-end.

### 1. fix(metax): route `torch.cuda.set_device` to the maca runtime

**File:** `torch_fl/accelerator/metax/_metax_compat.py` (+27 lines)

Under metax boxing, stock `torch.cuda.set_device(rank)` only calls
`torch._C._cuda_setDevice`, which on the CPU-only wheel merely bumps
torch's internal device counter and never reaches maca's `mcSetDevice`.
Result: `torch.cuda.current_device()` reports the right rank, but
`torch.flagos.current_device()` stays 0.

ProcessGroupNCCL (mccl) hides this because it wraps every collective in a
`CUDAGuard(tensor.device())`. **FlagCX does not** — it calls
`mcStreamCreateWithFlags` on the *current maca device* inside
`getStreamByIndex`, which runs before the communicator's `setDevice`.
So on rank≠0 the collective stream is created on device 0 while the
communicator, event, and tensor are on device *r*, giving:



**Fix:** patch `torch.cuda.set_device` to also call `_flagos.set_device`
(which calls `mcSetDevice`), and point `torch.cuda.current_device` at the
maca-backed reader, so both views of the current device stay in sync.

This is not a FlagCX bug — it is a device-tracking gap in the metax boxing
layer that ProcessGroupNCCL's per-op CUDAGuard masked.

### 2. fix(dist): add `_allgather_base` / `_reduce_scatter_base` overrides

**File:** `torch_fl/comm/process_group.py`

(Note: the same fix was independently applied via #30 for PPU. This commit
was authored before #30 merged; after rebasing onto main the delta is the
constructor-default-argument style and `opts` initialisation — kept as-is
since both versions are correct and the rebase applied cleanly.)

### 3. test: MetaX multi-GPU live test

**File:** `tests/manual/metax/test_flagos_dist_live_metax.py` (new, +187 lines)

Counterpart of `tests/manual/test_flagos_dist_live.py` for MetaX C550.
Exercises both the mccl-fallback path (`FLAGOS_DIST_FORCE_NCCL=1`) and the
FlagCX-first path. Covers all_reduce / broadcast / all_gather /
reduce_scatter_tensor + DDP grad sync with cross-rank identity check.

## Verification (2×MetaX C550, maca 3.8.0)

**mccl (NCCL) fallback path** (commit fa5dfaa):
```
GEMS_VENDOR=metax flagcx=no force_nccl=True world_size=2
=== metax dist live: ALL PASS (['all_reduce','broadcast','all_gather','reduce_scatter_tensor','ddp_grad_sync']) ===
```

**FlagCX path** (commit 0570d2b, this PR):
```
GEMS_VENDOR=metax flagcx=yes force_nccl=False world_size=2
=== metax dist live: ALL PASS (['all_reduce','broadcast','all_gather','reduce_scatter_tensor','ddp_grad_sync']) ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)