### PR TITLE
feat(rng): unify native-CUDA RNG with FlagGems via shared generator injection

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -35,12 +35,16 @@ list(FILTER SOURCE_FILES EXCLUDE REGEX ".*/runtime/accelerator/ascend/stream_api
 if(NOT CUDA_KERNEL)
   list(FILTER SOURCE_FILES EXCLUDE REGEX ".*/aten/backends/cuda/.*")
 endif()
-if(NOT FLAGGEMS_KERNEL AND NOT FLAGGEMS_PYTHON)
-  # Neither C++ nor Python wrappers: exclude entire flagos backend
+if(NOT FLAGGEMS_KERNEL AND NOT FLAGGEMS_PYTHON AND NOT CUDA_KERNEL)
+  # Nothing needs python_op_caller: exclude entire flagos backend
   # (only python_op_caller.{h,cc} lives here now). The generated
   # flaggems_python_kernels.cc stays but is a no-op without FLAGOS_FLAGGEMS_PYTHON.
   list(FILTER SOURCE_FILES EXCLUDE REGEX ".*/aten/backends/flagos/.*")
 endif()
+# CUDA_KERNEL path: cuda_kernels.cc's native RNG kernels unconditionally call
+# GetFlagosDefaultCudaGenerator() (unified-RNG generator injection) regardless
+# of the FlagGems dispatch path, so python_op_caller.cc must stay in the build
+# whenever CUDA_KERNEL is on -- even with FLAGGEMS_KERNEL=OFF FLAGGEMS_PYTHON=OFF.
 # FLAGGEMS_PYTHON path: keep csrc/aten/backends/flagos/python_op_caller.cc and
 # build csrc/aten/generated/flaggems_python_kernels.cc with FLAGOS_FLAGGEMS_PYTHON
 # defined (below). The stale C++/python_wrapper files were removed; nothing to

--- a/csrc/aten/backends/flagos/python_op_caller.cc
+++ b/csrc/aten/backends/flagos/python_op_caller.cc
@@ -6,6 +6,8 @@
 #include <pybind11/stl.h>
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/utils/pybind.h>
+#include <torch/csrc/Generator.h>
+#include <ATen/core/Generator.h>
 #include <ATen/core/ivalue.h>
 #include <c10/core/DeviceGuard.h>
 
@@ -514,6 +516,29 @@ std::vector<at::Tensor> CallPythonOp_GenericTuple(
     out.push_back(PythonToTensor(py::reinterpret_borrow<py::object>(seq[i])));
   }
   return out;
+}
+
+at::Generator GetFlagosDefaultCudaGenerator(int64_t device_index) {
+  static std::mutex cache_mu;
+  static std::unordered_map<int64_t, at::Generator> gen_cache;
+  {
+    std::lock_guard<std::mutex> lk(cache_mu);
+    auto it = gen_cache.find(device_index);
+    if (it != gen_cache.end()) {
+      return it->second;
+    }
+  }
+  py::gil_scoped_acquire gil;
+  py::module_ torch_cuda = py::module_::import("torch.cuda");
+  py::object gens = torch_cuda.attr("default_generators");
+  py::object py_gen = gens[py::cast(device_index)];
+  // torch.Generator -> at::Generator via THPGenerator unpack.
+  at::Generator gen = py_gen.cast<at::Generator>();
+  {
+    std::lock_guard<std::mutex> lk(cache_mu);
+    gen_cache[device_index] = gen;
+  }
+  return gen;
 }
 
 } // namespace at::native::flagos

