### PR TITLE
fix: FlagGems factory device index (all backends) + DCU comm vendor routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,10 +402,14 @@ ACCELERATOR=dcu FLAGGEMS_PYTHON=1 pip install --no-build-isolation -e .
 export PYTHONPATH=/path/to/gems_path
 export TRITON_BACKENDS_IN_TREE=1       # this install has no dist-info, so
                                        # entry-point backend discovery finds nothing
-export GEMS_VENDOR=hygon
 export FLAGOS_USE_FLAGGEMS=1
 pytest tests/integration/ops -q        # no marker deselection needed
 ```
+
+`GEMS_VENDOR=hygon` is set automatically on a DCU build, so you no longer need to
+export it. This matters beyond FlagGems: `GEMS_VENDOR` also selects the comm
+profile (see `torch_fl/comm/process_group.py`), and DCU is a CUDA-ABI vendor
+whose `ProcessGroupNCCL` is RCCL underneath. Export it yourself only to override.
 
 A DCU build records `ACCELERATOR=dcu` in `torch_fl/_build_config.py`, so
 `FLAGOS_USE_FLAGGEMS=1` alone selects `backends_dcu_flaggems.conf` — no need to
@@ -415,6 +419,25 @@ kernel: `silu_backward` (`tl.math.div_rn` has no `create_precise_divf` lowering)
 and `slice_backward` (its output is correct standalone, but feeding that grad to
 MIOpen's `convolution_backward` triggers a hardware VMFault). Override per op
 with `FLAGOS_OP_<name>=flagos_python|cuda`.
+
+#### Multi-card on DCU
+
+Multi-card works with FlagGems on, over FlagCX or the RCCL fallback. Nothing extra
+to configure — the automatic `GEMS_VENDOR=hygon` routes `ProcessGroupFlagOS` to the
+CUDA-ABI profile (zero-copy `_flagos_to_cuda_view` + `ProcessGroupNCCL`, which on
+DTK is RCCL: `dist.is_nccl_available()` is `True` and `torch.cuda.nccl.version()`
+reports `(2, 22, 3)`).
+
+```bash
+export HSA_FORCE_FINE_GRAIN_PCIE=1     # RCCL warns when unset; affects
+                                       # multi-card throughput and stability
+python tests/manual/test_flagos_dist_live.py --world-size 2
+```
+
+Note that factory ops honoring their `device` index is a prerequisite here: every
+rank>0 worker builds its tensors via a factory, and an output allocated on device 0
+while the Triton kernel launches on device N is a cross-device write that faults
+the GPU. See `tests/integration/test_factory_device_index.py`.
 
 ### Build from Source (Enflame GCU Platform)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -365,10 +365,13 @@ ACCELERATOR=dcu FLAGGEMS_PYTHON=1 pip install --no-build-isolation -e .
 export PYTHONPATH=/path/to/gems_path
 export TRITON_BACKENDS_IN_TREE=1       # 该安装没有 dist-info，
                                        # 基于 entry-point 的后端发现拿不到任何后端
-export GEMS_VENDOR=hygon
 export FLAGOS_USE_FLAGGEMS=1
 pytest tests/integration/ops -q        # 无需再屏蔽 marker
 ```
+
+DCU 构建会自动设置 `GEMS_VENDOR=hygon`，无需再手动导出。这一点不只影响 FlagGems：
+`GEMS_VENDOR` 同时决定通信 profile（见 `torch_fl/comm/process_group.py`），而 DCU
+属于 CUDA-ABI vendor，其 `ProcessGroupNCCL` 底层就是 RCCL。只有需要覆盖时才自行导出。
 
 DCU 构建会把 `ACCELERATOR=dcu` 记录到 `torch_fl/_build_config.py`，因此运行时只需
 `FLAGOS_USE_FLAGGEMS=1` 就会选中 `backends_dcu_flaggems.conf`，不必重新导出
@@ -377,6 +380,24 @@ DCU 构建会把 `ACCELERATOR=dcu` 记录到 `torch_fl/_build_config.py`，因�
 `create_precise_divf` lowering）与 `slice_backward`（单独跑结果正确，但其梯度喂给
 MIOpen 的 `convolution_backward` 会触发硬件 VMFault）。可用
 `FLAGOS_OP_<name>=flagos_python|cuda` 按算子覆盖。
+
+#### DCU 多卡
+
+开着 FlagGems 也可以多卡，走 FlagCX 或 RCCL 回退路径均可，无需额外配置：自动设置的
+`GEMS_VENDOR=hygon` 会把 `ProcessGroupFlagOS` 路由到 CUDA-ABI profile（零拷贝
+`_flagos_to_cuda_view` + `ProcessGroupNCCL`，在 DTK 上底层即 RCCL：
+`dist.is_nccl_available()` 为 `True`，`torch.cuda.nccl.version()` 返回
+`(2, 22, 3)`）。
+
+```bash
+export HSA_FORCE_FINE_GRAIN_PCIE=1     # 不设置时 RCCL 会告警；
+                                       # 影响多卡吞吐与稳定性
+python tests/manual/test_flagos_dist_live.py --world-size 2
+```
+
+这里的前提是工厂算子必须遵守传入的 `device` index：每个 rank>0 的 worker 都通过工厂
+算子建张量，若输出分配在 device 0 而 Triton kernel 在 device N 上启动，就是一次跨设备
+写入，会直接把 GPU 打挂。参见 `tests/integration/test_factory_device_index.py`。
 
 ### 从源码安装（燧原 GCU 平台）
 

