### PR TITLE
fix(flaggems): record recursive-fallback ops in conf so consistency tests pass

### DIFF
--- a/tests/integration/ops/test_mul_dispatch.py
+++ b/tests/integration/ops/test_mul_dispatch.py
@@ -108,12 +108,21 @@ class TestMulTensorDispatch:
     @pytest.mark.flaggems
     @pytest.mark.main_ops
     def test_dispatch_log_flaggems_runtime(self):
-        """With the FlagGems runtime path on, mul.Tensor routes to flagos_python."""
+        """With the FlagGems runtime path on, mul.Tensor still routes to cuda.
+
+        mul is in codegen's flaggems_recursive_fallback: flag_gems'
+        mul_broadcast_func falls back to torch.mul() when device.type != "cuda",
+        which on a PrivateUse1 (flagos) tensor re-enters the same flagos_python
+        kernel and recurses until RecursionError. So the FlagGems confs pin
+        mul.Tensor to the cuda boxing kernel even though a kFlagOsPython kernel
+        exists for it (still reachable via the explicit per-op override below).
+        """
         result = _run_mul_subprocess(
             {"FLAGOS_LOG_DISPATCH": "1", "FLAGOS_USE_FLAGGEMS": "1"}
         )
         assert result.returncode == 0, f"Failed:\n{result.stderr}"
-        assert "[flagos dispatch] mul.Tensor -> flagos_python" in result.stderr
+        assert "[flagos dispatch] mul.Tensor -> cuda" in result.stderr
+        assert "[flagos dispatch] mul.Tensor -> flagos_python" not in result.stderr
 
     @pytest.mark.cuda
     @pytest.mark.main_ops


### PR DESCRIPTION
## Problem

#28 pinned `mul.Tensor` to the cuda boxing kernel — its `flag_gems` impl re-enters `torch.mul()` when `device.type != "cuda"`, which on a PrivateUse1 (flagos) tensor recurses until `RecursionError`. Its `kFlagOsPython` kernel is still generated on purpose, so it stays reachable via `FLAGOS_OP_mul__Tensor=flagos_python` for debugging.

That leaves a kernel with no conf route pointing at it, which is indistinguishable from real conf/codegen drift:

```
test_no_orphan_flagos_python_kernels -> ['mul_tensor_dispatcher']
test_counts_match                    -> conf=318 kernels=319
```

## Change

`scripts/codegen_ops.py` emits a machine-readable directive into each FlagGems conf header:

```
# flaggems-recursive-fallback: <space-separated ops>
```

listing the FlagGems-capable ops deliberately held back on cuda, so the test reads the list rather than duplicating it. Per-conf values: `backends_flaggems.conf` → `mul.Tensor`; `backends_dcu_flaggems.conf` → `mul.Tensor silu_backward slice_backward`; `backends_metax_flaggems.conf` → the 14 ops already in `metax_triton_fallback` that FlagGems can serve. The `n_*_fallback` counters are dropped in favour of `len()` over the same sets.

`test_flaggems_conf_consistency` exempts those dispatchers from the orphan and count assertions, and gains `test_fallback_directive_kernels_exist`: the fallback ops' kernels must still exist, so a stale directive fails loudly instead of silently widening the exemption.

`test_mul_dispatch::test_dispatch_log_flaggems_runtime` now asserts `mul.Tensor -> cuda` and NOT `-> flagos_python`, matching the conf pin.

The conf changes are header-only — no route lines change.

## Testing

On T-Head PPU (Zhenwu ZW810E, PPU_SDK 2.1.0, torch 2.10.0 + CUDA 13):

- 27 passed — `test_flaggems_conf_consistency` (6) + `test_mul_dispatch` + `tests/unit`
- `ruff check .` and `ruff format --check .` both clean
- Codegen re-run with `flag_gems` importable reproduces the flaggems and dcu directives byte-for-byte
- Full FlagGems integration suite (`FLAGOS_USE_FLAGGEMS=1 pytest tests/integration`): 509 passed, 45 skipped, 2 xfailed, 1 xpassed

Two pre-existing issues in that suite, neither from this change: 9 errors are `ModuleNotFoundError: No module named 'transformers'` (qwen3 + fallback-trace tests), and `test_allocator::test_empty_cache` asserts `41943040 < 41943040` — it passes in isolation both with and without FlagGems, so it is order-dependent on an earlier test leaving a cached block in the pool.