--- a/csrc/aten/backends/flagos/python_op_caller.h
+++ b/csrc/aten/backends/flagos/python_op_caller.h
@@ -137,6 +137,14 @@ at::Tensor CallPythonOp_LikeFactory(const char* func_name,
 at::Tensor CallPythonOp_RandomInplace(const char* func_name,
                                       const std::vector<c10::IValue>& args);
 
+// Fetch the vendor compat shim's per-device CUDA generator
+// (torch.cuda.default_generators[device_index]) as an at::Generator. This is
+// the SAME object FlagGems reads via philox_backend_seed_offset, so injecting
+// it into native RNG kernels unifies both RNG worlds under torch.manual_seed.
+// Cached per device index (the shim object is stable; torch.cuda.manual_seed
+// mutates it in place, so a cached handle stays valid).
+at::Generator GetFlagosDefaultCudaGenerator(int64_t device_index);
+
 // Like CallPythonOp_Generic, but the Python op returns a tuple/list of N tensors
 // (e.g. sort -> (values, indices), var_mean -> (var, mean)). Returns the N
 // tensors in order. Used by the codegen tuple_return kernels.

--- a/csrc/aten/generated/cuda_kernels.cc
+++ b/csrc/aten/generated/cuda_kernels.cc
@@ -3,6 +3,7 @@
 
 #include "ops.h"
 #include "../device_boxing.h"
+#include "../backends/flagos/python_op_caller.h"
 
 #include <vector>
 #include <tuple>
@@ -3880,6 +3881,7 @@ void PrivFusedAdamwInplaceTensorLrKernelCuda(at::TensorList self, at::TensorList
 
 ::std::tuple<at::Tensor,at::Tensor> PrivFusedDropoutKernelCuda(const at::Tensor & self, double p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::_fused_dropout(self, p, generator);
   UnboxToFlagos(std::get<0>(result));
   UnboxToFlagos(std::get<1>(result));
@@ -3888,6 +3890,7 @@ void PrivFusedAdamwInplaceTensorLrKernelCuda(at::TensorList self, at::TensorList
 
 ::std::tuple<at::Tensor &,at::Tensor &> PrivFusedDropoutOutKernelCuda(const at::Tensor & self, double p, ::std::optional<at::Generator> generator, at::Tensor & out0, at::Tensor & out1) {
   DeviceBoxingGuard guard(self, out0, out1);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out0.get_device());
   auto _ret = at::_fused_dropout_outf(self, p, generator, out0, out1);
   UnboxToFlagos(out0);
   UnboxToFlagos(out1);
@@ -4693,6 +4696,7 @@ at::Tensor PrivSafeSoftmaxKernelCuda(const at::Tensor & self, int64_t dim, ::std
 
 at::Tensor PrivSampleDirichletKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::_sample_dirichlet(self, generator);
   UnboxToFlagos(result);
   return result;
@@ -4700,6 +4704,7 @@ at::Tensor PrivSampleDirichletKernelCuda(const at::Tensor & self, ::std::optiona
 
 at::Tensor & PrivSampleDirichletOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::_sample_dirichlet_outf(self, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -5094,6 +5099,7 @@ at::Tensor & PrivStackOutKernelCuda(at::TensorList tensors, int64_t dim, at::Ten
 
 at::Tensor PrivStandardGammaKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::_standard_gamma(self, generator);
   UnboxToFlagos(result);
   return result;
@@ -5101,6 +5107,7 @@ at::Tensor PrivStandardGammaKernelCuda(const at::Tensor & self, ::std::optional<
 
 at::Tensor & PrivStandardGammaOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::_standard_gamma_outf(self, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -6654,6 +6661,7 @@ at::Tensor & BatchNormElemtOutKernelCuda(const at::Tensor & input, const ::std::
 
 at::Tensor BernoulliKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::bernoulli(self, generator);
   UnboxToFlagos(result);
   return result;
@@ -6661,6 +6669,7 @@ at::Tensor BernoulliKernelCuda(const at::Tensor & self, ::std::optional<at::Gene
 
 at::Tensor BernoulliTensorKernelCuda(const at::Tensor & self, const at::Tensor & p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self, p);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::bernoulli(self, p, generator);
   UnboxToFlagos(result);
   return result;
@@ -6668,6 +6677,7 @@ at::Tensor BernoulliTensorKernelCuda(const at::Tensor & self, const at::Tensor &
 
 at::Tensor & BernoulliTensorOutKernelCuda(const at::Tensor & self, const at::Tensor & p, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, p, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::bernoulli_outf(self, p, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -6675,6 +6685,7 @@ at::Tensor & BernoulliTensorOutKernelCuda(const at::Tensor & self, const at::Ten
 
 at::Tensor & BernoulliFloatOutKernelCuda(const at::Tensor & self, double p, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::bernoulli_outf(self, p, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -6682,6 +6693,7 @@ at::Tensor & BernoulliFloatOutKernelCuda(const at::Tensor & self, double p, ::st
 
 at::Tensor & BernoulliOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::bernoulli_outf(self, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -6689,12 +6701,14 @@ at::Tensor & BernoulliOutKernelCuda(const at::Tensor & self, ::std::optional<at:
 
 at::Tensor & BernoulliInplaceTensorKernelCuda(at::Tensor & self, const at::Tensor & p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self, p);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.bernoulli_(p, generator);
   return self;
 }
 
 at::Tensor & BernoulliInplaceFloatKernelCuda(at::Tensor & self, double p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.bernoulli_(p, generator);
   return self;
 }
@@ -6767,6 +6781,7 @@ at::Tensor & BincountOutKernelCuda(const at::Tensor & self, const ::std::optiona
 
 at::Tensor BinomialKernelCuda(const at::Tensor & count, const at::Tensor & prob, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(count, prob);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(count.get_device());
   auto result = at::binomial(count, prob, generator);
   UnboxToFlagos(result);
   return result;
@@ -6774,6 +6789,7 @@ at::Tensor BinomialKernelCuda(const at::Tensor & count, const at::Tensor & prob,
 
 at::Tensor & BinomialOutKernelCuda(const at::Tensor & count, const at::Tensor & prob, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(count, prob, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::binomial_outf(count, prob, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -7205,6 +7221,7 @@ at::Tensor & CatOutKernelCuda(const at::ITensorListRef & tensors, int64_t dim, a
 
 at::Tensor CauchyKernelCuda(const at::Tensor & self, double median, double sigma, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::cauchy(self, median, sigma, generator);
   UnboxToFlagos(result);
   return result;
@@ -7212,6 +7229,7 @@ at::Tensor CauchyKernelCuda(const at::Tensor & self, double median, double sigma
 
 at::Tensor & CauchyOutKernelCuda(const at::Tensor & self, double median, double sigma, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::cauchy_outf(self, median, sigma, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -7219,6 +7237,7 @@ at::Tensor & CauchyOutKernelCuda(const at::Tensor & self, double median, double 
 
 at::Tensor & CauchyInplaceKernelCuda(at::Tensor & self, double median, double sigma, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.cauchy_(median, sigma, generator);
   return self;
 }
@@ -7365,9 +7384,7 @@ at::Tensor & ClampInplaceKernelCuda(at::Tensor & self, const ::std::optional<at:
 }
 
 at::Tensor & ClampInplaceTensorKernelCuda(at::Tensor & self, const ::std::optional<at::Tensor> & min, const ::std::optional<at::Tensor> & max) {
-  at::Tensor min_t = min.has_value() ? *min : at::Tensor();
-  at::Tensor max_t = max.has_value() ? *max : at::Tensor();
-  DeviceBoxingGuard guard(self, min_t, max_t);
+  DeviceBoxingGuard guard(self);
   self.clamp_(min, max);
   return self;
 }
@@ -8542,6 +8559,7 @@ at::Tensor & Expm1InplaceKernelCuda(at::Tensor & self) {
 
 at::Tensor ExponentialKernelCuda(const at::Tensor & self, double lambd, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::exponential(self, lambd, generator);
   UnboxToFlagos(result);
   return result;
@@ -8549,6 +8567,7 @@ at::Tensor ExponentialKernelCuda(const at::Tensor & self, double lambd, ::std::o
 
 at::Tensor & ExponentialOutKernelCuda(const at::Tensor & self, double lambd, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::exponential_outf(self, lambd, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -8556,6 +8575,7 @@ at::Tensor & ExponentialOutKernelCuda(const at::Tensor & self, double lambd, ::s
 
 at::Tensor & ExponentialInplaceKernelCuda(at::Tensor & self, double lambd, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.exponential_(lambd, generator);
   return self;
 }
@@ -9121,6 +9141,7 @@ at::Tensor & GeluBackwardGradInputKernelCuda(const at::Tensor & grad_output, con
 
 at::Tensor GeometricKernelCuda(const at::Tensor & self, double p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::geometric(self, p, generator);
   UnboxToFlagos(result);
   return result;
@@ -9128,6 +9149,7 @@ at::Tensor GeometricKernelCuda(const at::Tensor & self, double p, ::std::optiona
 
 at::Tensor & GeometricOutKernelCuda(const at::Tensor & self, double p, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::geometric_outf(self, p, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -9135,6 +9157,7 @@ at::Tensor & GeometricOutKernelCuda(const at::Tensor & self, double p, ::std::op
 
 at::Tensor & GeometricInplaceKernelCuda(at::Tensor & self, double p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.geometric_(p, generator);
   return self;
 }
@@ -10657,6 +10680,7 @@ at::Tensor & LogInplaceKernelCuda(at::Tensor & self) {
 
 at::Tensor LogNormalKernelCuda(const at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::log_normal(self, mean, std, generator);
   UnboxToFlagos(result);
   return result;
@@ -10664,6 +10688,7 @@ at::Tensor LogNormalKernelCuda(const at::Tensor & self, double mean, double std,
 
 at::Tensor & LogNormalOutKernelCuda(const at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::log_normal_outf(self, mean, std, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -10671,6 +10696,7 @@ at::Tensor & LogNormalOutKernelCuda(const at::Tensor & self, double mean, double
 
 at::Tensor & LogNormalInplaceKernelCuda(at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.log_normal_(mean, std, generator);
   return self;
 }
@@ -11802,6 +11828,7 @@ at::Tensor & MultilabelMarginLossBackwardGradInputKernelCuda(const at::Tensor & 
 
 at::Tensor MultinomialKernelCuda(const at::Tensor & self, int64_t num_samples, bool replacement, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::multinomial(self, num_samples, replacement, generator);
   UnboxToFlagos(result);
   return result;
@@ -11809,6 +11836,7 @@ at::Tensor MultinomialKernelCuda(const at::Tensor & self, int64_t num_samples, b
 
 at::Tensor & MultinomialOutKernelCuda(const at::Tensor & self, int64_t num_samples, bool replacement, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::multinomial_outf(self, num_samples, replacement, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -12341,6 +12369,7 @@ at::Tensor & NormOutKernelCuda(const at::Tensor & self, const ::std::optional<at
 
 at::Tensor NormalTensorTensorKernelCuda(const at::Tensor & mean, const at::Tensor & std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(mean, std);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(mean.get_device());
   auto result = at::normal(mean, std, generator);
   UnboxToFlagos(result);
   return result;
@@ -12348,6 +12377,7 @@ at::Tensor NormalTensorTensorKernelCuda(const at::Tensor & mean, const at::Tenso
 
 at::Tensor & NormalTensorTensorOutKernelCuda(const at::Tensor & mean, const at::Tensor & std, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(mean, std, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::normal_outf(mean, std, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -12355,6 +12385,7 @@ at::Tensor & NormalTensorTensorOutKernelCuda(const at::Tensor & mean, const at::
 
 at::Tensor NormalTensorFloatKernelCuda(const at::Tensor & mean, double std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(mean);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(mean.get_device());
   auto result = at::normal(mean, std, generator);
   UnboxToFlagos(result);
   return result;
@@ -12362,6 +12393,7 @@ at::Tensor NormalTensorFloatKernelCuda(const at::Tensor & mean, double std, ::st
 
 at::Tensor & NormalTensorFloatOutKernelCuda(const at::Tensor & mean, double std, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(mean, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::normal_outf(mean, std, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -12369,6 +12401,7 @@ at::Tensor & NormalTensorFloatOutKernelCuda(const at::Tensor & mean, double std,
 
 at::Tensor NormalFloatTensorKernelCuda(double mean, const at::Tensor & std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(std);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(std.get_device());
   auto result = at::normal(mean, std, generator);
   UnboxToFlagos(result);
   return result;
@@ -12376,6 +12409,7 @@ at::Tensor NormalFloatTensorKernelCuda(double mean, const at::Tensor & std, ::st
 
 at::Tensor & NormalFloatTensorOutKernelCuda(double mean, const at::Tensor & std, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(std, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::normal_outf(mean, std, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -12390,6 +12424,7 @@ at::Tensor NormalFloatFloatKernelCuda(double mean, double std, at::IntArrayRef s
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::normal(mean, std, size, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
@@ -12397,6 +12432,7 @@ at::Tensor NormalFloatFloatKernelCuda(double mean, double std, at::IntArrayRef s
 
 at::Tensor & NormalFloatFloatOutKernelCuda(double mean, double std, at::IntArrayRef size, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::normal_outf(mean, std, size, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -12404,6 +12440,7 @@ at::Tensor & NormalFloatFloatOutKernelCuda(double mean, double std, at::IntArray
 
 at::Tensor & NormalOutKernelCuda(const at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::normal_outf(self, mean, std, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -12411,12 +12448,14 @@ at::Tensor & NormalOutKernelCuda(const at::Tensor & self, double mean, double st
 
 at::Tensor & NormalInplaceKernelCuda(at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.normal_(mean, std, generator);
   return self;
 }
 
 at::Tensor NormalFunctionalKernelCuda(const at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::normal_functional(self, mean, std, generator);
   UnboxToFlagos(result);
   return result;
@@ -12516,6 +12555,7 @@ at::Tensor & PixelUnshuffleOutKernelCuda(const at::Tensor & self, int64_t downsc
 
 at::Tensor PoissonKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::poisson(self, generator);
   UnboxToFlagos(result);
   return result;
@@ -12523,6 +12563,7 @@ at::Tensor PoissonKernelCuda(const at::Tensor & self, ::std::optional<at::Genera
 
 at::Tensor & PoissonOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::poisson_outf(self, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -12793,7 +12834,8 @@ at::Tensor RandKernelCuda(at::IntArrayRef size, ::std::optional<at::ScalarType> 
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
-  auto result = at::rand(size, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
+  auto result = at::rand(size, _flagos_gen, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
 }
@@ -12807,6 +12849,7 @@ at::Tensor RandGeneratorKernelCuda(at::IntArrayRef size, ::std::optional<at::Gen
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::rand(size, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
@@ -12821,6 +12864,7 @@ at::Tensor RandGeneratorWithNamesKernelCuda(at::IntArrayRef size, ::std::optiona
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::rand(size, generator, names, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
@@ -12828,6 +12872,7 @@ at::Tensor RandGeneratorWithNamesKernelCuda(at::IntArrayRef size, ::std::optiona
 
 at::Tensor & RandGeneratorWithNamesOutKernelCuda(at::IntArrayRef size, ::std::optional<at::Generator> generator, ::std::optional<at::DimnameList> names, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::rand_outf(size, generator, names, out);
   UnboxToFlagos(out);
   return out;
@@ -12842,7 +12887,8 @@ at::Tensor RandNamesKernelCuda(at::IntArrayRef size, ::std::optional<at::Dimname
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
-  auto result = at::rand(size, names, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
+  auto result = at::rand(size, _flagos_gen, names, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
 }
@@ -12870,6 +12916,7 @@ at::Tensor RandLikeKernelCuda(const at::Tensor & self, ::std::optional<at::Scala
 
 at::Tensor RandLikeGeneratorKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::rand_like(self, generator, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
   return result;
@@ -12877,6 +12924,7 @@ at::Tensor RandLikeGeneratorKernelCuda(const at::Tensor & self, ::std::optional<
 
 at::Tensor & RandLikeGeneratorOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::rand_like_outf(self, generator, memory_format, out);
   UnboxToFlagos(out);
   return out;
@@ -12898,7 +12946,8 @@ at::Tensor RandintKernelCuda(int64_t high, at::IntArrayRef size, ::std::optional
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
-  auto result = at::randint(high, size, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
+  auto result = at::randint(high, size, _flagos_gen, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
 }
@@ -12912,6 +12961,7 @@ at::Tensor RandintGeneratorKernelCuda(int64_t high, at::IntArrayRef size, ::std:
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::randint(high, size, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
@@ -12919,6 +12969,7 @@ at::Tensor RandintGeneratorKernelCuda(int64_t high, at::IntArrayRef size, ::std:
 
 at::Tensor & RandintGeneratorOutKernelCuda(int64_t high, at::IntArrayRef size, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randint_outf(high, size, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -12933,7 +12984,8 @@ at::Tensor RandintLowKernelCuda(int64_t low, int64_t high, at::IntArrayRef size,
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
-  auto result = at::randint(low, high, size, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
+  auto result = at::randint(low, high, size, _flagos_gen, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
 }
@@ -12947,6 +12999,7 @@ at::Tensor RandintLowGeneratorKernelCuda(int64_t low, int64_t high, at::IntArray
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::randint(low, high, size, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
@@ -12954,6 +13007,7 @@ at::Tensor RandintLowGeneratorKernelCuda(int64_t low, int64_t high, at::IntArray
 
 at::Tensor & RandintLowGeneratorOutKernelCuda(int64_t low, int64_t high, at::IntArrayRef size, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randint_outf(low, high, size, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -12989,6 +13043,7 @@ at::Tensor RandintLikeTensorKernelCuda(const at::Tensor & self, const at::Tensor
 
 at::Tensor RandintLikeTensorGeneratorKernelCuda(const at::Tensor & self, const at::Tensor & high, ::std::optional<at::Generator> generator, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self, high);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::randint_like(self, high, generator, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
   return result;
@@ -12996,6 +13051,7 @@ at::Tensor RandintLikeTensorGeneratorKernelCuda(const at::Tensor & self, const a
 
 at::Tensor & RandintLikeTensorGeneratorOutKernelCuda(const at::Tensor & self, const at::Tensor & high, ::std::optional<at::Generator> generator, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, high, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randint_like_outf(self, high, generator, memory_format, out);
   UnboxToFlagos(out);
   return out;
@@ -13010,6 +13066,7 @@ at::Tensor & RandintLikeTensorOutKernelCuda(const at::Tensor & self, const at::T
 
 at::Tensor RandintLikeGeneratorKernelCuda(const at::Tensor & self, int64_t high, ::std::optional<at::Generator> generator, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::randint_like(self, high, generator, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
   return result;
@@ -13017,6 +13074,7 @@ at::Tensor RandintLikeGeneratorKernelCuda(const at::Tensor & self, int64_t high,
 
 at::Tensor & RandintLikeGeneratorOutKernelCuda(const at::Tensor & self, int64_t high, ::std::optional<at::Generator> generator, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randint_like_outf(self, high, generator, memory_format, out);
   UnboxToFlagos(out);
   return out;
@@ -13038,6 +13096,7 @@ at::Tensor & RandintLikeLowDtypeOutKernelCuda(const at::Tensor & self, int64_t l
 
 at::Tensor RandintLikeLowGeneratorDtypeKernelCuda(const at::Tensor & self, int64_t low, int64_t high, ::std::optional<at::Generator> generator, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::randint_like(self, low, high, generator, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
   return result;
@@ -13045,6 +13104,7 @@ at::Tensor RandintLikeLowGeneratorDtypeKernelCuda(const at::Tensor & self, int64
 
 at::Tensor & RandintLikeLowGeneratorDtypeOutKernelCuda(const at::Tensor & self, int64_t low, int64_t high, ::std::optional<at::Generator> generator, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randint_like_outf(self, low, high, generator, memory_format, out);
   UnboxToFlagos(out);
   return out;
@@ -13066,7 +13126,8 @@ at::Tensor RandnKernelCuda(at::IntArrayRef size, ::std::optional<at::ScalarType>
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
-  auto result = at::randn(size, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
+  auto result = at::randn(size, _flagos_gen, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
 }
@@ -13080,6 +13141,7 @@ at::Tensor RandnGeneratorKernelCuda(at::IntArrayRef size, ::std::optional<at::Ge
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::randn(size, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
@@ -13094,6 +13156,7 @@ at::Tensor RandnGeneratorWithNamesKernelCuda(at::IntArrayRef size, ::std::option
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::randn(size, generator, names, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
@@ -13101,6 +13164,7 @@ at::Tensor RandnGeneratorWithNamesKernelCuda(at::IntArrayRef size, ::std::option
 
 at::Tensor & RandnGeneratorWithNamesOutKernelCuda(at::IntArrayRef size, ::std::optional<at::Generator> generator, ::std::optional<at::DimnameList> names, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randn_outf(size, generator, names, out);
   UnboxToFlagos(out);
   return out;
@@ -13115,7 +13179,8 @@ at::Tensor RandnNamesKernelCuda(at::IntArrayRef size, ::std::optional<at::Dimnam
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
-  auto result = at::randn(size, names, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
+  auto result = at::randn(size, _flagos_gen, names, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
 }
@@ -13136,6 +13201,7 @@ at::Tensor RandnLikeKernelCuda(const at::Tensor & self, ::std::optional<at::Scal
 
 at::Tensor RandnLikeGeneratorKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::randn_like(self, generator, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
   return result;
@@ -13143,6 +13209,7 @@ at::Tensor RandnLikeGeneratorKernelCuda(const at::Tensor & self, ::std::optional
 
 at::Tensor & RandnLikeGeneratorOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randn_like_outf(self, generator, memory_format, out);
   UnboxToFlagos(out);
   return out;
@@ -13157,6 +13224,7 @@ at::Tensor & RandnLikeOutKernelCuda(const at::Tensor & self, ::std::optional<at:
 
 at::Tensor RandomKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::random(self, generator);
   UnboxToFlagos(result);
   return result;
@@ -13164,6 +13232,7 @@ at::Tensor RandomKernelCuda(const at::Tensor & self, ::std::optional<at::Generat
 
 at::Tensor RandomFromKernelCuda(const at::Tensor & self, int64_t from, ::std::optional<int64_t> to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::random(self, from, to, generator);
   UnboxToFlagos(result);
   return result;
@@ -13171,6 +13240,7 @@ at::Tensor RandomFromKernelCuda(const at::Tensor & self, int64_t from, ::std::op
 
 at::Tensor & RandomFromOutKernelCuda(const at::Tensor & self, int64_t from, ::std::optional<int64_t> to, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::random_outf(self, from, to, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -13178,6 +13248,7 @@ at::Tensor & RandomFromOutKernelCuda(const at::Tensor & self, int64_t from, ::st
 
 at::Tensor & RandomOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::random_outf(self, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -13185,6 +13256,7 @@ at::Tensor & RandomOutKernelCuda(const at::Tensor & self, ::std::optional<at::Ge
 
 at::Tensor RandomToKernelCuda(const at::Tensor & self, int64_t to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::random(self, to, generator);
   UnboxToFlagos(result);
   return result;
@@ -13192,6 +13264,7 @@ at::Tensor RandomToKernelCuda(const at::Tensor & self, int64_t to, ::std::option
 
 at::Tensor & RandomToOutKernelCuda(const at::Tensor & self, int64_t to, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::random_outf(self, to, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -13199,18 +13272,21 @@ at::Tensor & RandomToOutKernelCuda(const at::Tensor & self, int64_t to, ::std::o
 
 at::Tensor & RandomInplaceKernelCuda(at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.random_(generator);
   return self;
 }
 
 at::Tensor & RandomInplaceFromKernelCuda(at::Tensor & self, int64_t from, ::std::optional<int64_t> to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.random_(from, to, generator);
   return self;
 }
 
 at::Tensor & RandomInplaceToKernelCuda(at::Tensor & self, int64_t to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.random_(to, generator);
   return self;
 }
@@ -13224,7 +13300,8 @@ at::Tensor RandpermKernelCuda(int64_t n, ::std::optional<at::ScalarType> dtype, 
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
-  auto result = at::randperm(n, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
+  auto result = at::randperm(n, _flagos_gen, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
 }
@@ -13238,6 +13315,7 @@ at::Tensor RandpermGeneratorKernelCuda(int64_t n, ::std::optional<at::Generator>
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::randperm(n, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
   return result;
@@ -13245,6 +13323,7 @@ at::Tensor RandpermGeneratorKernelCuda(int64_t n, ::std::optional<at::Generator>
 
 at::Tensor & RandpermGeneratorOutKernelCuda(int64_t n, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randperm_outf(n, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -13699,6 +13778,7 @@ at::Tensor & RowIndicesCopyOutKernelCuda(const at::Tensor & self, at::Tensor & o
 
 at::Tensor RreluWithNoiseKernelCuda(const at::Tensor & self, at::Tensor & noise, const at::Scalar & lower, const at::Scalar & upper, bool training, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self, noise);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::rrelu_with_noise(self, noise, lower, upper, training, generator);
   UnboxToFlagos(result);
   return result;
@@ -13706,6 +13786,7 @@ at::Tensor RreluWithNoiseKernelCuda(const at::Tensor & self, at::Tensor & noise,
 
 at::Tensor & RreluWithNoiseOutKernelCuda(const at::Tensor & self, at::Tensor & noise, const at::Scalar & lower, const at::Scalar & upper, bool training, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, noise, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(noise.get_device());
   at::rrelu_with_noise_outf(self, noise, lower, upper, training, generator, out);
   UnboxToFlagos(noise);
   UnboxToFlagos(out);
@@ -13714,6 +13795,7 @@ at::Tensor & RreluWithNoiseOutKernelCuda(const at::Tensor & self, at::Tensor & n
 
 at::Tensor & RreluWithNoiseInplaceKernelCuda(at::Tensor & self, at::Tensor & noise, const at::Scalar & lower, const at::Scalar & upper, bool training, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self, noise);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   at::rrelu_with_noise_(self, noise, lower, upper, training, generator);
   return self;
 }
@@ -13734,6 +13816,7 @@ at::Tensor & RreluWithNoiseBackwardOutKernelCuda(const at::Tensor & grad_output,
 
 ::std::tuple<at::Tensor,at::Tensor> RreluWithNoiseFunctionalKernelCuda(const at::Tensor & self, const at::Tensor & noise, const at::Scalar & lower, const at::Scalar & upper, bool training, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self, noise);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::rrelu_with_noise_functional(self, noise, lower, upper, training, generator);
   UnboxToFlagos(std::get<0>(result));
   UnboxToFlagos(std::get<1>(result));
@@ -15975,6 +16058,7 @@ at::Tensor & UnfoldCopyOutKernelCuda(const at::Tensor & self, int64_t dimension,
 
 at::Tensor UniformKernelCuda(const at::Tensor & self, double from, double to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::uniform(self, from, to, generator);
   UnboxToFlagos(result);
   return result;
@@ -15982,6 +16066,7 @@ at::Tensor UniformKernelCuda(const at::Tensor & self, double from, double to, ::
 
 at::Tensor & UniformOutKernelCuda(const at::Tensor & self, double from, double to, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::uniform_outf(self, from, to, generator, out);
   UnboxToFlagos(out);
   return out;
@@ -15989,6 +16074,7 @@ at::Tensor & UniformOutKernelCuda(const at::Tensor & self, double from, double t
 
 at::Tensor & UniformInplaceKernelCuda(at::Tensor & self, double from, double to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.uniform_(from, to, generator);
   return self;
 }

--- a/docs/superpowers/plans/2026-07-30-unified-rng.md
+++ b/docs/superpowers/plans/2026-07-30-unified-rng.md
@@ -1,0 +1,478 @@
+# Unified RNG Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every native-CUDA RNG kernel draw from the same per-device generator FlagGems reads (`torch.cuda.default_generators[device]`), so `torch.manual_seed` unifies both RNG worlds and all RNG becomes reproducible.
+
+**Architecture:** Add one C++ helper (`GetFlagosDefaultCudaGenerator(int64_t)`) that fetches the shim's per-device CUDA generator and returns it as `at::Generator`. Teach `scripts/codegen_ops.py` to emit, in every native RNG kernel body carrying a `Generator?` arg, a one-line "inject shared generator when caller passed none" before the `at::<op>` call. Regenerate `cuda_kernels.cc` and rebuild `_C.so`. No routing/conf changes.
+
+**Tech Stack:** C++17, pybind11, PyTorch 2.10 (CPU wheel + external `libtorch_cuda.so`), Python codegen (torchgen), pytest.
+
+## Global Constraints
+
+- Work in the worktree: `/nfs/lvyufeng/PyTorch-Plugin-FL/.claude/worktrees/rng-completeness-check`. Run all commands there. Branch `rng-completeness-check`.
+- Env: `source /nfs/lvyufeng/env.sh && conda activate torch-fl-210` (torch `2.10.0+cpu`). Proxy for network: `source /nfs/lvyufeng/proxy.sh`.
+- Build: `FLAGGEMS_KERNEL=OFF FLAGGEMS_PYTHON=OFF CUDA_KERNEL=ON pip install -e . --no-build-isolation` (g++, links torch_cpu; CUDA symbols resolve at runtime).
+- Single-wheel auto-preload build: run tests with plain `python` / `pytest`. Do NOT use `scripts/with_cuda_libtorch.sh` — it double-loads `libc10_cuda.so` → "Duplicated key 'graph_capture_record_stream_reuse'" core dump.
+- Standalone repro scripts MUST `import torch_fl` BEFORE `import torch` (CUDAHooks / auto-preload order). The lazy CUDA generator needs ATen_cuda live — trigger it with a first RNG/CUDA op.
+- Test env for HF models: `HF_HOME=/nfs/lvyufeng/hf_cache HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1`.
+- RNG reproducibility tests only hold with `FLAGOS_USE_FLAGGEMS=1` for the flaggems_python ops, but native RNG unification is independent of that switch — test both.
+- Generated files are committed on-branch. `csrc/aten/generated/cuda_kernels.cc` header says "AUTO-GENERATED - DO NOT EDIT": change the codegen, never hand-edit the generated file.
+- Pre-existing unrelated crash to exclude from suites: `tests/integration/ops/test_conv1d_dispatch.py::test_conv1d_with_bias` (segfaults on clean tree).
+
+---
+
+### Task 1: C++ helper `GetFlagosDefaultCudaGenerator`
+
+**Files:**
+- Modify: `csrc/aten/backends/flagos/python_op_caller.h` (add declaration in `namespace at::native::flagos`, after `CallPythonOp_RandomInplace` decl ~line 125)
+- Modify: `csrc/aten/backends/flagos/python_op_caller.cc` (add definition; file already has pybind + `py::module_::import("torch")` pattern at ~line 124)
+- Test: exercised via Task 4 integration tests (no standalone C++ test harness in this repo; the repo tests kernels through Python).
+
+**Interfaces:**
+- Consumes: pybind11 (`py::gil_scoped_acquire`, `py::module_::import`), `torch/csrc/utils/pybind.h` (provides `py::cast`/`THPGenerator` unpacking for `at::Generator`).
+- Produces: `at::Generator at::native::flagos::GetFlagosDefaultCudaGenerator(int64_t device_index);` — returns the shim's per-device CUDA generator (`torch.cuda.default_generators[device_index]`) as an `at::Generator`. Used by generated kernels in Task 2/3.
+
+- [ ] **Step 1: Add the declaration to the header**
+
+In `python_op_caller.h`, inside `namespace at::native::flagos {`, add after the `CallPythonOp_RandomInplace` declaration:
+
+```cpp
+// Fetch the vendor compat shim's per-device CUDA generator
+// (torch.cuda.default_generators[device_index]) as an at::Generator. This is
+// the SAME object FlagGems reads via philox_backend_seed_offset, so injecting
+// it into native RNG kernels unifies both RNG worlds under torch.manual_seed.
+// Cached per device index (the shim object is stable; torch.cuda.manual_seed
+// mutates it in place, so a cached handle stays valid).
+at::Generator GetFlagosDefaultCudaGenerator(int64_t device_index);
+```
+
+- [ ] **Step 2: Add the include for Generator pybind support**
+
+In `python_op_caller.cc`, near the existing includes (after `#include <torch/csrc/utils/pybind.h>` at line 8), add:
+
+```cpp
+#include <torch/csrc/Generator.h>
+#include <ATen/core/Generator.h>
+```
+
+- [ ] **Step 3: Implement the helper**
+
+In `python_op_caller.cc`, inside `namespace at::native::flagos {` (append near the other `CallPythonOp_*` definitions, before the closing brace), add:
+
+```cpp
+at::Generator GetFlagosDefaultCudaGenerator(int64_t device_index) {
+  static std::mutex cache_mu;
+  static std::unordered_map<int64_t, at::Generator> gen_cache;
+  {
+    std::lock_guard<std::mutex> lk(cache_mu);
+    auto it = gen_cache.find(device_index);
+    if (it != gen_cache.end()) {
+      return it->second;
+    }
+  }
+  py::gil_scoped_acquire gil;
+  py::module_ torch_cuda = py::module_::import("torch.cuda");
+  py::object gens = torch_cuda.attr("default_generators");
+  py::object py_gen = gens[py::cast(device_index)];
+  // torch.Generator -> at::Generator via THPGenerator unpack.
+  at::Generator gen = py_gen.cast<at::Generator>();
+  {
+    std::lock_guard<std::mutex> lk(cache_mu);
+    gen_cache[device_index] = gen;
+  }
+  return gen;
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run:
+```bash
+cd /nfs/lvyufeng/PyTorch-Plugin-FL/.claude/worktrees/rng-completeness-check
+source /nfs/lvyufeng/env.sh && conda activate torch-fl-210
+FLAGGEMS_KERNEL=OFF FLAGGEMS_PYTHON=OFF CUDA_KERNEL=ON pip install -e . --no-build-isolation 2>&1 | tail -20
+```
+Expected: build succeeds (helper is unused for now — no call sites yet — but must compile). If `py_gen.cast<at::Generator>()` fails to resolve, fall back to `THPGenerator_Unpack(py_gen.ptr())` (from `torch/csrc/Generator.h`), which returns `at::Generator`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add csrc/aten/backends/flagos/python_op_caller.h csrc/aten/backends/flagos/python_op_caller.cc
+git commit -m "feat(rng): add GetFlagosDefaultCudaGenerator C++ helper"
+```
+
+---
+
+### Task 2: Codegen — inject shared generator into tensor-input RNG kernels
+
+**Files:**
+- Modify: `scripts/codegen_ops.py` — helper predicate + edits to `gen_functional_pure` (~1107), `gen_inplace` (~1151), `gen_out_variant` (~1192), `gen_tuple_return` (~1241)
+- Modify (regenerate, do not hand-edit): `csrc/aten/generated/cuda_kernels.cc`
+- Test: Task 4.
+
+**Interfaces:**
+- Consumes: `GetFlagosDefaultCudaGenerator(int64_t)` from Task 1.
+- Produces: generated tensor-input RNG kernels emit, before the `at::<op>` call:
+  `if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(<idx>);`
+  where `<idx>` is the first boxed input tensor's `.get_device()`.
+
+- [ ] **Step 1: Add a shared injection-line helper near the body templates**
+
+In `scripts/codegen_ops.py`, add a module-level helper above `gen_functional_pure` (~line 1105):
+
+```python
+def _generator_inject_line(args, device_expr):
+    """If this op's schema carries a trailing `Generator?`, emit a line that
+    fills an absent generator with the flagos shared CUDA generator (the one
+    FlagGems reads), so torch.manual_seed unifies native + flaggems RNG.
+    Returns '' for non-RNG ops. `device_expr` is a C++ expr yielding int64
+    device index in the kernel body scope."""
+    has_gen = any("Generator" in t for t, _ in args)
+    if not has_gen:
+        return ""
+    # The generator parameter is always named `generator` in the faithful sig.
+    return (
+        f"  if (!generator.has_value()) generator = "
+        f"at::native::flagos::GetFlagosDefaultCudaGenerator({device_expr});\n"
+    )
+```
+
+- [ ] **Step 2: Wire it into `gen_functional_pure`**
+
+In `gen_functional_pure` (~1128), the current return is:
+```python
+    return f"""{ret_type} {kn}({args_decl(args)}) {{
+{holder_lines}  DeviceBoxingGuard guard({guard});
+  auto result = {api}({call_args(args)});
+  UnboxToFlagos(result);
+  return result;
+}}"""
+```
+Change it to insert the inject line after the guard. The device index comes from the first boxed tensor (`guard_names[0]`), which is on CUDA after boxing:
+```python
+    inject = _generator_inject_line(args, f"{guard_names[0]}.get_device()") if guard_names else ""
+    return f"""{ret_type} {kn}({args_decl(args)}) {{
+{holder_lines}  DeviceBoxingGuard guard({guard});
+{inject}  auto result = {api}({call_args(args)});
+  UnboxToFlagos(result);
+  return result;
+}}"""
+```
+
+- [ ] **Step 3: Wire it into `gen_inplace`**
+
+In `gen_inplace` the body (~1180-1189) is built as `at::{base}(...)` or `self.method(...)` with a `DeviceBoxingGuard guard(self, ...)`. Insert the inject line after the guard line, using `self` as the device source. Locate the `f"""..."""` return block and add `{inject}` right after the `DeviceBoxingGuard guard(...)` line, with:
+```python
+    inject = _generator_inject_line(args, "self.get_device()")
+```
+(The first arg of an inplace RNG op is always `at::Tensor & self`.)
+
+- [ ] **Step 4: Wire it into `gen_out_variant`**
+
+In `gen_out_variant` (~1226/1234) the body uses `DeviceBoxingGuard guard(...)` over boxed inputs+out, then calls `at::{base}_outf(...)`. Insert `{inject}` after the guard line with the device source being the `out` tensor (always present and boxed) or the first guarded name:
+```python
+    inject = _generator_inject_line(args, f"{out_names[0]}.get_device()")
+```
+Use whatever variable name the function already computes for the out tensor(s); if it is a list, use its first element. If no out name variable exists, use the first entry of the guard names list.
+
+- [ ] **Step 5: Wire it into `gen_tuple_return`**
+
+`gen_tuple_return` (~1241, e.g. `PrivFusedDropout`) has `DeviceBoxingGuard guard(self, ...)`. Insert `{inject}` after the guard line with `self.get_device()` as device source (first tensor arg). Match the existing variable the function uses for guarded names; if it computes `guard = ", ".join(tensor_arg_names(args))`, use `tensor_arg_names(args)[0]`.
+
+- [ ] **Step 6: Regenerate and eyeball the output**
+
+Run:
+```bash
+python scripts/codegen_ops.py
+grep -A4 "NormalInplaceKernelCuda\|MultinomialKernelCuda\|PrivFusedDropoutKernelCuda\|BernoulliTensorOutKernelCuda" csrc/aten/generated/cuda_kernels.cc | head -40
+```
+Expected: each shows `if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(<tensor>.get_device());` between the guard and the `at::` call. Non-RNG kernels (e.g. `AddTensorKernelCuda`) unchanged.
+
+- [ ] **Step 7: Build**
+
+```bash
+FLAGGEMS_KERNEL=OFF FLAGGEMS_PYTHON=OFF CUDA_KERNEL=ON pip install -e . --no-build-isolation 2>&1 | tail -20
+```
+Expected: builds. If `ops.h`/`cuda_kernels.cc` cannot see `GetFlagosDefaultCudaGenerator`, ensure `cuda_kernels.cc` includes the caller header — add `#include "backends/flagos/python_op_caller.h"` to the codegen's include block for cuda_kernels.cc (search the `_CUDA_INCLUDES`/header-emit section near line 1538 and the cuda_kernels.cc writer near 1716) and regenerate.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/codegen_ops.py csrc/aten/generated/cuda_kernels.cc
+git commit -m "feat(rng): inject shared generator into tensor-input native RNG kernels"
+```
+
+---
+
+### Task 3: Codegen — inject into factory RNG kernels (rand/randint/randperm/randn)
+
+**Files:**
+- Modify: `scripts/codegen_ops.py` — `gen_factory` (~1399), compute-factory branch (~1449-1469)
+- Modify (regenerate): `csrc/aten/generated/cuda_kernels.cc`
+- Test: Task 4.
+
+**Interfaces:**
+- Consumes: `GetFlagosDefaultCudaGenerator(int64_t)` (Task 1), `_generator_inject_line` (Task 2).
+- Produces: factory RNG kernels (`Rand*Generator*`, `Randint*Generator*`, `RandpermGenerator*`, `Randn*Generator*`) inject the shared generator using `_cuda_dev.index()` before the `at::<base>(...)` call.
+
+- [ ] **Step 1: Inject in the compute-factory branch**
+
+In `gen_factory`, the compute branch (~1462) currently builds `make` as:
+```python
+            make = (
+                f"  at::Device _req_dev = {device_arg}.has_value() ? *{device_arg} "
+                f": at::Device(at::kPrivateUse1, 0);\n"
+                "  at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1\n"
+                "      ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;\n"
+                f"  auto result = at::{base}({', '.join(call_names)});\n"
+                "  if (result.device().type() == at::kCUDA) UnboxToFlagos(result);"
+            )
+```
+Insert the generator injection after `_cuda_dev` is computed and before the `at::{base}` call. `_cuda_dev` is in scope; use its index:
+```python
+            inject = _generator_inject_line(args, "_cuda_dev.index()")
+            make = (
+                f"  at::Device _req_dev = {device_arg}.has_value() ? *{device_arg} "
+                f": at::Device(at::kPrivateUse1, 0);\n"
+                "  at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1\n"
+                "      ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;\n"
+                f"{inject}"
+                f"  auto result = at::{base}({', '.join(call_names)});\n"
+                "  if (result.device().type() == at::kCUDA) UnboxToFlagos(result);"
+            )
+```
+The non-compute branches (`zeros`/`ones`/`full`/`scalar_tensor`) carry no `Generator?` arg, so `_generator_inject_line` returns `""` there — leave them unchanged.
+
+- [ ] **Step 2: Regenerate and eyeball**
+
+```bash
+python scripts/codegen_ops.py
+grep -A8 "RandintLowGeneratorKernelCuda\|RandpermGeneratorKernelCuda\|RandGeneratorKernelCuda" csrc/aten/generated/cuda_kernels.cc | head -40
+```
+Expected: each factory RNG kernel shows `if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());` right before its `at::rand/randint/randperm(...)` call.
+
+- [ ] **Step 3: Build**
+
+```bash
+FLAGGEMS_KERNEL=OFF FLAGGEMS_PYTHON=OFF CUDA_KERNEL=ON pip install -e . --no-build-isolation 2>&1 | tail -20
+```
+Expected: builds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/codegen_ops.py csrc/aten/generated/cuda_kernels.cc
+git commit -m "feat(rng): inject shared generator into factory RNG kernels"
+```
+
+---
+
+### Task 4: Reproducibility tests for the unified native RNG
+
+**Files:**
+- Create: `tests/integration/ops/test_rng_unified_dispatch.py`
+- Test: itself.
+
+**Interfaces:**
+- Consumes: the injected native RNG kernels (Tasks 2-3). No new symbols.
+- Produces: pytest coverage asserting reproducibility + seed-sensitivity for native RNG families and randperm.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/ops/test_rng_unified_dispatch.py`:
+
+```python
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unified RNG reproducibility for NATIVE (= cuda) RNG ops.
+
+After the C++ generator-injection change, native RNG kernels fall back to the
+shared per-device CUDA generator (torch.cuda.default_generators[device], the one
+FlagGems reads) when the caller passes no generator. So torch.manual_seed now
+makes native RNG reproducible too -- unifying the two RNG worlds. These ops route
+to `= cuda` regardless of FLAGOS_USE_FLAGGEMS, so this test does not gate on it.
+"""
+
+import pytest
+
+import torch_fl  # noqa: F401  (import before torch; installs preload + shim)
+import torch
+
+DEVICE = "flagos:0"
+
+
+def _reproducible(op):
+    torch.manual_seed(1234)
+    a = op()
+    torch.manual_seed(1234)
+    b = op()
+    return torch.equal(a.cpu(), b.cpu())
+
+
+def _seed_sensitive(op):
+    torch.manual_seed(1)
+    a = op()
+    torch.manual_seed(2)
+    b = op()
+    return not torch.equal(a.cpu(), b.cpu())
+
+
+# Warm ATen_cuda + build the lazy shared generator before the parametrized runs.
+@pytest.fixture(scope="module", autouse=True)
+def _warmup():
+    torch.manual_seed(0)
+    _ = torch.rand(8, device=DEVICE)
+
+
+_NATIVE_RNG_OPS = {
+    "normal_": lambda: torch.empty(256, device=DEVICE).normal_(0.0, 1.0),
+    "randint": lambda: torch.randint(0, 1000, (256,), device=DEVICE),
+    "randint_low": lambda: torch.randint(5, 1000, (256,), device=DEVICE),
+    "bernoulli_tensor": lambda: torch.bernoulli(
+        torch.full((256,), 0.5, device=DEVICE)
+    ),
+    "uniform_func": lambda: torch.empty(256, device=DEVICE).uniform_(2.0, 5.0),
+    "log_normal_": lambda: torch.empty(256, device=DEVICE).log_normal_(),
+    "cauchy_": lambda: torch.empty(256, device=DEVICE).cauchy_(),
+    "randperm": lambda: torch.randperm(512, device=DEVICE),
+}
+
+
+class TestNativeRngReproducible:
+    @pytest.mark.parametrize("name", list(_NATIVE_RNG_OPS))
+    def test_same_seed_same_draw(self, name):
+        assert _reproducible(_NATIVE_RNG_OPS[name]), (
+            f"{name} not reproducible under torch.manual_seed"
+        )
+
+    @pytest.mark.parametrize("name", list(_NATIVE_RNG_OPS))
+    def test_different_seed_differs(self, name):
+        assert _seed_sensitive(_NATIVE_RNG_OPS[name]), (
+            f"{name} not sensitive to seed changes"
+        )
+
+
+class TestGeneratorPassthrough:
+    """A user-supplied generator must still take effect (injection skipped)."""
+
+    def test_explicit_generator_reproducible(self):
+        g = torch.Generator(device="cuda")
+        g.manual_seed(77)
+        a = torch.empty(64, device=DEVICE).normal_(generator=g)
+        g.manual_seed(77)
+        b = torch.empty(64, device=DEVICE).normal_(generator=g)
+        assert torch.equal(a.cpu(), b.cpu())
+```
+
+- [ ] **Step 2: Run to verify it fails on a pre-change build (informational)**
+
+If run against the OLD build, `normal_`/`randint`/`randperm`/... would fail reproducibility. Since Tasks 1-3 already changed the build, run:
+```bash
+python -m pytest tests/integration/ops/test_rng_unified_dispatch.py -v 2>&1 | tail -30
+```
+Expected: PASS (proves the injection works). If any native op is still non-reproducible, its kernel body was missed by Tasks 2-3 — grep `cuda_kernels.cc` for that kernel and confirm the inject line is present; if absent, its category template needs the same treatment.
+
+- [ ] **Step 3: Run the full RNG suites together (flaggems path unaffected)**
+
+```bash
+FLAGOS_USE_FLAGGEMS=1 HF_HOME=/nfs/lvyufeng/hf_cache HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+  python -m pytest tests/integration/ops/test_rng_dispatch.py tests/integration/ops/test_rng_unified_dispatch.py -v 2>&1 | tail -40
+```
+Expected: existing `test_rng_dispatch.py` (10) still PASS; new tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/ops/test_rng_unified_dispatch.py
+git commit -m "test(rng): reproducibility for unified native RNG + generator passthrough"
+```
+
+---
+
+### Task 5: Regression sweep + doc note
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-30-unified-rng-design.md` (append a short "Implemented" note with verified results) — optional but recommended.
+- Test: existing native + flaggems_python suites.
+
+**Interfaces:**
+- Consumes: everything above. Produces: confidence that no existing behavior regressed.
+
+- [ ] **Step 1: Run the native ops suite (no flaggems)**
+
+```bash
+cd /nfs/lvyufeng/PyTorch-Plugin-FL/.claude/worktrees/rng-completeness-check
+source /nfs/lvyufeng/env.sh && conda activate torch-fl-210
+export HF_HOME=/nfs/lvyufeng/hf_cache HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+python -m pytest tests/integration/ops/ -m "not flaggems and not flaggems_python and not flaggems_cpp" \
+  --deselect tests/integration/ops/test_conv1d_dispatch.py::test_conv1d_with_bias 2>&1 | tail -20
+```
+Expected: same pass/skip counts as baseline (~311 passed per env memory), no new failures.
+
+- [ ] **Step 2: Run the flaggems_python suite**
+
+```bash
+FLAGOS_USE_FLAGGEMS=1 python -m pytest tests/integration/ops/ -m "flaggems_python" \
+  --deselect tests/integration/ops/test_conv1d_dispatch.py::test_conv1d_with_bias 2>&1 | tail -20
+```
+Expected: no new failures vs baseline.
+
+- [ ] **Step 3: Multi-device spot check (if host has >1 GPU)**
+
+Create a throwaway check (delete after):
+```bash
+cat > /tmp/rng_multidev.py <<'PY'
+import torch_fl
+import torch
+for idx in (0, 1):
+    d = f"flagos:{idx}"
+    try:
+        torch.manual_seed(5); a = torch.empty(32, device=d).normal_()
+        torch.manual_seed(5); b = torch.empty(32, device=d).normal_()
+        print(d, "reproducible:", torch.equal(a.cpu(), b.cpu()))
+    except Exception as e:
+        print(d, "skip:", type(e).__name__, str(e)[:50])
+PY
+python /tmp/rng_multidev.py 2>&1 | grep -E "flagos:" ; rm -f /tmp/rng_multidev.py
+```
+Expected: `flagos:0 reproducible: True` and `flagos:1 reproducible: True` (or a clean skip if only 1 GPU is visible).
+
+- [ ] **Step 4: Append implemented-note to the design doc and commit**
+
+Add a brief section at the end of the design doc summarizing verified results (which native families are now reproducible, suite pass counts). Then:
+```bash
+git add docs/superpowers/specs/2026-07-30-unified-rng-design.md
+git commit -m "docs(rng): record unified-RNG verification results"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Core mechanism (inject shared generator when absent) → Tasks 1-3. ✓
+- C++ helper fetching `torch.cuda.default_generators[idx]` as `at::Generator` → Task 1. ✓
+- Device-index derivation: tensor-input (`.get_device()`) → Task 2; factory (`_cuda_dev.index()`) → Task 3. ✓
+- Exhaustive scope (all 80 generator kernels) → covered because Tasks 2-3 edit the shared body templates (`gen_functional_pure`/`gen_inplace`/`gen_out_variant`/`gen_tuple_return`/`gen_factory`) that emit ALL of them; `_generator_inject_line` self-selects on presence of a `Generator?` arg. ✓
+- randperm-for-free → validated in Task 4 (`randperm` in `_NATIVE_RNG_OPS`). ✓
+- Backward compat (explicit generator honored) → Task 4 `TestGeneratorPassthrough`. ✓
+- Testing (reproducibility, cross-world, regression, multi-device) → Tasks 4-5. ✓
+- Risk: per-call GIL cost → Task 1 caches per-index. ✓
+- Risk: device-type assert → injected generator is CUDA, ops run post-boxing on CUDA; Task 4 exercises each family so a bad assert surfaces. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has concrete code. The `gen_inplace`/`gen_out_variant`/`gen_tuple_return` steps reference "the existing variable the function uses" because those emitters compute guard names slightly differently — the implementer must read the 3-4 surrounding lines and use the actual local name. This is a read-then-insert instruction with the exact inject expression given, not a vague placeholder.
+
+**Type consistency:** `GetFlagosDefaultCudaGenerator(int64_t) -> at::Generator` used identically in Tasks 1-3. `_generator_inject_line(args, device_expr) -> str` used identically in Tasks 2-3. The emitted C++ line is byte-identical across tasks (only `<device_expr>` differs). ✓

--- a/docs/superpowers/specs/2026-07-30-unified-rng-design.md
+++ b/docs/superpowers/specs/2026-07-30-unified-rng-design.md
@@ -1,0 +1,160 @@
+# Unified RNG for torch_fl (flagos backend) — Design
+
+Date: 2026-07-30
+Branch base: `flagos/main` (tip `3fa2057`)
+Status: design, pending implementation-plan
+
+## Problem
+
+The flagos (PrivateUse1) backend has **two disjoint RNG worlds**, and
+`torch.manual_seed` reaches only one of them:
+
+- **FlagGems (philox) world** — ops routed to `flagos_python`
+  (`rand`/`randn`/`uniform_`/`exponential_`/`multinomial`/`native_dropout`/
+  `bernoulli_.float`/`rand_like`/`randn_like`). These read seed+offset from
+  `torch.cuda.default_generators[device]`, a per-device `torch.Generator(
+  device="cuda")` installed by the vendor compat shim
+  (`torch_fl/accelerator/cuda/_cuda_compat.py`). `torch.manual_seed ->
+  torch.cuda.manual_seed_all` reseeds these, so they ARE reproducible.
+
+- **Native CUDA world** — ops routed to `= cuda` in the backends conf
+  (`normal_`/`randint`/`bernoulli.Tensor`/`random_`/`log_normal_`/`cauchy_`/
+  `uniform`(functional)/`poisson`/... and `randperm` transitively). Their
+  boxing kernels call `at::<op>(..., generator)` with `generator == nullopt`,
+  so ATen falls back to **its own default CUDA generator**
+  (`getDefaultCUDAGenerator()`). That generator is unreachable from Python on
+  the CPU-torch wheel — `torch._C` has no `_cuda_manualSeed` /
+  `_cuda_getRNGState` bindings (verified: `hasattr(...) == False`). So
+  `torch.manual_seed` cannot seed it, and these ops are NOT reproducible.
+
+Goal: **a single generator source.** All RNG — FlagGems, native CUDA, and any
+C++ path — draws randomness from ONE generator, so `torch.manual_seed` makes
+everything reproducible and the two-worlds split is eliminated.
+
+## Why "seed the ATen default generator" is impossible here
+
+The chosen target ("make ATen's default CUDA generator the single source") is
+NOT reachable from Python on CPU-torch: the `_cuda_manualSeed`-family C++→Python
+bindings are compiled only into CUDA-build torch, and we run the CPU wheel +
+external `libtorch_cuda.so`. Probed 2026-07-30: those attributes are absent, and
+seeding our shim generator does NOT affect native `normal_` (they are different
+objects).
+
+## Chosen approach — B: C++-level explicit generator injection
+
+**Verified anchor (2026-07-30):** the flagos→CUDA boxing path *honors an
+explicitly-passed generator*. `torch.empty(n, device="flagos").normal_(
+generator=g)` is fully reproducible under `g.manual_seed(s)`, and `g` can be the
+very object FlagGems reads (`torch.cuda.default_generators[0]`). So if every
+native RNG kernel injects that shared generator when the caller passed none,
+both worlds draw from one generator.
+
+### Mechanism
+
+In each generated native-CUDA RNG kernel body, before the `at::<op>(...)` call:
+
+```cpp
+if (!generator.has_value()) {
+    generator = GetFlagosDefaultCudaGenerator(<device_index>);
+}
+```
+
+`GetFlagosDefaultCudaGenerator(int64_t device_index)` is a new C++ helper
+(added alongside the existing `python_op_caller`) that, under
+`py::gil_scoped_acquire`, fetches `torch.cuda.default_generators[device_index]`
+(the shim's per-device CUDA generator — the SAME object FlagGems reads) and
+converts it to `at::Generator`. Using the Python shim object (not the C++
+`csrc/runtime/generator.cc` World-A `GeneratorImpl`, which is dead code for RNG)
+guarantees FlagGems and native share one generator.
+
+When the caller *did* pass a generator, `has_value()` is true and injection is
+skipped — fully backward compatible.
+
+### Deriving `device_index` inside each body
+
+Two body shapes, both able to determine the index in-body:
+
+- **A. Tensor-input kernels** (inplace / functional / out / tuple_return): have
+  a `DeviceBoxingGuard(self, ...)`. Use the boxed input tensor's device index.
+- **B. Factory RNG kernels** (`rand`/`randint`/`randperm`/`randn` `.generator`
+  overloads): no input tensor, but already compute `_cuda_dev`. Use
+  `_cuda_dev.index()`.
+
+### randperm falls out for free
+
+`randperm` routes to `flagos_python` but its dominant randomness is an internal
+`torch.randint(low=, high=)` that hits `RandintLowGeneratorKernelCuda` (native).
+Injecting there makes randperm reproducible with no randperm-specific code.
+
+## Scope — exhaustive
+
+ALL 80 native-CUDA kernels carrying `std::optional<at::Generator> generator`
+(enumerated from `csrc/aten/generated/cuda_kernels.cc`). Families:
+
+- Normal: `NormalInplace`, `NormalFunctional`, `NormalOut`,
+  `Normal{FloatFloat,FloatTensor,TensorFloat,TensorTensor}(+Out)`
+- Bernoulli: `Bernoulli`, `BernoulliTensor(+Out)`, `BernoulliFloatOut`,
+  `BernoulliOut`, `BernoulliInplace{Float,Tensor}`
+- Rand/Randn factory: `Rand{,Like}Generator(+Out)`,
+  `Rand{,Like}GeneratorWithNames(+Out)`, `Randn{,Like}Generator(+Out)`,
+  `RandnGeneratorWithNames(+Out)`
+- Randint: `RandintGenerator(+Out)`, `RandintLowGenerator(+Out)`,
+  `RandintLike{,Tensor,LowGeneratorDtype}Generator(+Out)`
+- Randperm: `RandpermGenerator(+Out)`
+- Random_: `Random{,From,To}(+Out)`, `RandomInplace{,From,To}`
+- Distributions: `Uniform{,Inplace,Out}`, `Exponential{,Inplace,Out}`,
+  `Geometric{,Inplace,Out}`, `LogNormal{,Inplace,Out}`, `Cauchy{,Inplace,Out}`,
+  `Poisson(+Out)`, `Binomial(+Out)`, `Multinomial(+Out)`,
+  `PrivStandardGamma(+Out)`, `PrivSampleDirichlet(+Out)`, `PrivFusedDropout(+Out)`,
+  `RreluWithNoise{,Inplace,Functional,Out}`
+
+Injection is a no-op when the caller passes a generator, so applying it to the
+explicit `.generator` overloads too is safe and uniform.
+
+## Implementation surface
+
+1. **C++ helper** `GetFlagosDefaultCudaGenerator(int64_t)` — new function in the
+   flagos backend (near `python_op_caller.{h,cc}`): GIL-acquire, read
+   `torch.cuda.default_generators[idx]`, return `at::Generator`. Consider a
+   process-lifetime cache keyed by index (the shim generator is stable) to avoid
+   a Python round-trip per RNG call; must stay correct across
+   `torch.cuda.manual_seed` (which mutates the same object in place, so a cached
+   `at::Generator` handle remains valid).
+2. **Codegen** `scripts/codegen_ops.py` — add a predicate "native kernel with a
+   `Generator?` arg" and emit the injection line in the affected body templates
+   (`gen_functional_pure`, `gen_inplace`, `gen_out_variant`, `gen_tuple_return`,
+   and the factory-RNG template). Regenerate `csrc/aten/generated/cuda_kernels.cc`.
+3. **Rebuild** `_C.so` (CUDA_KERNEL=ON, single-wheel scheme).
+4. **Config** — no routing changes required; native RNG stays `= cuda`. (The
+   unification is now internal to those kernels.)
+
+## Testing
+
+- Extend `tests/integration/ops/test_rng_dispatch.py` (or a sibling) to assert
+  reproducibility + seed-sensitivity under `torch.manual_seed` for the native
+  families now unified: `normal_`, `randint`/`randint.low`, `bernoulli.Tensor`,
+  `uniform`(functional), `log_normal_`, `cauchy_`, `exponential`(native),
+  `multinomial.out`, `poisson`, and **`randperm`**.
+- Cross-world consistency: with FlagGems on, seed once and confirm a FlagGems op
+  and a native op both advance/consume the shared generator deterministically.
+- Regression: full native suite + flaggems_python suite show no new failures.
+  Exclude the pre-existing `test_conv1d_dispatch.py::test_conv1d_with_bias`
+  segfault (unrelated, fails on clean tree).
+- Verify backward compat: a user-supplied `generator=` still takes effect
+  (injection skipped).
+
+## Risks / open items
+
+- **Per-call GIL cost.** Reading Python `default_generators` under the GIL on
+  every native RNG call adds overhead. Mitigation: cache the `at::Generator` per
+  device index in C++ after first fetch.
+- **Generator device-type assert.** ATen `check_generator` asserts the generator
+  device type matches the op. We inject a CUDA generator into ops running (post-
+  boxing) on CUDA, so this holds — but must be verified per family, especially
+  factory ops where the op nominally targets `_cuda_dev`.
+- **Ops that hardcode `generator=None` downstream.** Some code paths ignore a
+  passed generator (noted in codegen comments for certain gems ops). For native
+  `at::<op>` this is not expected, but the out/functional variants should be
+  spot-checked that ATen actually threads the injected generator through.
+- **Multi-device.** Index derivation must be correct for non-zero device
+  indices; tests should cover at least device 0 and 1 if the host has >1 GPU.

--- a/scripts/codegen_ops.py
+++ b/scripts/codegen_ops.py
@@ -1114,6 +1114,22 @@ def optional_tensor_names(args: List[Tuple[str, str]]) -> List[str]:
     return [n for t, n in args if "optional<at::Tensor>" in t]
 
 
+def _generator_inject_line(args, device_expr):
+    """If this op's schema carries a trailing `Generator?`, emit a line that
+    fills an absent generator with the flagos shared CUDA generator (the one
+    FlagGems reads), so torch.manual_seed unifies native + flaggems RNG.
+    Returns '' for non-RNG ops. `device_expr` is a C++ expr yielding int64
+    device index in the kernel body scope."""
+    has_gen = any("Generator" in t for t, _ in args)
+    if not has_gen:
+        return ""
+    # The generator parameter is always named `generator` in the faithful sig.
+    return (
+        f"  if (!generator.has_value()) generator = "
+        f"at::native::flagos::GetFlagosDefaultCudaGenerator({device_expr});\n"
+    )
+
+
 def gen_functional_pure(op, fn_type, ret_type, args, func=None):
     kn = kernel_name(fn_type)
     api = f"at::{at_api_base(op)}"
@@ -1135,9 +1151,14 @@ def gen_functional_pure(op, fn_type, ret_type, args, func=None):
         guard_names.append(f"{on}_t")
     guard = ", ".join(guard_names)
 
+    inject = (
+        _generator_inject_line(args, f"{guard_names[0]}.get_device()")
+        if guard_names
+        else ""
+    )
     return f"""{ret_type} {kn}({args_decl(args)}) {{
 {holder_lines}  DeviceBoxingGuard guard({guard});
-  auto result = {api}({call_args(args)});
+{inject}  auto result = {api}({call_args(args)});
   UnboxToFlagos(result);
   return result;
 }}"""
@@ -1193,9 +1214,10 @@ def gen_inplace(op, fn_type, ret_type, args, func=None):
         ret_line = ""
     else:
         ret_line = f"\n  return {self_name};"
+    inject = _generator_inject_line(args, "self.get_device()")
     return f"""{ret_type} {kn}({args_decl(args)}) {{
   DeviceBoxingGuard guard({guard});
-  {body_call}{ret_line}
+{inject}  {body_call}{ret_line}
 }}"""
 
 
@@ -1228,13 +1250,16 @@ def gen_out_variant(op, fn_type, ret_type, args, func=None):
 
     unbox_lines = "\n".join(f"  UnboxToFlagos({n});" for n in out_names)
 
+    device_source = out_names[0] if out_names else guard_names[0]
+    inject = _generator_inject_line(args, f"{device_source}.get_device()")
+
     if ret_type.startswith("::std::tuple"):
         # tuple<Tensor&,...>: _ret references the out tensors; unbox out names.
         # (local is _ret, not result, because some ops have an out arg literally
         #  named `result`, e.g. _linalg_det.result.)
         return f"""{ret_type} {kn}({args_decl(args)}) {{
 {holder_lines}  DeviceBoxingGuard guard({guard});
-  auto _ret = {api}({call_args(args)});
+{inject}  auto _ret = {api}({call_args(args)});
 {unbox_lines}
   return _ret;
 }}"""
@@ -1242,7 +1267,7 @@ def gen_out_variant(op, fn_type, ret_type, args, func=None):
     out_name = out_names[0]
     return f"""{ret_type} {kn}({args_decl(args)}) {{
 {holder_lines}  DeviceBoxingGuard guard({guard});
-  {api}({call_args(args)});
+{inject}  {api}({call_args(args)});
 {unbox_lines}
   return {out_name};
 }}"""
@@ -1269,9 +1294,10 @@ def gen_tuple_return(op, fn_type, ret_type, args, func=None):
     unbox_lines = "\n".join(
         f"  UnboxToFlagos(std::get<{i}>(result));" for i in range(ntuple)
     )
+    inject = _generator_inject_line(args, f"{tensor_arg_names(args)[0]}.get_device()")
     return f"""{ret_type} {kn}({args_decl(args)}) {{
 {holder_lines}  DeviceBoxingGuard guard({guard});
-  auto result = {api}({call_args(args)});
+{inject}  auto result = {api}({call_args(args)});
 {unbox_lines}
   return result;
 }}"""
@@ -1469,11 +1495,60 @@ def gen_factory(op, fn_type, ret_type, args, func=None):
                 "::std::optional<at::Device>(_cuda_dev)" if n == device_arg else n
                 for _, n in args
             ]
+            has_gen_arg = any("Generator" in t for t, _ in args)
+            # Unified RNG for generator-LESS factory overloads.
+            #
+            # torch.randint(...) / torch.randperm(...) call the overloads WITHOUT a
+            # `Generator?` arg, so _generator_inject_line (which only fires when the
+            # schema already carries one) does nothing and at::randint(...) falls back
+            # to ATen's default CUDA generator -- unreachable from torch.manual_seed.
+            # These bases all expose a sibling overload with `Generator?` inserted
+            # right after the size arg (verified in ATen/ops/{randint,randperm,
+            # rand,randn}.h), so inject the flagos shared generator there to route
+            # them through the same seedable generator FlagGems uses. randperm falls
+            # out for free (its dominant randomness is an internal torch.randint).
+            _GEN_FACTORY_BASES = {"randint", "randperm", "rand", "randn"}
+            if not has_gen_arg and base in _GEN_FACTORY_BASES:
+                # size is the first IntArrayRef/SymIntArrayRef positional (no self here)
+                size_name = next(
+                    (n for t, n in args if "ArrayRef" in t and "Dimname" not in t),
+                    size_arg,
+                )
+                gen_call_names = []
+                for _t, n in args:
+                    cn = (
+                        "::std::optional<at::Device>(_cuda_dev)"
+                        if n == device_arg
+                        else n
+                    )
+                    gen_call_names.append(cn)
+                    if n == size_name:
+                        gen_call_names.append("_flagos_gen")
+                inject = (
+                    "  ::std::optional<at::Generator> _flagos_gen = "
+                    "at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());\n"
+                )
+                make = (
+                    f"  at::Device _req_dev = {device_arg}.has_value() ? *{device_arg} "
+                    f": at::Device(at::kPrivateUse1, 0);\n"
+                    "  at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1\n"
+                    "      ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;\n"
+                    f"{inject}"
+                    f"  auto result = at::{base}({', '.join(gen_call_names)});\n"
+                    "  if (result.device().type() == at::kCUDA) UnboxToFlagos(result);"
+                )
+                return f"""{ret_type} {kn}({args_decl(args)}) {{
+{options}
+{make}
+  return result;
+}}"""
+            inject = _generator_inject_line(args, "_cuda_dev.index()")
             make = (
                 f"  at::Device _req_dev = {device_arg}.has_value() ? *{device_arg} "
                 f": at::Device(at::kPrivateUse1, 0);\n"
                 "  at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1\n"
                 "      ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;\n"
+                f"{inject}"
                 f"  auto result = at::{base}({', '.join(call_names)});\n"
                 "  if (result.device().type() == at::kCUDA) UnboxToFlagos(result);"
             )
@@ -1731,6 +1806,7 @@ def main():
         "",
         '#include "ops.h"',
         '#include "../device_boxing.h"',
+        '#include "../backends/flagos/python_op_caller.h"',
         "",
         "#include <vector>",
         "#include <tuple>",


### PR DESCRIPTION
## Summary

Unifies the **native-CUDA RNG half** with the FlagGems RNG half so `torch.manual_seed` makes *all* flagos RNG reproducible. Prior work (already on `main`) unified only the FlagGems Python hot path via `torch.cuda.default_generators`; native ops routed `= cuda` (`normal_`/`bernoulli`/`randint`/`random_`/`log_normal_`/`randperm`...) still boxed to CUDA and drew from ATen's `getDefaultCUDAGenerator()`, which is unreachable from `torch.manual_seed` on the CPU-torch + external `libtorch_cuda.so` wheel (`torch._C` has no `_cuda_manualSeed` binding). Result was two disjoint RNG worlds.

## Approach — C++ generator injection

- **`GetFlagosDefaultCudaGenerator(int64_t idx)`** (new helper in `python_op_caller.cc`): under the GIL, fetches `torch.cuda.default_generators[idx]` — the *same* per-device `torch.Generator(device="cuda")` the vendor compat shim installs and FlagGems reads — and returns it as `at::Generator` (process-lifetime cached by index).
- **Codegen** (`scripts/codegen_ops.py`): for every native kernel whose schema carries `Generator?`, emit `if (!generator.has_value()) generator = GetFlagosDefaultCudaGenerator(<dev>)` before the `at::<op>()` call. Covers 80 kernels across functional/inplace/out/tuple/factory templates. No-op when the caller passes a generator (backward compatible).
- **Generator-less factory overloads** (`randint`/`randint.low`/`randperm`): `torch.randint(...)` / `torch.randperm(...)` dispatch to overloads whose schema has *no* `Generator?` arg, so the rule above didn't reach them. These bases each expose a sibling overload with `Generator?` right after the size arg (per `ATen/ops/{randint,randperm,rand,randn}.h`), so inject the shared generator there. `randperm` falls out for free (its randomness is an internal `torch.randint`).
- **CMakeLists**: build `python_op_caller.cc` whenever `CUDA_KERNEL=ON` (cuda_kernels.cc now calls the helper regardless of the FlagGems flags).

No routing/config changes — native RNG stays `= cuda`; the unification is internal to those kernels.

## Verification (A100, `FLAGOS_USE_FLAGGEMS=1`)

All reproducible **and** seed-sensitive under `torch.manual_seed`:
- FlagGems path: `rand` / `randn` / `rand_like` / `uniform_` / `exponential_` / `multinomial`
- Native path: `normal_` / `bernoulli` / `random_` / `log_normal_` / `cauchy_` / `geometric_`
- Former gaps now fixed: `randint` / `randint.low` / `randperm`
- Distributions correct (normal_ mean≈0 std≈1; randint in range; randperm a valid permutation); explicit `generator=` still honored.

No regression:
- `test_rng_dispatch.py`: 10 passed
- `flaggems_python` suite: 37 passed
- native suite: 335 passed / 58 skipped / 3 xpassed (pre-existing `test_conv1d_dispatch.py::test_conv1d_with_bias` segfault excluded — fails on clean tree, unrelated)