--- a/csrc/aten/backends/flagos/python_op_caller.cc
+++ b/csrc/aten/backends/flagos/python_op_caller.cc
@@ -7,6 +7,9 @@
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/utils/pybind.h>
 #include <ATen/core/ivalue.h>
+#include <c10/core/DeviceGuard.h>
+
+#include "runtime/functions.h"
 
 #include <mutex>
 #include <unordered_map>
@@ -64,13 +67,30 @@ PythonOpCache& GetCache() {
   return *cache;
 }
 
+// Resolve the flagos device a factory call should produce on.
+//
+// Mirrors aten factory semantics (and csrc/aten/empty.cc): an absent device, or
+// one carrying no index, means "the current device". Hardcoding index 0 here
+// used to allocate the output on device 0 while gems' Triton kernel launched on
+// whatever the current device was -- on a multi-GPU run that is a cross-device
+// write, which faults the GPU (VMFault / "Invalid address access") instead of
+// raising, and it also made torch.ones(..., device="flagos:1") report device 0.
+c10::Device ResolveFactoryDevice(std::optional<at::Device> device) {
+  if (device.has_value() && device->has_index()) {
+    return *device;
+  }
+  return c10::Device(c10::DeviceType::PrivateUse1, c10::flagos::CurrentDevice());
+}
+
 // Convert at::Tensor to Python THPVariable.
 // CPU scalar tensors are moved to the flagos device since FlagGems kernels
 // cannot access CPU memory.
 py::object TensorToPython(const at::Tensor& t) {
   if (!t.defined()) return py::none();
   if (t.device().is_cpu() && t.dim() == 0) {
-    auto dev_t = t.to(c10::Device(c10::DeviceType::PrivateUse1, 0));
+    // Current device, not index 0: a scalar operand feeding a computation on
+    // device N must not drag that computation back to device 0.
+    auto dev_t = t.to(ResolveFactoryDevice(std::nullopt));
     PyObject* obj = THPVariable_Wrap(dev_t);
     return py::reinterpret_steal<py::object>(obj);
   }
@@ -364,19 +384,26 @@ at::Tensor CallPythonOp_GenericKw(const char* func_name,
 
 at::Tensor CallPythonOp_Factory(const char* func_name,
                                 const std::vector<c10::IValue>& args,
-                                std::optional<at::ScalarType> dtype) {
+                                std::optional<at::ScalarType> dtype,
+                                std::optional<at::Device> device) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  // Set the device before entering Python: gems' internal torch.empty and the
+  // Triton launch both read the *current* device, so they must see the one we
+  // are about to name in the device kwarg.
+  const auto target = ResolveFactoryDevice(device);
+  const c10::DeviceGuard device_guard(target);
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::tuple py_args = BuildPyArgs(args, func_name);
 
   static py::module_ torch_mod = py::module_::import("torch");
-  // device=flagos:0 -> gems' internal torch.empty(...) allocates on PrivateUse1
-  // via our own allocator (no recursion, no CUDA copy). Uses the registered
-  // PrivateUse1 backend name so it stays correct if the alias changes.
+  // device=flagos:<idx> -> gems' internal torch.empty(...) allocates on
+  // PrivateUse1 via our own allocator (no recursion, no CUDA copy). Uses the
+  // registered PrivateUse1 backend name so it stays correct if the alias changes.
   py::object flagos_dev = torch_mod.attr("device")(
-      torch_mod.attr("_C").attr("_get_privateuse1_backend_name")(), 0);
+      torch_mod.attr("_C").attr("_get_privateuse1_backend_name")(),
+      static_cast<int>(target.index()));
   py::object result = func(
       *py_args,
       "dtype"_a = OptionalDtypeToPython(dtype),
@@ -388,18 +415,34 @@ at::Tensor CallPythonOp_Factory(const char* func_name,
 
 at::Tensor CallPythonOp_LikeFactory(const char* func_name,
                                     const std::vector<c10::IValue>& args,
-                                    std::optional<at::ScalarType> dtype) {
+                                    std::optional<at::ScalarType> dtype,
+                                    std::optional<at::Device> device) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  // For *_like, an absent device means "same as self" (not "current device"), so
+  // fall back to args[0]'s device before ResolveFactoryDevice's current-device
+  // default. args[0] is the source tensor by construction -- see the header.
+  std::optional<at::Device> device_hint = device;
+  if ((!device_hint.has_value() || !device_hint->has_index()) && !args.empty() &&
+      args[0].isTensor()) {
+    const auto& self = args[0].toTensor();
+    if (self.defined() && self.device().is_privateuseone() &&
+        self.device().has_index()) {
+      device_hint = self.device();
+    }
+  }
+  const auto target = ResolveFactoryDevice(device_hint);
+  const c10::DeviceGuard device_guard(target);
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::tuple py_args = BuildPyArgs(args, func_name);
 
   static py::module_ torch_mod = py::module_::import("torch");
-  // device=flagos:0 -> gems' internal torch.empty_like(self, device=...) stays
-  // on PrivateUse1 (no CUDA round-trip). dtype=None means "same as self".
+  // device=flagos:<idx> -> gems' internal torch.empty_like(self, device=...)
+  // stays on PrivateUse1 (no CUDA round-trip). dtype=None means "same as self".
   py::object flagos_dev = torch_mod.attr("device")(
-      torch_mod.attr("_C").attr("_get_privateuse1_backend_name")(), 0);
+      torch_mod.attr("_C").attr("_get_privateuse1_backend_name")(),
+      static_cast<int>(target.index()));
   py::object result = func(
       *py_args,
       "dtype"_a = OptionalDtypeToPython(dtype),

--- a/csrc/aten/backends/flagos/python_op_caller.h
+++ b/csrc/aten/backends/flagos/python_op_caller.h
@@ -96,9 +96,17 @@ std::vector<at::Tensor> CallPythonOp_GenericKwTuple(
 // a PrivateUse1 tensor -- no CUDA round-trip, no recursion), layout=strided
 // (gems eye/randperm validate layout, None is rejected), pin_memory=None, and
 // dtype forwarded from the aten call (nullopt -> None, else the ScalarType).
+//
+// `device` is the aten call's device argument, forwarded so the result lands on
+// the requested index. Following aten factory semantics, nullopt (or a device
+// with no index) means "the current device". The injected kwarg carries the
+// resolved index and the Python call runs under a DeviceGuard on it, so gems'
+// internal torch.empty and its Triton launch agree -- a mismatch allocates on
+// one device and launches on another, which faults the GPU rather than erroring.
 at::Tensor CallPythonOp_Factory(const char* func_name,
                                 const std::vector<c10::IValue>& args,
-                                std::optional<at::ScalarType> dtype);
+                                std::optional<at::ScalarType> dtype,
+                                std::optional<at::Device> device = std::nullopt);
 
 // Like-factory caller (zeros_like/ones_like/full_like/...). `args` are the
 // non-TensorOptions positionals -- the input tensor `self` (whose shape/device
@@ -108,9 +116,13 @@ at::Tensor CallPythonOp_Factory(const char* func_name,
 // memory_format=None, pin_memory=None, and dtype forwarded (nullopt -> None,
 // meaning "same as self"). Distinct from CallPythonOp_Factory whose first arg
 // is a shape array; here it's the source tensor.
+//
+// `device` behaves as in CallPythonOp_Factory: forwarded from the aten call,
+// nullopt/index-less means the current device.
 at::Tensor CallPythonOp_LikeFactory(const char* func_name,
                                     const std::vector<c10::IValue>& args,
-                                    std::optional<at::ScalarType> dtype);
+                                    std::optional<at::ScalarType> dtype,
+                                    std::optional<at::Device> device = std::nullopt);
 
 // Random in-place caller (uniform_/exponential_/bernoulli_.float). `args` are
 // the aten positionals with the trailing `Generator?` arg dropped (self, plus

--- a/csrc/aten/generated/flaggems_python_kernels.cc
+++ b/csrc/aten/generated/flaggems_python_kernels.cc
@@ -205,7 +205,7 @@ at::Tensor ArangeKernelPython(const at::Scalar & end, ::std::optional<at::Scalar
   ::std::optional<at::ScalarType> _dt = dtype;
   if (!_dt.has_value()) _dt = (end.isFloatingPoint())
       ? at::typeMetaToScalarType(at::get_default_dtype()) : at::kLong;
-  auto result = CallPythonOp_Factory("flag_gems.ops.arange.arange", {end}, _dt);
+  auto result = CallPythonOp_Factory("flag_gems.ops.arange.arange", {end}, _dt, device);
   UnboxToFlagos(result);
   return result;
 }
@@ -214,7 +214,7 @@ at::Tensor ArangeStartKernelPython(const at::Scalar & start, const at::Scalar & 
   ::std::optional<at::ScalarType> _dt = dtype;
   if (!_dt.has_value()) _dt = (start.isFloatingPoint() || end.isFloatingPoint())
       ? at::typeMetaToScalarType(at::get_default_dtype()) : at::kLong;
-  auto result = CallPythonOp_Factory("flag_gems.ops.arange.arange_start", {start, end}, _dt);
+  auto result = CallPythonOp_Factory("flag_gems.ops.arange.arange_start", {start, end}, _dt, device);
   UnboxToFlagos(result);
   return result;
 }
@@ -223,7 +223,7 @@ at::Tensor ArangeStartStepKernelPython(const at::Scalar & start, const at::Scala
   ::std::optional<at::ScalarType> _dt = dtype;
   if (!_dt.has_value()) _dt = (start.isFloatingPoint() || end.isFloatingPoint() || step.isFloatingPoint())
       ? at::typeMetaToScalarType(at::get_default_dtype()) : at::kLong;
-  auto result = CallPythonOp_Factory("flag_gems.ops.arange.arange_start", {start, end, step}, _dt);
+  auto result = CallPythonOp_Factory("flag_gems.ops.arange.arange_start", {start, end, step}, _dt, device);
   UnboxToFlagos(result);
   return result;
 }
@@ -693,13 +693,13 @@ at::Tensor & ExponentialInplaceKernelPython(at::Tensor & self, double lambd, ::s
 }
 
 at::Tensor EyeKernelPython(int64_t n, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
-  auto result = CallPythonOp_Factory("flag_gems.ops.eye.eye", {n}, dtype);
+  auto result = CallPythonOp_Factory("flag_gems.ops.eye.eye", {n}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
 
 at::Tensor EyeMKernelPython(int64_t n, int64_t m, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
-  auto result = CallPythonOp_Factory("flag_gems.ops.eye_m.eye_m", {n, m}, dtype);
+  auto result = CallPythonOp_Factory("flag_gems.ops.eye_m.eye_m", {n, m}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
@@ -788,13 +788,13 @@ at::Tensor & FminOutKernelPython(const at::Tensor & self, const at::Tensor & oth
 }
 
 at::Tensor FullKernelPython(at::IntArrayRef size, const at::Scalar & fill_value, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
-  auto result = CallPythonOp_Factory("flag_gems.ops.full.full", {size, fill_value}, dtype);
+  auto result = CallPythonOp_Factory("flag_gems.ops.full.full", {size, fill_value}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
 
 at::Tensor FullLikeKernelPython(const at::Tensor & self, const at::Scalar & fill_value, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
-  auto result = CallPythonOp_LikeFactory("flag_gems.ops.full_like.full_like", {self, fill_value}, dtype);
+  auto result = CallPythonOp_LikeFactory("flag_gems.ops.full_like.full_like", {self, fill_value}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
@@ -990,7 +990,7 @@ at::Tensor LinalgVectorNormKernelPython(const at::Tensor & self, const at::Scala
 }
 
 at::Tensor LinspaceKernelPython(const at::Scalar & start, const at::Scalar & end, int64_t steps, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
-  auto result = CallPythonOp_Factory("flag_gems.ops.linspace.linspace", {start, end, steps}, dtype);
+  auto result = CallPythonOp_Factory("flag_gems.ops.linspace.linspace", {start, end, steps}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
@@ -1084,7 +1084,7 @@ at::Tensor & LogitInplaceKernelPython(at::Tensor & self, ::std::optional<double>
 }
 
 at::Tensor LogspaceKernelPython(const at::Scalar & start, const at::Scalar & end, int64_t steps, double base, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
-  auto result = CallPythonOp_Factory("flag_gems.ops.logspace.logspace", {start, end, steps, base}, dtype);
+  auto result = CallPythonOp_Factory("flag_gems.ops.logspace.logspace", {start, end, steps, base}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
@@ -1348,13 +1348,13 @@ at::Tensor NonzeroKernelPython(const at::Tensor & self) {
 }
 
 at::Tensor OnesKernelPython(at::IntArrayRef size, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
-  auto result = CallPythonOp_Factory("flag_gems.ops.ones.ones", {size}, dtype);
+  auto result = CallPythonOp_Factory("flag_gems.ops.ones.ones", {size}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
 
 at::Tensor OnesLikeKernelPython(const at::Tensor & self, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
-  auto result = CallPythonOp_LikeFactory("flag_gems.ops.ones_like.ones_like", {self}, dtype);
+  auto result = CallPythonOp_LikeFactory("flag_gems.ops.ones_like.ones_like", {self}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
@@ -1413,31 +1413,31 @@ at::Tensor ProdDimIntKernelPython(const at::Tensor & self, int64_t dim, bool kee
 }
 
 at::Tensor RandKernelPython(at::IntArrayRef size, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
-  auto result = CallPythonOp_Factory("flag_gems.ops.rand.rand", {size}, dtype);
+  auto result = CallPythonOp_Factory("flag_gems.ops.rand.rand", {size}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
 
 at::Tensor RandLikeKernelPython(const at::Tensor & self, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
-  auto result = CallPythonOp_LikeFactory("flag_gems.ops.rand_like.rand_like", {self}, dtype);
+  auto result = CallPythonOp_LikeFactory("flag_gems.ops.rand_like.rand_like", {self}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
 
 at::Tensor RandnKernelPython(at::IntArrayRef size, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
-  auto result = CallPythonOp_Factory("flag_gems.ops.randn.randn", {size}, dtype);
+  auto result = CallPythonOp_Factory("flag_gems.ops.randn.randn", {size}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
 
 at::Tensor RandnLikeKernelPython(const at::Tensor & self, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
-  auto result = CallPythonOp_LikeFactory("flag_gems.ops.randn_like.randn_like", {self}, dtype);
+  auto result = CallPythonOp_LikeFactory("flag_gems.ops.randn_like.randn_like", {self}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
 
 at::Tensor RandpermKernelPython(int64_t n, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
-  auto result = CallPythonOp_Factory("flag_gems.ops.randperm.randperm", {n}, dtype);
+  auto result = CallPythonOp_Factory("flag_gems.ops.randperm.randperm", {n}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
@@ -1937,13 +1937,13 @@ at::Tensor & ZeroInplaceKernelPython(at::Tensor & self) {
 }
 
 at::Tensor ZerosKernelPython(at::IntArrayRef size, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory) {
-  auto result = CallPythonOp_Factory("flag_gems.ops.zeros.zeros", {size}, dtype);
+  auto result = CallPythonOp_Factory("flag_gems.ops.zeros.zeros", {size}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }
 
 at::Tensor ZerosLikeKernelPython(const at::Tensor & self, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
-  auto result = CallPythonOp_LikeFactory("flag_gems.ops.zeros_like.zeros_like", {self}, dtype);
+  auto result = CallPythonOp_LikeFactory("flag_gems.ops.zeros_like.zeros_like", {self}, dtype, device);
   UnboxToFlagos(result);
   return result;
 }

--- a/scripts/codegen_ops.py
+++ b/scripts/codegen_ops.py
@@ -836,11 +836,17 @@ def gen_flaggems_python_kernel(
     if category == "factory":
         # Factory: pass only the shape/scalar positionals; the factory caller
         # injects device=flagos/layout=strided/pin_memory=None and forwards
-        # dtype. `kwargs` here carries the positional (aten_type, name) list.
+        # dtype + device. `kwargs` here carries the positional (aten_type, name) list.
         positional = kwargs or []
         pos_names = [n for _t, n in positional]
         dtype_name = next((a.name for a in aten_args if a.name == "dtype"), None)
         dtype_expr = dtype_name if dtype_name else "::std::nullopt"
+        # Forward the aten `device` arg so the output lands on the requested
+        # index. Without it the caller fell back to a hardcoded index 0, which
+        # allocated on device 0 while the Triton kernel launched on the current
+        # device -- a cross-device write that faults the GPU on multi-card runs.
+        device_name = next((a.name for a in aten_args if a.name == "device"), None)
+        device_expr = device_name if device_name else "::std::nullopt"
         pos_init = "{" + ", ".join(pos_names) + "}"
         infer = ""
         # arange: gems defaults dtype=None to int64 unconditionally, but aten
@@ -862,7 +868,7 @@ def gen_flaggems_python_kernel(
         body = (
             f"{infer}"
             f'  auto result = CallPythonOp_Factory("{gems_func}", '
-            f"{pos_init}, {dtype_expr});\n"
+            f"{pos_init}, {dtype_expr}, {device_expr});\n"
             f"  UnboxToFlagos(result);\n"
             f"  return result;"
         )
@@ -871,16 +877,20 @@ def gen_flaggems_python_kernel(
     if category == "like_factory":
         # *_like: pass the source tensor (+ full_like's fill_value); the caller
         # injects device=flagos/layout/memory_format/pin_memory and forwards
-        # dtype (nullopt -> None means "same as self"). `kwargs` here carries the
-        # non-option positional (aten_type, name) list.
+        # dtype (nullopt -> None means "same as self") + device. `kwargs` here
+        # carries the non-option positional (aten_type, name) list.
         positional = kwargs or []
         pos_names = [n for _t, n in positional]
         dtype_name = next((a.name for a in aten_args if a.name == "dtype"), None)
         dtype_expr = dtype_name if dtype_name else "::std::nullopt"
+        # See the factory branch: forwarded so the result honors the requested
+        # device index. nullopt here means "same device as self".
+        device_name = next((a.name for a in aten_args if a.name == "device"), None)
+        device_expr = device_name if device_name else "::std::nullopt"
         pos_init = "{" + ", ".join(pos_names) + "}"
         body = (
             f'  auto result = CallPythonOp_LikeFactory("{gems_func}", '
-            f"{pos_init}, {dtype_expr});\n"
+            f"{pos_init}, {dtype_expr}, {device_expr});\n"
             f"  UnboxToFlagos(result);\n"
             f"  return result;"
         )

--- a/tests/integration/test_factory_device_index.py
+++ b/tests/integration/test_factory_device_index.py
@@ -1,0 +1,167 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Multi-device factory regression: a factory op must honor its `device` index.
+
+The FlagGems factory path (CallPythonOp_Factory / CallPythonOp_LikeFactory in
+csrc/aten/backends/flagos/python_op_caller.cc) used to inject a hardcoded
+`device=flagos:0` kwarg, dropping the `device` argument the generated kernels
+already had in scope. Two consequences, both platform-independent:
+
+  1. torch.ones(4, device="flagos:1").device reported flagos:0.
+  2. Worse, the output was allocated on device 0 while gems' Triton kernel
+     launched on the *current* device -- a cross-device write, which faults the
+     GPU (observed on DCU as "Invalid address access" / KERNEL VMFault) rather
+     than raising a Python error. That made every rank>0 worker crash under
+     FlagGems, since DDP workers build their tensors via factories.
+
+Only meaningful with 2+ devices, so it skips otherwise. It is also worth running
+with FLAGOS_USE_FLAGGEMS unset: the boxing path must stay correct too.
+
+Usage:
+    FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/test_factory_device_index.py -v
+"""
+
+import pytest
+import torch
+import torch_fl
+
+
+pytestmark = pytest.mark.skipif(
+    torch_fl.flagos.device_count() < 2,
+    reason="needs at least 2 flagos devices",
+)
+
+# Device 1 specifically: index 0 is what the bug produced, so asserting on it
+# would pass either way.
+DEVICE = "flagos:1"
+INDEX = 1
+
+
+def _assert_on_device1(t: torch.Tensor, what: str) -> None:
+    assert t.device.type == "flagos", f"{what}: got device type {t.device.type}"
+    assert t.device.index == INDEX, (
+        f"{what}: allocated on flagos:{t.device.index}, expected flagos:{INDEX} "
+        f"-- the factory dropped its device argument"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shape factories: torch.<fn>(size, device=...)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fn", [torch.ones, torch.zeros, torch.empty, torch.rand, torch.randn]
+)
+def test_shape_factory_honors_device_index(fn):
+    t = fn(4, 8, device=DEVICE)
+    _assert_on_device1(t, fn.__name__)
+    assert t.shape == (4, 8)
+
+
+@pytest.mark.parametrize(
+    "fn,expected",
+    [(torch.ones, 1.0), (torch.zeros, 0.0)],
+    ids=["ones", "zeros"],
+)
+def test_fill_factory_values_are_correct(fn, expected):
+    """Values, not just metadata: a cross-device write can leave the buffer
+    untouched (or corrupt), which the device assertion alone would not catch."""
+    t = fn(64, device=DEVICE)
+    torch.testing.assert_close(t.cpu(), torch.full((64,), expected))
+
+
+def test_full_honors_device_index():
+    t = torch.full((3, 5), 2.5, device=DEVICE)
+    _assert_on_device1(t, "full")
+    torch.testing.assert_close(t.cpu(), torch.full((3, 5), 2.5))
+
+
+def test_arange_honors_device_index():
+    t = torch.arange(0, 10, device=DEVICE)
+    _assert_on_device1(t, "arange")
+    torch.testing.assert_close(t.cpu(), torch.arange(0, 10))
+
+
+def test_eye_honors_device_index():
+    t = torch.eye(4, device=DEVICE)
+    _assert_on_device1(t, "eye")
+    torch.testing.assert_close(t.cpu(), torch.eye(4))
+
+
+def test_linspace_honors_device_index():
+    t = torch.linspace(0, 1, 11, device=DEVICE)
+    _assert_on_device1(t, "linspace")
+    torch.testing.assert_close(t.cpu(), torch.linspace(0, 1, 11), rtol=1e-4, atol=1e-4)
+
+
+def test_random_factory_values_are_plausible():
+    """randn on a non-zero device must produce real samples, not zeros/garbage."""
+    t = torch.randn(4096, device=DEVICE)
+    _assert_on_device1(t, "randn")
+    c = t.cpu()
+    assert abs(c.mean().item()) < 0.15, c.mean().item()
+    assert 0.8 < c.std().item() < 1.2, c.std().item()
+
+
+# ---------------------------------------------------------------------------
+# *_like factories: device defaults to the source tensor's device
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fn", [torch.ones_like, torch.zeros_like, torch.rand_like, torch.randn_like]
+)
+def test_like_factory_defaults_to_source_device(fn):
+    src = torch.empty(4, 8, device=DEVICE)
+    _assert_on_device1(src, "empty (source)")
+    _assert_on_device1(fn(src), f"{fn.__name__} (no explicit device)")
+
+
+def test_full_like_defaults_to_source_device():
+    src = torch.empty(2, 3, device=DEVICE)
+    out = torch.full_like(src, 7.0)
+    _assert_on_device1(out, "full_like")
+    torch.testing.assert_close(out.cpu(), torch.full((2, 3), 7.0))
+
+
+# ---------------------------------------------------------------------------
+# Interaction with the current device
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_device_wins_over_current_device():
+    """An explicit index must be honored regardless of the current device, and
+    setting the current device must not be required to reach device 1."""
+    prev = torch_fl.flagos.current_device()
+    try:
+        torch_fl.flagos.set_device(0)
+        _assert_on_device1(torch.ones(16, device=DEVICE), "ones with current=0")
+    finally:
+        torch_fl.flagos.set_device(prev)
+
+
+def test_index_less_device_follows_current_device():
+    """device="flagos" (no index) means "current device", matching aten factory
+    semantics -- the same rule csrc/aten/empty.cc applies via device_or_default."""
+    prev = torch_fl.flagos.current_device()
+    try:
+        torch_fl.flagos.set_device(INDEX)
+        t = torch.ones(16, device="flagos")
+        _assert_on_device1(t, "ones with index-less device")
+        torch.testing.assert_close(t.cpu(), torch.ones(16))
+    finally:
+        torch_fl.flagos.set_device(prev)

--- a/tests/unit/test_vendor_routing.py
+++ b/tests/unit/test_vendor_routing.py
@@ -59,7 +59,7 @@ def test_unknown_vendor_falls_back_to_default_profile():
 
 
 def test_known_cuda_vendors():
-    for v in ("nvidia", "metax", "iluvatar", "kunlunxin", "du", "thead"):
+    for v in ("nvidia", "metax", "iluvatar", "kunlunxin", "du", "thead", "hygon"):
         prof = pg._get_profile(v)
         assert prof.flagcx_dev == "cuda"
         assert prof.view == "_flagos_to_cuda_view"
@@ -72,6 +72,20 @@ def test_thead_ppu_routes_without_warning():
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # any warning fails the test
         prof = pg._get_profile("thead")
+    assert prof.flagcx_dev == "cuda"
+    assert prof.native == "_try_build_nccl"
+    assert prof.view == pg._VENDOR_PROFILES["nvidia"].view
+
+
+def test_hygon_dcu_routes_without_warning():
+    """DCU (DTK) sets GEMS_VENDOR=hygon. torch there is a hipified CUDA build, so
+    flagos is a cuda alias and ProcessGroupNCCL is RCCL: the CUDA-ABI profile
+    applies verbatim. Must not trip the unknown-vendor warning -- before the row
+    existed, an unset GEMS_VENDOR on DCU landed on the ascend profile instead and
+    init_process_group failed with "no suitable inner backend"."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning fails the test
+        prof = pg._get_profile("hygon")
     assert prof.flagcx_dev == "cuda"
     assert prof.native == "_try_build_nccl"
     assert prof.view == pg._VENDOR_PROFILES["nvidia"].view

--- a/torch_fl/__init__.py
+++ b/torch_fl/__init__.py
@@ -292,6 +292,15 @@ def _patch_flaggems_codegen_config():
       CPU-frozen torch wheel against maca's libtorch_cuda.so. Auto-selected when
       FLAGOS_METAX_BOXING=1 (or FLAGOS_METAX_COMPAT=1) and a MetaX card is present.
 
+    - Hygon DCU (DTK): set GEMS_VENDOR=hygon so FlagGems uses its _hygon
+      codegen config (triton hcu backend, triton_extra_name="hip"). No
+      torch.cuda shim is needed -- DTK ships a hipified torch with a real,
+      working torch.cuda. This branch must precede the generic-NVIDIA one:
+      is_nvidia_cuda_available() is False on DTK (there is no libcuda.so, only
+      libgalaxyhip), so without it DCU would reach the ascend fallback and get
+      GEMS_VENDOR=ascend -- which also breaks the comm layer, since that vendor
+      selects the HCCL profile (see comm/process_group.py _VENDOR_PROFILES).
+
     - Ascend (fallback): set GEMS_VENDOR=ascend so FlagGems uses the ASCEND
       codegen config (prefer_block_pointer=False, avoiding a triton-ascend
       tl.make_block_ptr bug), and register torch.flagos as a torch.npu shim so
@@ -317,6 +326,16 @@ def _patch_flaggems_codegen_config():
             os.environ.setdefault("GEMS_VENDOR", "metax")
             patch_torch_cuda_for_metax()
             return
+
+    # --- Hygon DCU branch (DTK) ---
+    # Keyed on the build accelerator rather than probing the runtime: DTK's torch
+    # is hipified, so torch.cuda/torch.version.hip look "cuda-ish" and no
+    # libcuda.so probe can tell the two apart. Must come before both the generic
+    # NVIDIA branch (which no-ops here anyway -- no libcuda.so) and the ascend
+    # fallback. setdefault so an explicit GEMS_VENDOR still wins.
+    if _build_accelerator() == "dcu" and os.environ.get("GEMS_VENDOR") != "ascend":
+        os.environ.setdefault("GEMS_VENDOR", "hygon")
+        return
 
     # --- Generic NVIDIA CUDA branch (default) ---
     if (

--- a/torch_fl/comm/process_group.py
+++ b/torch_fl/comm/process_group.py
@@ -28,7 +28,8 @@ For every vendor the inner-backend priority is FlagCX first, then the vendor's
 native backend (NCCL for CUDA-ABI vendors, HCCL for Ascend).
 
 View conversion
-    flagos tensors on CUDA-ABI vendors (nvidia/metax/iluvatar/kunlunxin/du/thead)
+    flagos tensors on CUDA-ABI vendors
+    (nvidia/metax/iluvatar/kunlunxin/du/thead/hygon)
     share physical GPU memory with CUDA, so they are reinterpreted as CUDA
     tensors via a zero-copy shared-storage view (``_C._flagos_to_cuda_view``)
     before being handed to NCCL / FlagCX-cuda. The underlying buffer is the
@@ -69,7 +70,9 @@ from torch._C import _distributed_c10d as _c10d
 # cuda_alias vendors: flagos shares physical GPU memory with CUDA, so a flagos
 # tensor can be viewed as a cuda tensor zero-copy (_flagos_to_cuda_view) and
 # handed to NCCL/FlagCX-cuda directly. This is the property that makes the
-# CPU-torch + external libtorch_cuda scheme work.
+# CPU-torch + external libtorch_cuda scheme work. A hipified torch (hygon)
+# qualifies too: its HIP kernels register under the CUDA dispatch key and its
+# "NCCL" backend is RCCL, so the same row shape applies.
 # ---------------------------------------------------------------------------
 
 
@@ -97,6 +100,12 @@ _VENDOR_PROFILES = {
     # a vendor-adapted libnccl.so.2 and its torch wheel is a real CUDA build, so
     # ProcessGroupNCCL works on the zero-copy cuda view unchanged.
     "thead": _VendorProfile("cuda", "_flagos_to_cuda_view", "_try_build_nccl"),
+    # Hygon DCU (DTK). torch is a hipified CUDA build, so flagos IS a cuda alias
+    # and the zero-copy view applies unchanged. Its ProcessGroupNCCL is RCCL
+    # under the hood (dist.is_nccl_available() True, torch.cuda.nccl.version()
+    # -> (2, 22, 3)); measured working for all_reduce / broadcast / all_gather /
+    # all_gather_into_tensor / reduce_scatter_tensor and DDP on 2 cards.
+    "hygon": _VendorProfile("cuda", "_flagos_to_cuda_view", "_try_build_nccl"),
     # Ascend: flagos is NOT a cuda alias; native fallback is HCCL. The flagos->
     # npu view is not implemented yet, so only the FlagCX(cann) path is viable.
     "ascend": _VendorProfile("cann", None, "_try_build_hccl"),


### PR DESCRIPTION
Two independent fixes. **The first is not DCU-specific** — it affects every backend that runs the FlagGems Python path on more than one device, so reviewers on CUDA/MetaX/Ascend should take a look.

## 1. FlagGems factory ops ignored their `device` argument

`CallPythonOp_Factory` / `CallPythonOp_LikeFactory` injected a hardcoded `device=flagos:0` kwarg, dropping the `device` the generated kernels already had in scope. Two consequences:

- `torch.ones(4, device="flagos:1").device` reported `flagos:0`.
- The output was allocated on device 0 while gems' Triton kernel launched on the *current* device — a cross-device write, which **faults the GPU rather than raising**. On DCU this surfaced as `Invalid address access, Error code: 3` / KERNEL VMFault, and it made every rank>0 worker crash under FlagGems, since DDP workers build their tensors via factories.

Both callers now take an optional `at::Device` and resolve the index once: the argument's index when it carries one, else `c10::flagos::CurrentDevice()`. That matches aten factory semantics — an index-less device means "current", the same rule `csrc/aten/empty.cc` applies via `c10::device_or_default`. The Python call runs under a `c10::DeviceGuard` on the resolved device so gems' internal `torch.empty` and the Triton launch agree. For `*_like`, an absent device falls back to the source tensor's device ("same as self") before the current-device default.

`codegen_ops.py` forwards the aten `device` arg at both emit sites. The 18 regenerated call sites (13 `Factory` + 5 `LikeFactory`) are the **only** change to `flaggems_python_kernels.cc` — 18 insertions, 18 deletions, no unrelated ops (this env's codegen emits ~700 ops the checked-in file lacks due to torch version drift, so the change was applied surgically and cross-checked against what the updated generator produces).

`TensorToPython`'s CPU-scalar hop moves to the current device too, so a scalar operand on device N no longer drags the computation back to device 0.

## 2. comm layer did not know `GEMS_VENDOR=hygon`

`_VENDOR_PROFILES` had no `hygon` row, so DCU tripped the unknown-vendor warning and fell back to guessing nvidia. Worse, with `GEMS_VENDOR` unset `_patch_flaggems_codegen_config()` reached the **ascend** fallback on DCU (`is_nvidia_cuda_available()` is False — DTK has no `libcuda.so`, only `libgalaxyhip`), selecting the HCCL profile and failing outright:

```
RuntimeError: ProcessGroupFlagOS: no suitable inner backend for GEMS_VENDOR='ascend'
```

This adds the `hygon` row (CUDA-ABI: zero-copy view + NCCL, which on DTK is RCCL — `dist.is_nccl_available()` True, `torch.cuda.nccl.version()` → `(2, 22, 3)`) and a DCU branch setting `GEMS_VENDOR=hygon`, keyed on the existing `_build_accelerator()` helper and placed before both the generic-NVIDIA branch and the ascend fallback. `setdefault`, so an explicit `GEMS_VENDOR` still wins. The transport itself needed no work — only the table row and the vendor detection.

## Verification

On Hygon DCU (DTK 26.04-rc4, 8× BW), with `GEMS_VENDOR` left **unset** to prove the detection change:

- `ones` / `zeros` / `randn` / `empty` / `rand` / `full` / `arange` / `eye` / `linspace` and the `*_like` variants all land on `flagos:1` with correct values. Dispatch log confirms `ones -> flagos_python`, i.e. the gems path, not boxing.
- `tests/manual/test_flagos_dist_live.py` with FlagGems **on**: all five collectives + DDP fwd/bwd pass at `--world-size 2` and `--world-size 8` (40 OK lines = 8 ranks × 5 collectives). Previously VMFaulted.
- **88 passed** across `tests/unit` + `test_allocator` + `test_factory_ops` + the new `test_factory_device_index`, with FlagGems both on and off.
- Full per-file ops sweep (one process per file — a VMFault kills the whole pytest process, and `--forked` is unusable since fork destroys the HIP context): **37/39 clean with FlagGems on, 38/39 with it off**, including `test_full_cuda_coverage` 46/46 and `test_ops` 58 passed.

New tests: `test_hygon_dcu_routes_without_warning` (pure logic, no GPU) and `tests/integration/test_factory_device_index.py` — the platform-neutral regression guard for the device-index bug, skipped when `device_count() < 2`.

## Known-failing, not caused by this work

`test_mul_dispatch::test_dispatch_log_flaggems_runtime` and the orphan/count checks in `test_flaggems_conf_consistency` (`['mul_tensor_dispatcher']`, `conf=318 kernels=319`). Reproduced against unmodified `main`: #28 routed `mul.Tensor` to cuda but left its `kFlagOsPython` kernel registered and the test asserting `flagos_python`. Left alone rather than widening this PR's scope.
