### PR TITLE
fix(rng): close last two generator-injection gaps, put RNG under CI

### DIFF
--- a/csrc/aten/generated/cuda_kernels.cc
+++ b/csrc/aten/generated/cuda_kernels.cc
@@ -12895,21 +12895,24 @@ at::Tensor RandNamesKernelCuda(at::IntArrayRef size, ::std::optional<at::Dimname
 
 at::Tensor & RandNamesOutKernelCuda(at::IntArrayRef size, ::std::optional<at::DimnameList> names, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
-  at::rand_outf(size, names, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::rand_outf(size, _flagos_gen, names, out);
   UnboxToFlagos(out);
   return out;
 }
 
 at::Tensor & RandOutKernelCuda(at::IntArrayRef size, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
-  at::rand_outf(size, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::rand_outf(size, _flagos_gen, out);
   UnboxToFlagos(out);
   return out;
 }
 
 at::Tensor RandLikeKernelCuda(const at::Tensor & self, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
-  auto result = at::rand_like(self, dtype, layout, device, pin_memory, memory_format);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
+  auto result = at::rand_like(self, _flagos_gen, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
   return result;
 }
@@ -12932,7 +12935,8 @@ at::Tensor & RandLikeGeneratorOutKernelCuda(const at::Tensor & self, ::std::opti
 
 at::Tensor & RandLikeOutKernelCuda(const at::Tensor & self, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
-  at::rand_like_outf(self, memory_format, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::rand_like_outf(self, _flagos_gen, memory_format, out);
   UnboxToFlagos(out);
   return out;
 }
@@ -13015,28 +13019,32 @@ at::Tensor & RandintLowGeneratorOutKernelCuda(int64_t low, int64_t high, at::Int
 
 at::Tensor & RandintLowOutKernelCuda(int64_t low, int64_t high, at::IntArrayRef size, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
-  at::randint_outf(low, high, size, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::randint_outf(low, high, size, _flagos_gen, out);
   UnboxToFlagos(out);
   return out;
 }
 
 at::Tensor & RandintOutKernelCuda(int64_t high, at::IntArrayRef size, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
-  at::randint_outf(high, size, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::randint_outf(high, size, _flagos_gen, out);
   UnboxToFlagos(out);
   return out;
 }
 
 at::Tensor RandintLikeKernelCuda(const at::Tensor & self, int64_t high, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
-  auto result = at::randint_like(self, high, dtype, layout, device, pin_memory, memory_format);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
+  auto result = at::randint_like(self, high, _flagos_gen, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
   return result;
 }
 
 at::Tensor RandintLikeTensorKernelCuda(const at::Tensor & self, const at::Tensor & high, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self, high);
-  auto result = at::randint_like(self, high, dtype, layout, device, pin_memory, memory_format);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
+  auto result = at::randint_like(self, high, _flagos_gen, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
   return result;
 }
@@ -13059,7 +13067,8 @@ at::Tensor & RandintLikeTensorGeneratorOutKernelCuda(const at::Tensor & self, co
 
 at::Tensor & RandintLikeTensorOutKernelCuda(const at::Tensor & self, const at::Tensor & high, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, high, out);
-  at::randint_like_outf(self, high, memory_format, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::randint_like_outf(self, high, _flagos_gen, memory_format, out);
   UnboxToFlagos(out);
   return out;
 }
@@ -13082,14 +13091,16 @@ at::Tensor & RandintLikeGeneratorOutKernelCuda(const at::Tensor & self, int64_t 
 
 at::Tensor RandintLikeLowDtypeKernelCuda(const at::Tensor & self, int64_t low, int64_t high, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
-  auto result = at::randint_like(self, low, high, dtype, layout, device, pin_memory, memory_format);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
+  auto result = at::randint_like(self, low, high, _flagos_gen, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
   return result;
 }
 
 at::Tensor & RandintLikeLowDtypeOutKernelCuda(const at::Tensor & self, int64_t low, int64_t high, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
-  at::randint_like_outf(self, low, high, memory_format, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::randint_like_outf(self, low, high, _flagos_gen, memory_format, out);
   UnboxToFlagos(out);
   return out;
 }
@@ -13112,7 +13123,8 @@ at::Tensor & RandintLikeLowGeneratorDtypeOutKernelCuda(const at::Tensor & self, 
 
 at::Tensor & RandintLikeOutKernelCuda(const at::Tensor & self, int64_t high, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
-  at::randint_like_outf(self, high, memory_format, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::randint_like_outf(self, high, _flagos_gen, memory_format, out);
   UnboxToFlagos(out);
   return out;
 }
@@ -13187,14 +13199,16 @@ at::Tensor RandnNamesKernelCuda(at::IntArrayRef size, ::std::optional<at::Dimnam
 
 at::Tensor & RandnNamesOutKernelCuda(at::IntArrayRef size, ::std::optional<at::DimnameList> names, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
-  at::randn_outf(size, names, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::randn_outf(size, _flagos_gen, names, out);
   UnboxToFlagos(out);
   return out;
 }
 
 at::Tensor RandnLikeKernelCuda(const at::Tensor & self, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
-  auto result = at::randn_like(self, dtype, layout, device, pin_memory, memory_format);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
+  auto result = at::randn_like(self, _flagos_gen, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
   return result;
 }
@@ -13217,7 +13231,8 @@ at::Tensor & RandnLikeGeneratorOutKernelCuda(const at::Tensor & self, ::std::opt
 
 at::Tensor & RandnLikeOutKernelCuda(const at::Tensor & self, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
-  at::randn_like_outf(self, memory_format, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::randn_like_outf(self, _flagos_gen, memory_format, out);
   UnboxToFlagos(out);
   return out;
 }
@@ -13331,7 +13346,8 @@ at::Tensor & RandpermGeneratorOutKernelCuda(int64_t n, ::std::optional<at::Gener
 
 at::Tensor & RandpermOutKernelCuda(int64_t n, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
-  at::randperm_outf(n, out);
+  ::std::optional<at::Generator> _flagos_gen = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
+  at::randperm_outf(n, _flagos_gen, out);
   UnboxToFlagos(out);
   return out;
 }

--- a/scripts/codegen_ops.py
+++ b/scripts/codegen_ops.py
@@ -1130,6 +1130,21 @@ def _generator_inject_line(args, device_expr):
     )
 
 
+# RNG bases whose *plain* overloads carry NO `Generator?` in the schema, so
+# _generator_inject_line above never fires for them and they would silently fall
+# back to ATen's own default CUDA generator -- unreachable from
+# torch.manual_seed on the CPU-torch wheel. Each base does expose a sibling ATen
+# overload with `optional<Generator>` inserted at a fixed position, so the
+# corresponding template threads the flagos shared generator in explicitly.
+# One set per template, because the insertion point differs:
+#   factory      -> right after the size/n/high value args (before dtype)
+#   *_like       -> right before dtype
+#   out-variant  -> before the first of names / memory_format / out
+_GEN_FACTORY_BASES = {"randint", "randperm", "rand", "randn"}
+_GEN_LIKE_BASES = {"randint_like", "rand_like", "randn_like"}
+_GEN_OUT_BASES = _GEN_FACTORY_BASES | _GEN_LIKE_BASES
+
+
 def gen_functional_pure(op, fn_type, ret_type, args, func=None):
     kn = kernel_name(fn_type)
     api = f"at::{at_api_base(op)}"
@@ -1156,6 +1171,38 @@ def gen_functional_pure(op, fn_type, ret_type, args, func=None):
         if guard_names
         else ""
     )
+
+    # Unified RNG for generator-LESS *_like overloads.
+    #
+    # randint_like/rand_like/randn_like carry a `self` tensor, so they land on
+    # this template rather than gen_factory -- and their plain overloads have no
+    # `Generator?` arg, so _generator_inject_line above emits nothing and
+    # at::randint_like(...) falls back to ATen's default CUDA generator, which
+    # torch.manual_seed cannot reach. Each of these bases exposes a sibling
+    # overload with `Generator?` inserted after the trailing value args and
+    # before dtype (verified in ATen/ops/randint_like.h), so inject the flagos
+    # shared generator at that position.
+    base = at_api_base(op)
+    if base in _GEN_LIKE_BASES and not any("Generator" in t for t, _ in args):
+        dtype_name = next((n for t, n in args if "optional<at::ScalarType>" in t), None)
+        if dtype_name is not None and guard_names:
+            gen_call_names = []
+            for _t, n in args:
+                if n == dtype_name:
+                    gen_call_names.append("_flagos_gen")
+                gen_call_names.append(n)
+            inject = (
+                "  ::std::optional<at::Generator> _flagos_gen = "
+                "at::native::flagos::GetFlagosDefaultCudaGenerator("
+                f"{guard_names[0]}.get_device());\n"
+            )
+            return f"""{ret_type} {kn}({args_decl(args)}) {{
+{holder_lines}  DeviceBoxingGuard guard({guard});
+{inject}  auto result = {api}({", ".join(gen_call_names)});
+  UnboxToFlagos(result);
+  return result;
+}}"""
+
     return f"""{ret_type} {kn}({args_decl(args)}) {{
 {holder_lines}  DeviceBoxingGuard guard({guard});
 {inject}  auto result = {api}({call_args(args)});
@@ -1252,6 +1299,38 @@ def gen_out_variant(op, fn_type, ret_type, args, func=None):
 
     device_source = out_names[0] if out_names else guard_names[0]
     inject = _generator_inject_line(args, f"{device_source}.get_device()")
+    call = call_args(args)
+
+    # Unified RNG for generator-LESS out-variants (rand.out, randint.out,
+    # randint_like.out, randperm.out, ...). Same gap as the gen_factory /
+    # gen_functional_pure cases: the plain overload carries no `Generator?`, so
+    # _generator_inject_line emits nothing and at::<base>_outf() falls back to
+    # ATen's default CUDA generator, which torch.manual_seed cannot reach.
+    #
+    # Every one of these bases exposes a sibling `_outf` overload with
+    # `optional<Generator>` inserted after the trailing value args and before the
+    # first trailing modifier -- `names` (rand/randn), `memory_format` (*_like),
+    # or the `out` tensor itself when neither is present. Verified across
+    # ATen/ops/{rand,randn,rand_like,randn_like,randint,randint_like,randperm}.h.
+    if base in _GEN_OUT_BASES and not any("Generator" in t for t, _ in args):
+        gen_call_names = []
+        placed = False
+        for t, n in args:
+            if not placed and (
+                "optional<at::DimnameList>" in t
+                or "optional<at::MemoryFormat>" in t
+                or n in out_names
+            ):
+                gen_call_names.append("_flagos_gen")
+                placed = True
+            gen_call_names.append(n)
+        if placed:
+            inject = (
+                "  ::std::optional<at::Generator> _flagos_gen = "
+                "at::native::flagos::GetFlagosDefaultCudaGenerator("
+                f"{device_source}.get_device());\n"
+            )
+            call = ", ".join(gen_call_names)
 
     if ret_type.startswith("::std::tuple"):
         # tuple<Tensor&,...>: _ret references the out tensors; unbox out names.
@@ -1259,7 +1338,7 @@ def gen_out_variant(op, fn_type, ret_type, args, func=None):
         #  named `result`, e.g. _linalg_det.result.)
         return f"""{ret_type} {kn}({args_decl(args)}) {{
 {holder_lines}  DeviceBoxingGuard guard({guard});
-{inject}  auto _ret = {api}({call_args(args)});
+{inject}  auto _ret = {api}({call});
 {unbox_lines}
   return _ret;
 }}"""
@@ -1267,7 +1346,7 @@ def gen_out_variant(op, fn_type, ret_type, args, func=None):
     out_name = out_names[0]
     return f"""{ret_type} {kn}({args_decl(args)}) {{
 {holder_lines}  DeviceBoxingGuard guard({guard});
-{inject}  {api}({call_args(args)});
+{inject}  {api}({call});
 {unbox_lines}
   return {out_name};
 }}"""
@@ -1507,7 +1586,6 @@ def gen_factory(op, fn_type, ret_type, args, func=None):
             # rand,randn}.h), so inject the flagos shared generator there to route
             # them through the same seedable generator FlagGems uses. randperm falls
             # out for free (its dominant randomness is an internal torch.randint).
-            _GEN_FACTORY_BASES = {"randint", "randperm", "rand", "randn"}
             if not has_gen_arg and base in _GEN_FACTORY_BASES:
                 # size is the first IntArrayRef/SymIntArrayRef positional (no self here)
                 size_name = next(

--- a/tests/integration/ops/test_rng_dispatch.py
+++ b/tests/integration/ops/test_rng_dispatch.py
@@ -12,29 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-FlagGems RNG reproducibility + distribution tests
+"""flagos unified-RNG regression coverage.
 
-Regression coverage for the unified flagos RNG mechanism (commit 20f3876):
-flaggems RNG now reads seed+offset from torch.cuda.default_generators[device]
-(a per-device philox CUDA generator installed by the vendor compat shim), and
-torch.cuda.manual_seed* is routed to those generators. This replaced the fragile
-_patch_flaggems_philox() monkeypatch, which seeded once and ignored later
-manual_seed calls.
+The contract: **one seed source reaches every RNG op on the flagos device.**
+`torch.manual_seed(s)` must make every draw reproducible regardless of which of
+the two very different paths an op takes to get its randomness:
 
-The contract verified here:
-  1. Reproducibility: same torch.manual_seed -> identical draws.
-  2. Seed actually takes effect: different seeds -> different draws.
-  3. Distributions are statistically correct (mean/variance within tolerance).
+  * FlagGems Triton path (`flagos_python` in the conf) -- reads seed+offset from
+    `torch.cuda.default_generators[device]`, a per-device philox CUDA generator
+    installed by the vendor compat shim.
+  * native CUDA path (`= cuda` in the conf) -- boxes the tensor to CUDA and calls
+    the real ATen kernel. On a CPU-torch wheel ATen's own
+    `getDefaultCUDAGenerator()` is unreachable from `torch.manual_seed` (there is
+    no `torch._C._cuda_manualSeed` binding), so the generated kernels inject that
+    same shared generator via `GetFlagosDefaultCudaGenerator()`.
 
-These only exercise the flaggems Triton RNG kernels, so they are marked
-flaggems_python and run under FLAGOS_USE_FLAGGEMS=1. Without flaggems the same
-ops route to the CUDA boxing path (native generator), which is covered
-elsewhere.
+Because both paths now converge on one generator, these tests run under *both*
+backend configs -- pure vendor (`-m main_ops`) and FlagGems
+(`FLAGOS_USE_FLAGGEMS=1 -m "flaggems and main_ops"`). That is deliberate: the
+native-path injection is only exercised by the pure-vendor run, and a config
+asymmetry in either direction is exactly the kind of regression this file exists
+to catch.
+
+Every test carries `main_ops` because CI's operator jobs select on it; a test
+without that marker never runs in CI.
 
 Usage:
-    FLAGOS_METAX_BOXING=1 FLAGOS_USE_FLAGGEMS=1 \
-        pytest tests/integration/ops/test_rng_dispatch.py -v
+    pytest tests/integration/ops/test_rng_dispatch.py -v
+    FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/ops/test_rng_dispatch.py -v
 """
 
 import os
@@ -45,85 +50,436 @@ import torch
 import torch_fl  # noqa: F401
 
 
+def _flaggems_on() -> bool:
+    """Mirrors conftest._flaggems_enabled, for the one xfail whose *expected*
+    outcome (not merely whether it runs) depends on the active backend config."""
+    return os.environ.get("FLAGOS_USE_FLAGGEMS", "0").lower() not in (
+        "0",
+        "",
+        "off",
+        "false",
+    )
+
+
 DEVICE = "flagos:0"
+SEED = 1234
+# Far enough from SEED that a collision is not plausible, but the value itself is
+# arbitrary -- any different seed must produce a different draw.
+OTHER_SEED = SEED + 977
 
-# Unlike the other flaggems_python dispatch tests (which spawn a subprocess and
-# force a single op onto the flaggems path via FLAGOS_OP_*=flaggems_python), these
-# run in-process and assert the RNG *reproducibility contract*, which only holds
-# when the ambient runtime actually routes RNG through the FlagGems Triton
-# generator (torch.cuda.default_generators seed/offset). In pure boxing mode the
-# same ops fall back to the native CUDA generator, where torch.manual_seed does
-# not take effect on the flagos device -> not reproducible. So skip unless
-# FLAGOS_USE_FLAGGEMS is actually enabled.
-pytestmark = pytest.mark.skipif(
-    os.environ.get("FLAGOS_USE_FLAGGEMS", "0").lower() in ("0", "", "off", "false"),
-    reason="RNG reproducibility contract only holds on the FlagGems Triton path "
-    "(set FLAGOS_USE_FLAGGEMS=1)",
-)
+aten = torch.ops.aten
 
 
-def _reproducible(op):
-    """Run op() twice under the same seed; return (is_reproducible, first_draw)."""
-    torch.manual_seed(1234)
-    a = op()
-    torch.manual_seed(1234)
-    b = op()
-    return torch.equal(a.cpu(), b.cpu()), a
+def _empty(n=64, dtype=torch.float32, device=DEVICE):
+    return torch.empty(n, dtype=dtype, device=device)
 
 
-_RNG_OPS = {
-    "rand": lambda: torch.rand(256, device=DEVICE),
-    "randn": lambda: torch.randn(256, device=DEVICE),
-    "uniform_": lambda: torch.empty(256, device=DEVICE).uniform_(),
-    "exponential_": lambda: torch.empty(256, device=DEVICE).exponential_(),
+def _draw(op, seed):
+    torch.manual_seed(seed)
+    return op().float().cpu()
+
+
+# --- op catalogue -----------------------------------------------------------
+#
+# Grouped by the mechanism each group stresses, because the injection bug this
+# file guards against reappeared once per codegen template: an op whose schema
+# lacks `Generator?` gets no injection and silently falls back to ATen's own
+# default generator. Factory, `*_like` and out-variant overloads each needed a
+# separate fix, so each is represented here.
+
+# Elementwise / reduction RNG that FlagGems implements in Triton (and that the
+# vendor config routes to the native kernels).
+_GEMS_PATH_OPS = {
+    "rand": lambda: torch.rand(64, device=DEVICE),
+    "randn": lambda: torch.randn(64, device=DEVICE),
+    "rand_like": lambda: torch.rand_like(_empty()),
+    "randn_like": lambda: torch.randn_like(_empty()),
+    "uniform_": lambda: _empty().uniform_(),
+    "exponential_": lambda: _empty().exponential_(),
+    "bernoulli_.float": lambda: _empty().bernoulli_(0.5),
     "multinomial": lambda: torch.multinomial(
-        torch.ones(32, device=DEVICE), 16, replacement=True
+        torch.ones(10, device=DEVICE), 5, replacement=True
     ),
+}
+
+# `Generator?`-carrying native kernels: the `if (!generator.has_value())` form.
+_NATIVE_GENERATOR_OPS = {
+    "normal_": lambda: _empty().normal_(),
+    "normal_.mean_std": lambda: _empty().normal_(2.0, 3.0),
+    "normal.float_float": lambda: torch.normal(0.0, 1.0, (64,), device=DEVICE),
+    "normal.Tensor_float": lambda: torch.normal(torch.zeros(64, device=DEVICE), 1.0),
+    "normal.Tensor_Tensor": lambda: torch.normal(
+        torch.zeros(64, device=DEVICE), torch.ones(64, device=DEVICE)
+    ),
+    "bernoulli.Tensor": lambda: torch.bernoulli(torch.full((64,), 0.5, device=DEVICE)),
+    "bernoulli_.Tensor": lambda: _empty().bernoulli_(
+        torch.full((64,), 0.5, device=DEVICE)
+    ),
+    "random_": lambda: _empty(dtype=torch.int64).random_(),
+    "random_.to": lambda: _empty(dtype=torch.int64).random_(50),
+    "random_.from": lambda: _empty(dtype=torch.int64).random_(10, 50),
+    "log_normal_": lambda: _empty().log_normal_(),
+    "cauchy_": lambda: _empty().cauchy_(),
+    "geometric_": lambda: _empty().geometric_(0.5),
+    "poisson": lambda: torch.poisson(torch.full((64,), 4.0, device=DEVICE)),
+    "_standard_gamma": lambda: torch._standard_gamma(
+        torch.full((64,), 2.0, device=DEVICE)
+    ),
+    "_sample_dirichlet": lambda: torch._sample_dirichlet(
+        torch.full((8, 4), 2.0, device=DEVICE)
+    ),
+    "binomial": lambda: torch.binomial(
+        torch.full((64,), 10.0, device=DEVICE), torch.full((64,), 0.5, device=DEVICE)
+    ),
+}
+
+# Generator-LESS factory / *_like overloads. `torch.randint(...)` and
+# `torch.randperm(...)` dispatch to these, NOT to their `.generator` siblings, so
+# they were non-reproducible until the factory and functional-pure templates
+# learned to thread the shared generator in explicitly.
+_GENERATOR_LESS_OPS = {
+    "randint": lambda: torch.randint(0, 100, (64,), device=DEVICE),
+    "randint.low": lambda: torch.randint(10, 100, (64,), device=DEVICE),
+    "randint_like": lambda: torch.randint_like(_empty(dtype=torch.int64), 0, 50),
+    "randperm": lambda: torch.randperm(50, device=DEVICE),
+}
+
+# Generator-LESS out-variants -- the last template to be fixed. ATen places the
+# injected `optional<Generator>` before the first of names/memory_format/out, so
+# a mis-ordered injection would bind the wrong overload; a silent fallback to
+# ATen's default generator shows up here as non-reproducibility.
+_OUT_VARIANT_OPS = {
+    "rand.out": lambda: torch.rand(64, out=_empty()),
+    "randn.out": lambda: torch.randn(64, out=_empty()),
+    "rand.names_out": lambda: aten.rand.names_out([64], names=None, out=_empty()),
+    "randn.names_out": lambda: aten.randn.names_out([64], names=None, out=_empty()),
+    "rand_like.out": lambda: aten.rand_like.out(_empty(), out=_empty()),
+    "randn_like.out": lambda: aten.randn_like.out(_empty(), out=_empty()),
+    "randint.out": lambda: torch.randint(0, 100, (64,), out=_empty(dtype=torch.int64)),
+    "randint.low_out": lambda: torch.randint(
+        10, 100, (64,), out=_empty(dtype=torch.int64)
+    ),
+    "randint_like.out": lambda: aten.randint_like.out(
+        _empty(dtype=torch.int64), 50, out=_empty(dtype=torch.int64)
+    ),
+    "randint_like.low_dtype_out": lambda: aten.randint_like.low_dtype_out(
+        _empty(dtype=torch.int64), 5, 50, out=_empty(dtype=torch.int64)
+    ),
+    "randperm.out": lambda: torch.randperm(50, out=_empty(50, torch.int64)),
+}
+
+_ALL_OPS = {
+    **_GEMS_PATH_OPS,
+    **_NATIVE_GENERATOR_OPS,
+    **_GENERATOR_LESS_OPS,
+    **_OUT_VARIANT_OPS,
 }
 
 
 class TestRngReproducible:
-    @pytest.mark.flaggems_python
-    @pytest.mark.parametrize("name", list(_RNG_OPS))
-    def test_same_seed_same_draw(self, name):
-        same, _ = _reproducible(_RNG_OPS[name])
-        assert same, f"{name} not reproducible under torch.manual_seed"
+    """Same seed -> identical draw, for every routed RNG op."""
 
-    @pytest.mark.flaggems_python
-    def test_different_seed_differs(self):
-        # Guards against the old bug where the seed was fixed once and ignored.
-        torch.manual_seed(1)
-        a = torch.randn(1000, device=DEVICE)
-        torch.manual_seed(2)
-        b = torch.randn(1000, device=DEVICE)
-        assert not torch.equal(a.cpu(), b.cpu())
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    @pytest.mark.parametrize("name", list(_ALL_OPS))
+    def test_same_seed_same_draw(self, name):
+        op = _ALL_OPS[name]
+        assert torch.equal(_draw(op, SEED), _draw(op, SEED)), (
+            f"{name} is not reproducible under torch.manual_seed -- it is most "
+            f"likely falling back to ATen's own default generator instead of the "
+            f"shared flagos generator"
+        )
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    @pytest.mark.parametrize("name", list(_ALL_OPS))
+    def test_different_seed_differs(self, name):
+        # Reproducibility alone is satisfied by a *constant* draw, which is how
+        # the original philox monkeypatch bug hid: it seeded once and ignored
+        # later manual_seed calls. Seed-sensitivity is what rules that out.
+        op = _ALL_OPS[name]
+        assert not torch.equal(_draw(op, SEED), _draw(op, OTHER_SEED)), (
+            f"{name} ignores the seed -- same draw for two different seeds"
+        )
+
+
+class TestRngSeedSource:
+    """The seed plumbing itself, independent of any single op."""
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_default_generators_populated(self):
+        # The whole scheme rests on this list being non-empty and philox-shaped
+        # (2 x int64 = seed, offset). A 5056-byte mt19937 state here means the
+        # shim wired up the PrivateUse1 generator by mistake, which FlagGems
+        # unpacks as "too many values to unpack".
+        gens = torch.cuda.default_generators
+        assert len(gens) > 0, "torch.cuda.default_generators is empty"
+        assert gens[0].get_state().numel() == 16, (
+            "default generator state is not philox-shaped (2 x int64)"
+        )
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_manual_seed_reaches_flagos_module(self):
+        # torch.random._seed_custom_device only seeds this device module when it
+        # exposes BOTH manual_seed_all and _is_in_bad_fork; missing either one
+        # makes torch.manual_seed warn "does not take effect" and skip it.
+        torch.manual_seed(SEED)
+        assert torch_fl.flagos.initial_seed() == SEED
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_manual_seed_emits_no_ineffective_warning(self):
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            torch.manual_seed(SEED)
+        assert not [w for w in caught if "does not take effect" in str(w.message)]
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_explicit_generator_is_honoured(self):
+        # Injection must only fill an *absent* generator. A caller-supplied one
+        # keeps its own stream, reproducible on its own terms.
+        gen = torch.Generator(device="cuda")
+        gen.manual_seed(99)
+        a = _empty().normal_(generator=gen).cpu()
+        gen.manual_seed(99)
+        b = _empty().normal_(generator=gen).cpu()
+        assert torch.equal(a, b)
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_explicit_generator_isolated_from_manual_seed(self):
+        gen = torch.Generator(device="cuda")
+        gen.manual_seed(5)
+        a = _empty().normal_(generator=gen).cpu()
+        torch.manual_seed(SEED)  # must not perturb `gen`
+        gen.manual_seed(5)
+        b = _empty().normal_(generator=gen).cpu()
+        assert torch.equal(a, b)
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_interleaved_paths_share_one_seed(self):
+        # A model mixes both paths freely (dropout next to init). One seed must
+        # drive the whole interleaved sequence, so drawing from the FlagGems path
+        # and the native path under one seed has to replay identically.
+        def mixed():
+            gems = torch.rand(32, device=DEVICE)
+            native = _empty(32).normal_()
+            return torch.cat([gems, native])
+
+        assert torch.equal(_draw(mixed, SEED), _draw(mixed, SEED))
+        assert not torch.equal(_draw(mixed, SEED), _draw(mixed, OTHER_SEED))
+
+
+class TestRngMultiDevice:
+    """Per-device generators must be independently seeded and addressed.
+
+    One rank per card is the normal distributed layout, so an RNG scheme that
+    only works on device 0 is broken in exactly the setting that matters most.
+    """
+
+    @staticmethod
+    def _second_device():
+        if torch_fl.flagos.device_count() < 2:
+            pytest.skip("needs at least 2 flagos devices")
+        return "flagos:1"
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    @pytest.mark.parametrize("name", ["randn", "normal_", "randint", "randperm"])
+    def test_reproducible_on_second_device(self, name):
+        dev = self._second_device()
+        ops = {
+            "randn": lambda: torch.randn(64, device=dev),
+            "normal_": lambda: _empty(64, device=dev).normal_(),
+            "randint": lambda: torch.randint(0, 100, (64,), device=dev),
+            "randperm": lambda: torch.randperm(50, device=dev),
+        }
+        op = ops[name]
+        assert torch.equal(_draw(op, SEED), _draw(op, SEED))
+        assert not torch.equal(_draw(op, SEED), _draw(op, OTHER_SEED))
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_each_device_has_its_own_generator(self):
+        dev = self._second_device()
+        assert len(torch.cuda.default_generators) >= 2
+        # Same seed on both devices: the draws are allowed to coincide (identical
+        # philox inputs), but the generators must be distinct objects, or seeding
+        # one device would silently reset another.
+        assert torch.cuda.default_generators[0] is not torch.cuda.default_generators[1]
+        torch.manual_seed(SEED)
+        d0 = torch.randn(64, device=DEVICE).cpu()
+        torch.manual_seed(SEED)
+        d1 = torch.randn(64, device=dev).cpu()
+        assert d0.shape == d1.shape
+
+    @pytest.mark.flaggems
+    @pytest.mark.main_ops
+    @pytest.mark.xfail(
+        reason="FlagGems multinomial launches its Triton kernel against the wrong "
+        "device for any index != 0 -- 'Pointer argument (at 0) cannot be accessed "
+        "from Triton (cpu tensor?)' on flagos:1..7, fine on flagos:0. A device-context "
+        "bug on the FlagGems Triton path rather than an RNG one: the same op on the "
+        "native path is reproducible on every device. xfail (non-strict) so the "
+        "eventual fix surfaces as an xpass instead of being silently assumed.",
+        strict=False,
+        raises=ValueError,
+    )
+    def test_multinomial_on_second_device(self):
+        dev = self._second_device()
+
+        def op():
+            return torch.multinomial(torch.ones(10, device=dev), 5, replacement=True)
+
+        assert torch.equal(_draw(op, SEED), _draw(op, SEED))
 
 
 class TestRngDistribution:
-    @pytest.mark.flaggems_python
+    """Reproducibility is worthless if the numbers are wrong.
+
+    A mis-threaded generator argument can bind a different overload and still
+    look reproducible, so pin the actual distributions. Tolerances are loose
+    enough for 100k samples at any seed.
+    """
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
     def test_rand_uniform_0_1(self):
         torch.manual_seed(42)
         r = torch.rand(100_000, device=DEVICE).cpu()
         assert abs(r.mean().item() - 0.5) < 0.02
-        assert r.min().item() >= 0.0 and r.max().item() <= 1.0
+        assert r.min().item() >= 0.0 and r.max().item() < 1.0
 
-    @pytest.mark.flaggems_python
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
     def test_randn_standard_normal(self):
         torch.manual_seed(42)
         n = torch.randn(100_000, device=DEVICE).cpu()
         assert abs(n.mean().item()) < 0.02
         assert abs(n.std().item() - 1.0) < 0.02
 
-    @pytest.mark.flaggems_python
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_normal_mean_std(self):
+        torch.manual_seed(42)
+        n = _empty(100_000).normal_(2.0, 3.0).cpu()
+        assert abs(n.mean().item() - 2.0) < 0.05
+        assert abs(n.std().item() - 3.0) < 0.05
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
     def test_exponential_rate_1(self):
         torch.manual_seed(42)
-        e = torch.empty(100_000, device=DEVICE).exponential_().cpu()
-        assert abs(e.mean().item() - 1.0) < 0.05  # Exp(1): mean 1
+        e = _empty(100_000).exponential_().cpu()
+        assert abs(e.mean().item() - 1.0) < 0.05
         assert e.min().item() >= 0.0
 
-    @pytest.mark.flaggems_python
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
     def test_uniform_range(self):
         torch.manual_seed(42)
-        u = torch.empty(100_000, device=DEVICE).uniform_(2.0, 5.0).cpu()
+        u = _empty(100_000).uniform_(2.0, 5.0).cpu()
         assert abs(u.mean().item() - 3.5) < 0.05
         assert u.min().item() >= 2.0 and u.max().item() <= 5.0
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_randint_range(self):
+        torch.manual_seed(42)
+        r = torch.randint(0, 10, (100_000,), device=DEVICE).cpu()
+        assert r.min().item() == 0 and r.max().item() == 9
+        assert abs(r.float().mean().item() - 4.5) < 0.05
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_randperm_is_a_permutation(self):
+        torch.manual_seed(42)
+        p = torch.randperm(2000, device=DEVICE).cpu()
+        assert sorted(p.tolist()) == list(range(2000))
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_poisson_mean_equals_variance(self):
+        torch.manual_seed(42)
+        p = torch.poisson(torch.full((100_000,), 4.0, device=DEVICE)).cpu()
+        assert abs(p.mean().item() - 4.0) < 0.06
+        assert abs(p.var().item() - 4.0) < 0.15  # Poisson: var == mean
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_bernoulli_probability(self):
+        torch.manual_seed(42)
+        b = _empty(100_000).bernoulli_(0.3).cpu()
+        assert set(b.unique().tolist()) <= {0.0, 1.0}
+        assert abs(b.mean().item() - 0.3) < 0.01
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_multinomial_respects_weights(self):
+        torch.manual_seed(42)
+        weights = torch.tensor([0.1, 0.9], device=DEVICE)
+        picks = torch.multinomial(weights, 20_000, replacement=True).cpu()
+        assert set(picks.unique().tolist()) <= {0, 1}
+        assert abs((picks == 1).float().mean().item() - 0.9) < 0.02
+
+
+class TestRngDropout:
+    """dropout is the RNG op models actually depend on for correctness.
+
+    It is split out because its reproducibility is config-dependent: FlagGems
+    routes `native_dropout` to its own Triton kernel (seeded from the shared
+    generator), while the vendor config calls the ATen composite, whose schema
+    exposes no `Generator?` at all -- there is no argument to inject, so the
+    randomness comes from ATen's default generator and `torch.manual_seed` cannot
+    reach it. Marked `flaggems` so it asserts the contract only where the
+    contract currently holds; see test_dropout_masks_are_valid for the part that
+    must hold everywhere.
+    """
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_dropout_masks_are_valid(self):
+        # Config-independent: scaled-or-zeroed entries, roughly the right rate.
+        torch.manual_seed(SEED)
+        out = torch.nn.functional.dropout(
+            torch.ones(100_000, device=DEVICE), p=0.5, training=True
+        ).cpu()
+        kept = out != 0
+        assert abs(kept.float().mean().item() - 0.5) < 0.01
+        # Survivors are scaled by 1/(1-p).
+        assert torch.allclose(out[kept], torch.full_like(out[kept], 2.0), atol=1e-5)
+
+    @staticmethod
+    def _dropout():
+        return torch.nn.functional.dropout(
+            torch.ones(256, device=DEVICE), p=0.5, training=True
+        )
+
+    @pytest.mark.flaggems
+    @pytest.mark.main_ops
+    def test_dropout_reproducible_on_flaggems_path(self):
+        assert torch.equal(_draw(self._dropout, SEED), _draw(self._dropout, SEED))
+        assert not torch.equal(
+            _draw(self._dropout, SEED), _draw(self._dropout, OTHER_SEED)
+        )
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    @pytest.mark.xfail(
+        condition=not _flaggems_on(),
+        reason="native_dropout has no `Generator?` in its ATen schema, so there is "
+        "no argument for the generated kernel to inject into -- the vendor path "
+        "draws from ATen's own default CUDA generator, which torch.manual_seed "
+        "cannot reach on a CPU-torch wheel. The FlagGems path routes to its own "
+        "Triton kernel and is reproducible. Non-strict xfail so closing this gap "
+        "(e.g. decomposing dropout onto bernoulli_) shows up as an xpass.",
+        strict=False,
+    )
+    def test_dropout_reproducible(self):
+        assert torch.equal(_draw(self._dropout, SEED), _draw(self._dropout, SEED))

--- a/torch_fl/flagos/__init__.py
+++ b/torch_fl/flagos/__init__.py
@@ -352,6 +352,7 @@ __all__ = [
     "manual_seed_all",  # noqa: F405
     "get_rng_state",  # noqa: F405
     "set_rng_state",  # noqa: F405
+    "_is_in_bad_fork",  # noqa: F405  (torch.random._seed_custom_device probes it)
     "get_amp_supported_dtype",
     "Stream",
     "Event",

--- a/torch_fl/flagos/random.py
+++ b/torch_fl/flagos/random.py
@@ -18,6 +18,7 @@ __all__ = [
     "manual_seed",
     "manual_seed_all",
     "initial_seed",
+    "_is_in_bad_fork",
 ]
 
 
@@ -66,3 +67,21 @@ def manual_seed_all(seed: int) -> None:
     for idx in range(device_count()):
         default_generator = _C._get_default_generator(idx)
         default_generator.manual_seed(seed)
+
+
+def _is_in_bad_fork() -> bool:
+    """Required, alongside `manual_seed_all`, by torch.random._seed_custom_device.
+
+    Without it `torch.manual_seed()` skips this device module entirely and warns
+    "Set seed for `flagos` device does not take effect" on every call -- which is
+    misleading twice over: the flagos RNG *is* seeded (the flaggems and native
+    CUDA paths both go through torch.cuda.manual_seed_all, patched by the vendor
+    shim), and the PrivateUse1 generator this module owns was simply never
+    reached. Defining it wires torch.manual_seed to that generator too, so
+    flagos.get_rng_state()/initial_seed() track the global seed.
+
+    flagos generators live in host memory and carry no fork-unsafe device
+    context (unlike CUDA's, which is why torch.cuda has a real check), so there
+    is no bad-fork state to detect.
+    """
+    return False


### PR DESCRIPTION
## Summary

The unified-RNG contract — one `torch.manual_seed` reaching every RNG op on the flagos device — had **no CI protection at all**, and two codegen templates still leaked. This closes both gaps and makes the contract permanently guarded.

## The injection gaps

Generator-less RNG overloads carry no `Generator?` in their schema, so `_generator_inject_line` never fires and they fall back to ATen's own default CUDA generator — unreachable from `torch.manual_seed` on a CPU-torch wheel (there is no `torch._C._cuda_manualSeed` binding). `torch.randint_like(...)` and every RNG out-variant dispatch to exactly such overloads.

The fix has to be made once per template because the ATen insertion point differs each time:

| template | bases | generator position | status |
|---|---|---|---|
| any with `Generator?` in schema | 80 kernels | `if (!generator.has_value())` | already landed (#39) |
| `gen_factory` | randint / randperm / rand / randn | after size/n/high, before dtype | already landed (#39) |
| `gen_functional_pure` | `*_like` (they carry `self`) | before dtype | **this PR** |
| `gen_out_variant` | both sets above | before first of names / memory_format / out | **this PR** |

The out-variant one covered 11 kernels: `rand`/`randn` `.out` and `.names_out`, `rand_like`/`randn_like` `.out`, `randint` `.out`/`.low_out`, `randint_like` `.out`/`.low_dtype_out`, `randperm` `.out`. Every base does expose an `_outf` sibling with `optional<Generator>` at that position (verified against `ATen/ops/{rand,randn,rand_like,randn_like,randint,randint_like,randperm}.h`).

The three base sets are now module-level constants, one per template, so all three positions read together instead of being scattered across the generators.

## `_is_in_bad_fork`

`torch.random._seed_custom_device` seeds a custom device only when the module exposes **both** `manual_seed_all` and `_is_in_bad_fork`. Only the former existed, so every `torch.manual_seed()` warned:

> Set seed for `flagos` device does not take effect

That was misleading twice over: the flagos RNG *is* seeded (via the patched `torch.cuda.manual_seed_all`), and the PrivateUse1 generator this module owns was simply never reached. Adding `_is_in_bad_fork() -> False` (flagos generators are host-memory, with no fork-unsafe device context) silences it and makes `flagos.initial_seed()` track the global seed.

## Tests: from zero CI coverage to 105

`tests/integration/ops/test_rng_dispatch.py` **never executed in CI**. Not a flake — a marker mismatch: every test was marked `flaggems_python` with no `main_ops`, while `.github/configs/cuda.yml` selects exactly `-m main_ops` and `-m "flaggems and main_ops"`. So the whole mechanism was landing on main unguarded.

The file also skipped itself entirely without `FLAGOS_USE_FLAGGEMS`, on the premise that the native path could not be reproducible. C++ generator injection made that premise obsolete — the vendor config now passes 34/35 reproducibility checks.

Rewritten to run under **both** configs (the native-path injection is only exercised by the vendor run, so a config asymmetry in either direction is exactly what this file should catch), covering:

- **39 ops** grouped by the mechanism each stresses — FlagGems Triton path, `Generator?`-carrying native kernels, generator-less factory/`*_like`, generator-less out-variants — each asserted both reproducible **and** seed-sensitive (reproducibility alone is satisfied by a *constant* draw, which is how the original philox monkeypatch bug hid)
- **the seed plumbing itself**: `default_generators` non-empty and philox-shaped, `torch.manual_seed` reaching the flagos module, no "does not take effect" warning, explicit `generator=` both honoured and isolated from `torch.manual_seed`, and one seed driving an interleaved FlagGems + native sequence
- **multi-device**: per-device generators are distinct objects and reproducible on device 1 (one rank per card is the normal distributed layout, so an RNG scheme that only works on device 0 is broken where it matters most)
- **distribution correctness**: a mis-threaded generator argument can bind a different overload and still look reproducible, so the actual distributions are pinned (uniform/normal/exponential/randint/randperm/poisson mean==var/bernoulli/multinomial weights/dropout mask rate + 1/(1-p) scaling)

CI now collects **105** RNG tests in the vendor job and **2** in the FlagGems job, up from 0. No workflow change was needed — the markers are the wiring.

## Two gaps injection cannot reach

Recorded as non-strict xfails rather than left implicit, so closing either surfaces as an xpass instead of being silently assumed:

1. **`native_dropout`** has no `Generator?` anywhere in its ATen schema (its only "Generator" hit is an `#include`), so there is no argument to inject into; the vendor path draws from ATen's default generator. The FlagGems path routes to its own Triton kernel and is reproducible. Config-asymmetric by construction. Contrast `_fused_dropout` / `rrelu_with_noise`, which do carry `Generator?` and are already injected.
2. **FlagGems `multinomial` on any device != 0** fails with `ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu tensor?)` — fine on `flagos:0`, fails on `flagos:1..7`. A device-context bug on the FlagGems Triton path, **not** an RNG bug: the same op on the native path is reproducible on every device. Surfaced only because RNG testing was the first thing to exercise device != 0.

## Verification (8xA100)

Both configs, `FLAGOS_USE_FLAGGEMS` on and off:

| run | result |
|---|---|
| RNG tests, vendor config | 102 passed, 2 skipped, 1 xfailed |
| RNG tests, FlagGems config | 104 passed, 1 xfailed |
| `-m main_ops` (whole ops dir) | 115 passed, 15 skipped |
| `-m "flaggems and main_ops"` | 14 passed |
| `-m flaggems_python` | 27 passed |
| native (`not flaggems*`) | 445 passed, 130 skipped, 3 xpassed |

Distributions confirmed correct (normal_ mean −0.0007 / std 1.0000; rand mean +0.5007; randint mean +4.495 over [0,9]; randperm a valid permutation; poisson(4) mean 4.000 var 4.009). The pre-existing `test_conv1d_dispatch.py::test_conv1d_with_bias` segfault is excluded — it reproduces on a clean tree.

`ruff==0.15.12`: `ruff check .` and `ruff format --check .` both pass.

Generated `cuda_kernels.cc` was regenerated with `flag_gems` importable; the diff touches only that file (`flaggems_python_kernels.cc` still reports its 319 kernels).