### PR TITLE
feat(metax): real device Event + pin_memory in _to_copy

### DIFF
--- a/csrc/aten/copy_ops.cc
+++ b/csrc/aten/copy_ops.cc
@@ -9,6 +9,7 @@
 #include "copy_dispatcher.h"
 
 #include <ATen/native/Resize.h>
+#include <ATen/ops/_pin_memory.h>
 #include <ATen/ops/copy_native.h>
 #include <include/flagos.h>
 #include "device_boxing.h"
@@ -226,12 +227,19 @@ at::Tensor _to_copy(
   TORCH_CHECK(
       !self.is_quantized(),
       "flagos _to_copy does not support quantized tensors yet");
-  TORCH_CHECK(
-      !pin_memory_opt.value_or(false),
-      "flagos _to_copy does not support pin_memory=True yet");
+  const bool want_pinned = pin_memory_opt.value_or(false);
   auto device = device_opt.value_or(self.device());
   auto dtype = dtype_opt.value_or(self.scalar_type());
   auto memory_format = memory_format_opt.value_or(c10::MemoryFormat::Preserve);
+
+  // pin_memory is a host-memory concept: only a CPU destination can be pinned.
+  // (Pinning is applied to the result CPU tensor below via _pin_memory, using
+  // the flagos host allocator = cudaMallocHost on MetaX.)
+  TORCH_CHECK(
+      !want_pinned || device.is_cpu(),
+      "flagos _to_copy: pin_memory=True is only valid for a CPU destination, "
+      "but got destination device ",
+      device);
 
   // Ascend NPU does not support float64; clamp to float32.
   if (dtype == at::kDouble && (device.is_privateuseone() || device.is_cuda())) {
@@ -369,6 +377,13 @@ at::Tensor _to_copy(
 
   if (memory_format != c10::MemoryFormat::Preserve) {
     result = result.contiguous(memory_format);
+  }
+
+  // Copy the result (CPU) into pinned host memory when requested. Guarded above
+  // so this only runs for a CPU destination; _pin_memory routes to the flagos
+  // host allocator (cudaMallocHost on MetaX) registered via the hooks.
+  if (want_pinned) {
+    result = at::_pin_memory(result, std::nullopt);
   }
 
   return result;

--- a/tests/manual/metax/test_event_pin_metax.py
+++ b/tests/manual/metax/test_event_pin_metax.py
@@ -1,0 +1,161 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify flagos Event (real device semantics) and pin_memory on MetaX.
+
+Run (from repo root):
+    ACCELERATOR=metax FLAGOS_METAX_BOXING=1 \
+    MACA_PATH=/opt/maca METAX_PATH=/opt/maca \
+    LD_LIBRARY_PATH=/opt/maca/lib:/opt/maca/lib64:$LD_LIBRARY_PATH \
+    PYTHONPATH=$PWD \
+    python tests/manual/metax/test_event_pin_metax.py
+
+Two areas:
+  1. Event -- flagos.Event now wraps torch.cuda.Event (real maca event), so
+     record/wait enforce cross-stream ordering and elapsed_time is on-device.
+     The previous host-timestamp stand-in had a no-op wait() -- this test would
+     have raced.
+  2. pin_memory -- x.pin_memory() must produce is_pinned()==True host memory,
+     and non_blocking H2D from a pinned tensor must land correct data. Also
+     checks tensor.to(device, pin_memory-side) round trips.
+"""
+
+import os
+
+import torch_fl  # noqa: F401  MUST precede torch (boxing preload + GEMS_VENDOR)
+import torch
+
+results = []
+
+
+def check(name, ok, detail=""):
+    results.append((name, ok))
+    print(f"[{'OK' if ok else 'FAIL'}] {name}" + (f" -- {detail}" if detail else ""))
+
+
+def test_event_timing():
+    """elapsed_time must be a real on-device measure (> 0 for real work)."""
+    dev = torch.device("flagos:0")
+    torch.cuda.set_device(0)
+    start = torch_fl.flagos.Event(enable_timing=True)
+    end = torch_fl.flagos.Event(enable_timing=True)
+
+    a = torch.randn(2048, 2048, device=dev)
+    start.record()
+    for _ in range(20):
+        a = a @ a
+        a = a / a.norm()
+    end.record()
+    end.synchronize()
+    ms = start.elapsed_time(end)
+    check("event.elapsed_time>0", ms > 0.0, f"{ms:.3f} ms")
+    check("event.query after sync", end.query() is True)
+
+
+def test_event_cross_stream_ordering():
+    """event.wait must make a second stream wait for work on the first.
+
+    Under the old host-timestamp Event, wait() was a no-op, so the consumer
+    stream could read x before the producer finished -> wrong result / race.
+    With a real event, the ordering holds.
+    """
+    dev = torch.device("flagos:0")
+    torch.cuda.set_device(0)
+
+    producer = torch_fl.flagos.Stream(device=0)
+    consumer = torch_fl.flagos.Stream(device=0)
+    ev = torch_fl.flagos.Event()
+
+    n = 4096
+    with torch_fl.flagos.stream(producer):
+        x = torch.ones(n, n, device=dev)
+        for _ in range(30):
+            x = x + 1.0  # heavy-ish producer work
+        ev.record(producer)
+
+    # consumer must not proceed until producer's event fires
+    consumer.wait_event(ev)
+    with torch_fl.flagos.stream(consumer):
+        y = x * 2.0
+    torch_fl.flagos.synchronize()
+
+    expected = (1.0 + 30) * 2.0
+    ok = torch.allclose(y.cpu(), torch.full((n, n), expected))
+    check("event cross-stream ordering", ok, f"got {y[0, 0].item()} expect {expected}")
+
+
+def test_pin_memory():
+    """x.pin_memory() yields real pinned host memory usable for async H2D."""
+    x = torch.randn(1024, 1024)
+    check("cpu tensor not pinned initially", x.is_pinned() is False)
+
+    xp = x.pin_memory()
+    check("pin_memory() -> is_pinned", xp.is_pinned() is True)
+    check("pin_memory preserves data", torch.allclose(xp, x))
+
+    # async H2D from pinned staging buffer
+    dev = torch.device("flagos:0")
+    torch.cuda.set_device(0)
+    d = xp.to(dev, non_blocking=True)
+    torch_fl.flagos.synchronize()
+    check("non_blocking H2D from pinned correct", torch.allclose(d.cpu(), x))
+
+
+def test_to_pin_memory_flag():
+    """tensor.to(..., pin_memory=True) path. Historically raised on flagos.
+
+    A CPU-destination copy with pin_memory=True should yield pinned host mem;
+    the previous _to_copy hard-rejected any pin_memory=True. A non-CPU dest
+    with pin_memory=True must still raise (you cannot pin device memory).
+    """
+    dev = torch.device("flagos:0")
+    torch.cuda.set_device(0)
+    d = torch.randn(512, 512, device=dev)
+
+    # baseline device->host still works
+    c = d.to("cpu", copy=True)
+    check("device->cpu copy", torch.allclose(c.cpu(), d.cpu()))
+
+    # device -> CPU with pin_memory=True now yields pinned host memory
+    cpu_pinned = torch.ops.aten._to_copy(d, device=torch.device("cpu"), pin_memory=True)
+    check("_to_copy(cpu, pin=True) is_pinned", cpu_pinned.is_pinned() is True)
+    check("_to_copy(cpu, pin=True) data", torch.allclose(cpu_pinned, d.cpu()))
+
+    # pin_memory=True with a non-CPU (flagos) destination must be rejected
+    try:
+        torch.ops.aten._to_copy(c, device=dev, pin_memory=True)
+        check("_to_copy(flagos, pin=True) rejected", False, "no error raised")
+    except RuntimeError as e:
+        check("_to_copy(flagos, pin=True) rejected", "pin_memory" in str(e))
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("FLAGOS_METAX_BOXING", "1")
+    torch_fl.flagos._lazy_init()
+
+    for fn in (
+        test_event_timing,
+        test_event_cross_stream_ordering,
+        test_pin_memory,
+        test_to_pin_memory_flag,
+    ):
+        try:
+            fn()
+        except Exception as e:  # noqa: BLE001
+            check(fn.__name__, False, f"raised {type(e).__name__}: {e}")
+
+    n_fail = sum(1 for _, ok in results if not ok)
+    status = "ALL PASS" if n_fail == 0 else f"{n_fail} FAILED"
+    print(f"=== event/pin metax: {status} ({[n for n, ok in results]}) ===")
+    raise SystemExit(1 if n_fail else 0)

--- a/torch_fl/flagos/__init__.py
+++ b/torch_fl/flagos/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+
 import torch
 
 from .. import _C  # type: ignore[misc]
@@ -236,45 +238,96 @@ class Stream(torch.cuda.Stream):
         return super().__new__(cls, device=device, priority=priority, **kwargs)
 
 
-class Event:
-    """Simple timing event using host-side timestamps after device sync."""
+def _real_current_stream(device=None):
+    """Resolve the actual current CUDA stream as a real ``torch.cuda.Stream``.
 
-    def __init__(
-        self, enable_timing=False, blocking=False, interprocess=False, external=False
+    Under MetaX boxing, ``torch.cuda.current_stream`` is monkey-patched to a
+    lightweight shim (only ``.cuda_stream``, for triton/FlagGems launch), which
+    is NOT a real Stream and makes ``torch.cuda.Event.record()`` fail with
+    "invalid StreamId". We instead read the true stream tuple straight from the
+    C++ runtime (``_cuda_getCurrentStream``) and rebuild a real Stream from it,
+    so events record/wait on the same physical (default) stream the boxing
+    kernels submit to.
+    """
+    idx = current_device() if device is None else int(device)
+    stream_id, device_index, device_type = torch._C._cuda_getCurrentStream(idx)
+    return torch.cuda.Stream(
+        stream_id=stream_id, device_index=device_index, device_type=device_type
+    )
+
+
+class Event(torch.cuda.Event):
+    """Flagos event that wraps a CUDA event (same physical GPU under boxing).
+
+    Since flagos shares the CUDA stream/GPU, a real ``torch.cuda.Event`` gives
+    true device-side semantics (maca event under the hood): ``record`` and
+    ``wait`` enforce cross-stream ordering, ``elapsed_time`` measures on-device
+    time, and ``query`` reflects actual completion -- unlike the previous
+    host-timestamp stand-in whose ``wait`` was a no-op.
+
+    ``record``/``wait`` are overridden to default to the *real* current stream
+    (see :func:`_real_current_stream`) rather than ``torch.cuda.current_stream``,
+    which boxing replaces with a non-Stream shim.
+    """
+
+    def __new__(
+        cls, enable_timing=False, blocking=False, interprocess=False, external=False
     ):
-        self._time = None
+        return super().__new__(
+            cls,
+            enable_timing=enable_timing,
+            blocking=blocking,
+            interprocess=interprocess,
+            external=external,
+        )
 
     def record(self, stream=None):
-        import time as _time
-
-        _C._synchronize()
-        self._time = _time.perf_counter()
-
-    def elapsed_time(self, end_event):
-        if self._time is None or end_event._time is None:
-            raise RuntimeError("Events have not been recorded")
-        return (end_event._time - self._time) * 1000.0
-
-    def synchronize(self):
-        _C._synchronize()
-
-    def query(self):
-        return True
+        if stream is None:
+            stream = _real_current_stream()
+        return super().record(stream)
 
     def wait(self, stream=None):
-        pass
+        if stream is None:
+            stream = _real_current_stream()
+        return super().wait(stream)
 
 
 def current_stream(device=None):
-    """Return the currently selected stream for the given device."""
-    if device is None:
-        device = current_device()
-    return torch.cuda.current_stream(device)
+    """Return the currently selected stream for the given device.
+
+    Returns a real ``torch.cuda.Stream`` (bypassing the boxing shim on
+    ``torch.cuda.current_stream``) so it is usable for event record/wait and
+    stream ordering, not just triton launch.
+    """
+    return _real_current_stream(device)
 
 
+@contextlib.contextmanager
 def stream(s):
-    """Context-manager that selects a given stream."""
-    return torch.cuda.stream(s)
+    """Context-manager that selects a given stream.
+
+    Reimplemented instead of delegating to ``torch.cuda.stream`` because the
+    latter saves/restores via ``torch.cuda.current_stream``, which boxing
+    replaces with a non-Stream shim (no ``.device``) -> AttributeError. We
+    save/restore the real stream through ``_cuda_setStream`` directly.
+    """
+    if s is None:
+        yield
+        return
+    prev = _real_current_stream(s.device.index)
+    torch._C._cuda_setStream(
+        stream_id=s.stream_id,
+        device_index=s.device_index,
+        device_type=s.device_type,
+    )
+    try:
+        yield
+    finally:
+        torch._C._cuda_setStream(
+            stream_id=prev.stream_id,
+            device_index=prev.device_index,
+            device_type=prev.device_type,
+        )
 
 
 def get_amp_supported_dtype():


### PR DESCRIPTION
## Summary

Two completeness gaps in the MetaX (flagos) backend, both verified on 2×C550.

### 1. `flagos.Event` — real device event (was a fake)

`flagos.Event` was a host-timestamp stand-in: `record()` did a global sync + `time.perf_counter()`, and `wait()` was a **no-op**. Any code relying on events for cross-stream ordering (FSDP/pipeline) silently raced.

Now `Event` wraps `torch.cuda.Event`, which under boxing is a real maca event (record/wait/elapsed_time/query all real). The C++ layer already had the full event API in `csrc/runtime/accelerator/metax/stream.cc`; it just wasn't exposed to Python, so proxying `torch.cuda.Event` is the minimal consistent fix (matches the existing `Stream(torch.cuda.Stream)` proxy).

**Gotcha handled:** boxing patches `torch.cuda.current_stream` into a lightweight `_MetaxStreamShim` (only `.cuda_stream`, for triton/FlagGems launch). That shim is not a real Stream, so `torch.cuda.Event.record()` (no-arg) and the `torch.cuda.stream()` context manager break on it (`invalid StreamId` / `no attribute 'device'`). Fix: resolve the real current stream straight from `torch._C._cuda_getCurrentStream` and reimplement `stream()` via `_cuda_setStream`, bypassing the shim. Events record on the default stream (handle 0), which is where the boxing kernels submit.

### 2. `pin_memory=True` in `_to_copy`

`_to_copy` hard-rejected `pin_memory=True`, so `tensor.to(pin_memory=True)` raised. The host allocator (`cudaMallocHost`), `isPinnedPtr`, and the `_pin_memory` dispatcher already work (verified: `x.pin_memory()` + async H2D are fine). Now `_to_copy` allows `pin_memory=True` for a CPU destination (pins the result via `at::_pin_memory`) and still rejects it for device destinations (you cannot pin device memory).

## Testing

`tests/manual/metax/test_event_pin_metax.py` — **11/11 ALL PASS** on 2×C550:
- Event: elapsed_time > 0 (real on-device), query, cross-stream ordering (previously raced)
- pin_memory: `x.pin_memory()` → is_pinned, non-blocking H2D correct, `_to_copy(cpu, pin=True)` → pinned, `_to_copy(flagos, pin=True)` correctly rejected

Run:
```
ACCELERATOR=metax FLAGOS_METAX_BOXING=1 MACA_PATH=/opt/maca METAX_PATH=/opt/maca \
LD_LIBRARY_PATH=/opt/maca/lib:/opt/maca/lib64:$LD_LIBRARY_PATH PYTHONPATH=$PWD \
python tests/manual/metax/test_event_pin_metax.py
```