### PR TITLE
perf+fix: _to_copy/boxing hot-path opts + unfold view op & group-norm layout fixes

### DIFF
--- a/csrc/aten/copy_ops.cc
+++ b/csrc/aten/copy_ops.cc
@@ -10,6 +10,8 @@
 
 #include <ATen/native/Resize.h>
 #include <ATen/ops/_pin_memory.h>
+#include <ATen/ops/_to_copy.h>
+#include <ATen/ops/_to_copy_ops.h>
 #include <ATen/ops/copy_native.h>
 #include <include/flagos.h>
 #include "device_boxing.h"
@@ -295,6 +297,11 @@ at::Tensor _to_copy(
     int device_index =
         device.index() >= 0 ? device.index()
                             : (self.device().index() >= 0 ? self.device().index() : 0);
+#if defined(USE_ASCEND) || defined(USE_TSINGMICRO) || defined(USE_GCU) || \
+    defined(USE_MUSA)
+    // No CUDA runtime on these platforms: keep the explicit contiguous + memcpy
+    // path (a "CUDA" destination here is only reachable via shared-memory tricks
+    // that don't exist without cudart).
     at::Tensor self_contig = self.contiguous();
     at::Tensor temp = at::empty(
         self_contig.sizes(),
@@ -304,6 +311,25 @@ at::Tensor _to_copy(
       Memcpy(temp.data_ptr(), self_contig.data_ptr(), nbytes, MemcpyDeviceToDevice);
     }
     result = (dtype != self.scalar_type()) ? temp.to(dtype) : temp;
+#else
+    // CUDA platform fast path: flagos (PrivateUse1) and CUDA share the same GPU
+    // memory, so box self to CUDA and redispatch straight to the native CUDA
+    // _to_copy with an explicit CUDA DispatchKeySet. That skips re-entering the
+    // dispatcher from the top (no risk of routing back to PrivateUse1) and lets
+    // the native kernel read self's strides + cast dtype in one on-device pass,
+    // allocating the result directly on CUDA -- no intermediate contiguous copy
+    // or manual Memcpy. self is unboxed back to PrivateUse1 on guard teardown.
+    DeviceBoxingGuard guard(self);
+    result = at::_ops::_to_copy::redispatch(
+        c10::DispatchKeySet(c10::DispatchKey::CUDA),
+        self,
+        dtype,
+        /*layout=*/std::nullopt,
+        c10::Device(c10::kCUDA, device_index),
+        /*pin_memory=*/std::nullopt,
+        non_blocking,
+        memory_format);
+#endif
   } else if (src_is_flagos && dst_is_flagos) {
     int device_index = device.index() >= 0 ? device.index() : 0;
     at::Tensor self_contig = self.contiguous();

--- a/csrc/aten/device_boxing.h
+++ b/csrc/aten/device_boxing.h
@@ -11,18 +11,18 @@
 #include <ATen/core/Tensor.h>
 #include <c10/core/DeviceType.h>
 #include <c10/core/TensorImpl.h>
+#include <c10/util/SmallVector.h>
+
+#include <type_traits>
 
 namespace at::native::flagos {
 
 // Change a tensor's device type in-place (metadata only, no data copy).
 // Modifies dispatch key set, DataPtr device, and device_opt_.
-inline void SetTensorDevice(const at::Tensor& t, c10::DeviceType type) {
-  // Undefined tensors (e.g. an unrequested grad in a *_backward output tuple,
-  // like the bias grad of convolution_backward when output_mask[2]==false) have
-  // no TensorImpl; touching device() would dereference null -> "tensor does not
-  // have a device". Nothing to rebox, so skip.
-  if (!t.defined()) return;
-  auto* impl = t.unsafeGetTensorImpl();
+// Operates directly on a TensorImpl* so callers holding a raw impl pointer
+// (e.g. the boxing guards, which record impls to avoid refcount churn) don't
+// need to reconstruct an owning Tensor to unbox.
+inline void SetTensorImplDevice(c10::TensorImpl* impl, c10::DeviceType type) {
   auto idx = impl->device().index();
   auto new_device = c10::Device(type, idx);
   impl->_change_backend_component_keys(new_device);
@@ -38,6 +38,15 @@ inline void SetTensorDevice(const at::Tensor& t, c10::DeviceType type) {
   static_cast<TensorImplAccessor*>(impl)->set_device_opt(new_device);
 }
 
+inline void SetTensorDevice(const at::Tensor& t, c10::DeviceType type) {
+  // Undefined tensors (e.g. an unrequested grad in a *_backward output tuple,
+  // like the bias grad of convolution_backward when output_mask[2]==false) have
+  // no TensorImpl; touching device() would dereference null -> "tensor does not
+  // have a device". Nothing to rebox, so skip.
+  if (!t.defined()) return;
+  SetTensorImplDevice(t.unsafeGetTensorImpl(), type);
+}
+
 inline void BoxToCuda(const at::Tensor& t) {
   SetTensorDevice(t, c10::DeviceType::CUDA);
 }
@@ -48,28 +57,41 @@ inline void UnboxToFlagos(const at::Tensor& t) {
 
 // RAII guard: boxes flagos (PrivateUse1) tensors to CUDA, unboxes on destruction.
 // CPU/CUDA inputs are left unchanged (e.g. mul/add with a CPU scalar).
+//
+// Boxed tensors are tracked by raw TensorImpl* rather than an owning Tensor:
+// the box target always outlives the guard (callers pass named tensors, never
+// temporaries), so no ownership is needed here and we avoid an atomic
+// refcount inc/dec per boxed tensor on both box and unbox.
 class DeviceBoxingGuard {
  public:
   template <typename... Tensors>
-  explicit DeviceBoxingGuard(const Tensors&... tensors)
-      : tensors_{tensors...} {
-    for (auto& t : tensors_) {
-      if (t.defined() && t.is_privateuseone()) {
-        BoxToCuda(t);
-        boxed_.push_back(t);
-      }
-    }
+  explicit DeviceBoxingGuard(Tensors&&... tensors) {
+    // Recording raw TensorImpl* is only safe if every boxed tensor outlives
+    // the guard. Binding an rvalue (temporary) Tensor here would dangle after
+    // the full expression, so reject temporaries at compile time -- callers
+    // must pass named lvalue tensors.
+    static_assert(
+        (std::is_lvalue_reference_v<Tensors> && ...),
+        "DeviceBoxingGuard must not box temporary (rvalue) tensors: "
+        "the guard records raw TensorImpl* and does not extend lifetime");
+    (maybe_box(tensors), ...);
   }
   ~DeviceBoxingGuard() {
-    for (auto& t : boxed_) {
-      if (t.defined()) UnboxToFlagos(t);
+    for (auto* impl : boxed_) {
+      SetTensorImplDevice(impl, c10::DeviceType::PrivateUse1);
     }
   }
   DeviceBoxingGuard(const DeviceBoxingGuard&) = delete;
   DeviceBoxingGuard& operator=(const DeviceBoxingGuard&) = delete;
  private:
-  std::vector<at::Tensor> tensors_;
-  std::vector<at::Tensor> boxed_;
+  void maybe_box(const at::Tensor& t) {
+    if (t.defined() && t.is_privateuseone()) {
+      auto* impl = t.unsafeGetTensorImpl();
+      SetTensorImplDevice(impl, c10::DeviceType::CUDA);
+      boxed_.push_back(impl);
+    }
+  }
+  c10::SmallVector<c10::TensorImpl*, 4> boxed_;
 };
 
 // Box/unbox all tensors in a TensorList (for _foreach_* ops).
@@ -140,7 +162,8 @@ inline void UnboxTensorVecToFlagos(std::vector<at::Tensor>& tensors) {
 
 // RAII guard for TensorList boxing (multiple lists).
 // Only unboxes tensors that were actually boxed (originally PrivateUse1),
-// leaving genuine CUDA tensors untouched.
+// leaving genuine CUDA tensors untouched. Boxed tensors are tracked by raw
+// TensorImpl* (the list elements outlive the guard) to avoid refcount churn.
 class TensorListBoxingGuard {
  public:
   TensorListBoxingGuard() = default;
@@ -148,20 +171,21 @@ class TensorListBoxingGuard {
   void box(at::TensorList tensors) {
     for (const auto& t : tensors) {
       if (t.defined() && t.is_privateuseone()) {
-        BoxToCuda(t);
-        boxed_.push_back(t);
+        auto* impl = t.unsafeGetTensorImpl();
+        SetTensorImplDevice(impl, c10::DeviceType::CUDA);
+        boxed_.push_back(impl);
       }
     }
   }
 
   // Track a tensor that was already boxed (for ITensorListRef iteration)
   void track(const at::Tensor& t) {
-    boxed_.push_back(t);
+    if (t.defined()) boxed_.push_back(t.unsafeGetTensorImpl());
   }
 
   ~TensorListBoxingGuard() {
-    for (auto& t : boxed_) {
-      if (t.defined()) UnboxToFlagos(t);
+    for (auto* impl : boxed_) {
+      SetTensorImplDevice(impl, c10::DeviceType::PrivateUse1);
     }
   }
 
@@ -169,7 +193,7 @@ class TensorListBoxingGuard {
   TensorListBoxingGuard& operator=(const TensorListBoxingGuard&) = delete;
 
  private:
-  std::vector<at::Tensor> boxed_;
+  c10::SmallVector<c10::TensorImpl*, 4> boxed_;
 };
 
 } // namespace at::native::flagos

--- a/csrc/aten/generated/cuda_kernels.cc
+++ b/csrc/aten/generated/cuda_kernels.cc
@@ -12034,10 +12034,11 @@ at::Tensor & NativeDropoutBackwardOutKernelCuda(const at::Tensor & grad_output, 
 }
 
 ::std::tuple<at::Tensor,at::Tensor,at::Tensor> NativeGroupNormKernelCuda(const at::Tensor & input, const ::std::optional<at::Tensor> & weight, const ::std::optional<at::Tensor> & bias, int64_t N, int64_t C, int64_t HxW, int64_t group, double eps) {
+  at::Tensor input_contiguous = input.is_contiguous() ? input : input.contiguous();
   at::Tensor weight_t = weight.has_value() ? *weight : at::Tensor();
   at::Tensor bias_t = bias.has_value() ? *bias : at::Tensor();
-  DeviceBoxingGuard guard(input, weight_t, bias_t);
-  auto result = at::native_group_norm(input, weight, bias, N, C, HxW, group, eps);
+  DeviceBoxingGuard guard(input_contiguous, weight_t, bias_t);
+  auto result = at::native_group_norm(input_contiguous, weight, bias, N, C, HxW, group, eps);
   UnboxToFlagos(std::get<0>(result));
   UnboxToFlagos(std::get<1>(result));
   UnboxToFlagos(std::get<2>(result));

--- a/csrc/aten/register.cc
+++ b/csrc/aten/register.cc
@@ -139,6 +139,10 @@ at::Tensor WrapperNarrow(const at::Tensor& self, int64_t dim, int64_t start, int
   return at::native::flagos::narrow(self, dim, start, length);
 }
 
+at::Tensor WrapperUnfold(const at::Tensor& self, int64_t dimension, int64_t size, int64_t step) {
+  return at::native::flagos::unfold(self, dimension, size, step);
+}
+
 at::Tensor WrapperContiguous(
     const at::Tensor& self, at::MemoryFormat memory_format) {
   return at::native::flagos::contiguous(self, memory_format);
@@ -301,6 +305,7 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
   m.impl("view", WrapperView);
   m.impl("expand", WrapperExpand);
   m.impl("narrow", WrapperNarrow);
+  m.impl("unfold", WrapperUnfold);
   m.impl("contiguous", WrapperContiguous);
   m.impl("clone", WrapperClone);
   m.impl("_to_copy", WrapperToCopy);

--- a/csrc/aten/strided_ops.cc
+++ b/csrc/aten/strided_ops.cc
@@ -19,6 +19,7 @@
 #include <ATen/ops/detach_native.h>
 #include <ATen/ops/t_native.h>
 #include <ATen/ops/unbind_native.h>
+#include <ATen/ops/unfold_native.h>
 
 namespace at::native::flagos {
 
@@ -101,6 +102,17 @@ at::Tensor unsqueeze(const at::Tensor& self, int64_t dim) {
 
 at::Tensor unsafe_view(const at::Tensor& self, at::IntArrayRef size) {
   return at::native::_unsafe_view(self, size);
+}
+
+// unfold constructs a strided view (extracting all sliding windows of `size`
+// along `dimension` with the given `step`); it is pure metadata, no GPU kernel.
+// at::native::unfold computes the new size/stride and calls as_strided, which
+// re-dispatches to the registered flagos as_strided. Without this registration
+// PyTorch has no PrivateUse1 unfold impl, and since view ops can't fall back to
+// CPU (storage can't be shared across devices) it returns an uninitialized
+// tensor -- callers like Tensor.repeat() then read garbage (SIGSEGV downstream).
+at::Tensor unfold(const at::Tensor& self, int64_t dimension, int64_t size, int64_t step) {
+  return at::native::unfold(self, dimension, size, step);
 }
 
 at::Tensor detach(const at::Tensor& self) {

--- a/csrc/aten/strided_ops.h
+++ b/csrc/aten/strided_ops.h
@@ -54,4 +54,6 @@ at::Tensor t(const at::Tensor& self);
 
 ::std::vector<at::Tensor> unbind_int(const at::Tensor& self, int64_t dim);
 
+at::Tensor unfold(const at::Tensor& self, int64_t dimension, int64_t size, int64_t step);
+
 } // namespace at::native::flagos

--- a/scripts/codegen_ops.py
+++ b/scripts/codegen_ops.py
@@ -104,6 +104,40 @@ MANUAL_REGISTERED_OPS = {
 }
 
 
+# Some backend CUDA kernels require a plain-contiguous input even though ATen's
+# reference impl (and the native CUDA path) would silently normalize the layout
+# first. When a boxed op receives a channels-last / strided tensor, the backend
+# kernel asserts (e.g. native_group_norm: "Expected X.is_contiguous(memory_format)
+# to be true"). This map names, per op, which Tensor args must be forced to
+# contiguous layout *before* DeviceBoxingGuard runs -- boxing rewrites the tensor's
+# device metadata, so the copy has to happen while the tensor still lives on flagos.
+# is_contiguous() short-circuits to a no-op when the input is already contiguous,
+# so the only cost is on the exact non-contiguous inputs that would otherwise crash.
+_CONTIGUOUS_TENSOR_ARGS_BY_OP = {
+    "native_group_norm": ("input",),
+}
+
+
+def _contiguous_prelude(op, args):
+    """Return (prelude_lines, rename_map) for op args listed in
+    _CONTIGUOUS_TENSOR_ARGS_BY_OP. prelude_lines declares `<arg>_contiguous`
+    locals (emitted before the DeviceBoxingGuard); rename_map maps the original
+    arg name to the contiguous local so the guard and the at:: call use it."""
+    targets = _CONTIGUOUS_TENSOR_ARGS_BY_OP.get(op)
+    if not targets:
+        return "", {}
+    arg_names = {n for _, n in args}
+    lines = ""
+    rename = {}
+    for name in targets:
+        if name not in arg_names:  # guard against schema drift
+            continue
+        local = f"{name}_contiguous"
+        lines += f"  at::Tensor {local} = {name}.is_contiguous() ? {name} : {name}.contiguous();\n"
+        rename[name] = local
+    return lines, rename
+
+
 def _delegate_target_has_cuda(func, funcs, cuda_index):
     """A structured_delegate op routes its CUDA kernel through the named target
     (e.g. add.Tensor -> add.out). Return True if that target has a CUDA kernel."""
@@ -1099,7 +1133,9 @@ def args_decl(args: List[Tuple[str, str]]) -> str:
     return ", ".join(f"{t} {n}" for t, n in args)
 
 
-def call_args(args: List[Tuple[str, str]]) -> str:
+def call_args(args: List[Tuple[str, str]], rename: Dict[str, str] = None) -> str:
+    if rename:
+        return ", ".join(rename.get(n, n) for _, n in args)
     return ", ".join(n for _, n in args)
 
 
@@ -1200,8 +1236,9 @@ def gen_functional_pure(op, fn_type, ret_type, args, func=None):
     # (same pattern as gen_out_variant / gen_tuple_return).
     plain = tensor_arg_names(args)
     opt_names = optional_tensor_names(args)
+    contig_lines, rename = _contiguous_prelude(op, args)
     holder_lines = ""
-    guard_names = list(plain)
+    guard_names = [rename.get(n, n) for n in plain]
     for on in opt_names:
         holder_lines += (
             f"  at::Tensor {on}_t = {on}.has_value() ? *{on} : at::Tensor();\n"
@@ -1247,8 +1284,8 @@ def gen_functional_pure(op, fn_type, ret_type, args, func=None):
 }}"""
 
     return f"""{ret_type} {kn}({args_decl(args)}) {{
-{holder_lines}  DeviceBoxingGuard guard({guard});
-{inject}  auto result = {api}({call_args(args)});
+{contig_lines}{holder_lines}  DeviceBoxingGuard guard({guard});
+{inject}  auto result = {api}({call_args(args, rename)});
   UnboxToFlagos(result);
   return result;
 }}"""
@@ -1346,8 +1383,9 @@ def gen_out_variant(op, fn_type, ret_type, args, func=None):
     # Box plain tensor inputs + optional<Tensor> inputs (via holders).
     plain = tensor_arg_names(args)
     opt_names = optional_tensor_names(args)
+    contig_lines, rename = _contiguous_prelude(op, args)
     holder_lines = ""
-    guard_names = list(plain)
+    guard_names = [rename.get(n, n) for n in plain]
     for on in opt_names:
         holder_lines += (
             f"  at::Tensor {on}_t = {on}.has_value() ? *{on} : at::Tensor();\n"
@@ -1359,7 +1397,7 @@ def gen_out_variant(op, fn_type, ret_type, args, func=None):
 
     device_source = out_names[0] if out_names else guard_names[0]
     inject = _generator_inject_line(args, f"{device_source}.get_device()")
-    call = call_args(args)
+    call = call_args(args, rename)
 
     # Unified RNG for generator-LESS out-variants (rand.out, randint.out,
     # randint_like.out, randperm.out, ...). Same gap as the gen_factory /
@@ -1397,7 +1435,7 @@ def gen_out_variant(op, fn_type, ret_type, args, func=None):
         # (local is _ret, not result, because some ops have an out arg literally
         #  named `result`, e.g. _linalg_det.result.)
         return f"""{ret_type} {kn}({args_decl(args)}) {{
-{holder_lines}  DeviceBoxingGuard guard({guard});
+{contig_lines}{holder_lines}  DeviceBoxingGuard guard({guard});
 {inject}  auto _ret = {api}({call});
 {unbox_lines}
   return _ret;
@@ -1405,7 +1443,7 @@ def gen_out_variant(op, fn_type, ret_type, args, func=None):
     # single mutable Tensor& out.
     out_name = out_names[0]
     return f"""{ret_type} {kn}({args_decl(args)}) {{
-{holder_lines}  DeviceBoxingGuard guard({guard});
+{contig_lines}{holder_lines}  DeviceBoxingGuard guard({guard});
 {inject}  {api}({call});
 {unbox_lines}
   return {out_name};
@@ -1421,8 +1459,12 @@ def gen_tuple_return(op, fn_type, ret_type, args, func=None):
     api = f"at::{at_api_base(op)}"
     ntuple = ret_type.count(",") + 1  # ::std::tuple<a,b> -> 2
 
+    # Layout normalization (e.g. native_group_norm.input) must run BEFORE the
+    # guard so the contiguous copy happens while the tensor still lives on flagos.
+    contig_lines, rename = _contiguous_prelude(op, args)
+
     holder_lines = ""
-    guard_names = list(plain)
+    guard_names = [rename.get(n, n) for n in plain]
     for on in opt_names:
         holder_lines += (
             f"  at::Tensor {on}_t = {on}.has_value() ? *{on} : at::Tensor();\n"
@@ -1433,10 +1475,10 @@ def gen_tuple_return(op, fn_type, ret_type, args, func=None):
     unbox_lines = "\n".join(
         f"  UnboxToFlagos(std::get<{i}>(result));" for i in range(ntuple)
     )
-    inject = _generator_inject_line(args, f"{tensor_arg_names(args)[0]}.get_device()")
+    inject = _generator_inject_line(args, f"{guard_names[0]}.get_device()")
     return f"""{ret_type} {kn}({args_decl(args)}) {{
-{holder_lines}  DeviceBoxingGuard guard({guard});
-{inject}  auto result = {api}({call_args(args)});
+{contig_lines}{holder_lines}  DeviceBoxingGuard guard({guard});
+{inject}  auto result = {api}({call_args(args, rename)});
 {unbox_lines}
   return result;
 }}"""


### PR DESCRIPTION
## 概述

一组 PrivateUse1（flagos）后端改动：两项热路径性能优化 + 两项正确性修复，每项一个独立 commit。

## 性能优化

### 1. `perf(copy)`: `_to_copy` 在 CUDA/MetaX 上走直接 CUDA redispatch 快速路径
flagos(PrivateUse1) 与 CUDA 共享同一块 GPU 显存。flagos→CUDA 分支原本要分配中间 contiguous tensor + 手动 Memcpy。改为 box `self` 到 CUDA 后，用 `at::_ops::_to_copy::redispatch(DispatchKeySet(CUDA), ...)` 直接重派发到原生 CUDA kernel，一次 on-device pass 完成读 stride + dtype 转换并直接在 CUDA 上分配结果，省掉中间拷贝。仅 CUDA-runtime 平台走快速路径；USE_ASCEND / TSINGMICRO / GCU / MUSA 保持原有 contiguous + Memcpy 路径。

### 2. `perf(boxing)`: boxing guard 用裸 TensorImpl* 记录已 box 的 tensor
`DeviceBoxingGuard` / `TensorListBoxingGuard` 记录的 boxed tensor 从 `std::vector<at::Tensor>` 改为 `c10::SmallVector<c10::TensorImpl*, 4>`，消除每次 box/unbox 的 intrusive refcount 原子操作。新增 `static_assert` + 转发引用约束，在编译期拒绝对临时（rvalue）tensor 构造 guard，避免悬垂指针。unbox 直接调用 `SetTensorImplDevice`。

## 正确性修复

### 3. `fix(flagos)`: 注册 unfold 视图算子，修复 repeat 数据损坏
`Tensor.repeat()` 内部调 `aten::unfold` 构造 strided 视图再 `copy_` 进去。flagos 之前只注册了 `unfold_backward` / `unfold_copy.out`，没有注册普通的 `unfold` 视图算子。视图算子不能 fallback 到 CPU（存储无法跨设备共享），于是 PyTorch 只打个 warning 就返回一个内容未初始化的空壳 tensor，`repeat()` 读到垃圾值。GPTJ 的 rotary embedding 用 `repeat()` 生成 gather 索引，索引损坏 → 越界 gather → 非法访存崩溃。

`unfold` 是纯 stride 计算，无 GPU kernel：委托 `at::native::unfold`（计算新 size/stride 后调已注册的 `as_strided`）。通过 always-on 的 `m.impl` 直接注册，对所有后端生效。改动文件：`csrc/aten/register.cc`、`csrc/aten/strided_ops.cc`、`csrc/aten/strided_ops.h`。

### 4. `fix(flagos)`: GroupNorm 输入在 boxing 前整理为连续布局
Diffusers UNet2DModel 会给 GroupNorm 喂 channels-last (NHWC) 或 strided（strides>1）输入。后端 `native_group_norm` CUDA kernel 要求标准连续布局（`is_contiguous() == true`），原生 CUDA 路径会在调 kernel 前自动整理，但 flagos boxing wrapper 漏了这步，直接报 `Expected X.is_contiguous(memory_format) to be true`。

在 codegen 里加了通用机制 `_CONTIGUOUS_TENSOR_ARGS_BY_OP`，指定哪些算子的哪些参数需在 boxing 前整理为连续。布局整理必须在 `DeviceBoxingGuard` 之前完成（boxing 会改写 device 元数据）；`is_contiguous()` 为 true 时零开销拷贝，只在实际非连续输入才触发 `contiguous()`。目前仅应用于 `native_group_norm.input`，影响范围精确可控。改动文件：`scripts/codegen_ops.py`、`csrc/aten/generated/cuda_kernels.cc`。

## 验证

在容器 `torch-fl-zhanglh-fulltest`（MACA 3.8.1.3 + torch 2.10）以 boxing 模式（`ACCELERATOR=metax FLAGOS_METAX_BOXING=1`）完整构建通过，`import torch_fl` 冒烟通过。两处性能改动均被 `copy_ops.cc` 编译单元传递包含并编译链接成功。

两项正确性修复均在同一环境（`t210-box`）复现原始故障并验证修复：
- **unfold/repeat**：修复后 view-fallback warning 消失、`unfold`/`repeat`/2D unfold 数值正确；小 GPTJ 前向从崩溃变为跑通（cosine 1.0 vs CPU，相对误差 0.05%，纯 fp32 漂移）。
- **GroupNorm**：channels_last / strided 输入的前向 + 反向从崩溃变为数值匹配 CPU（max diff ~2e-7）；Diffusers 风格 channels_last `Conv→GroupNorm→SiLU` ResnetBlock 跑通（cosine 0.99999988）；sort/layernorm/topk（共用 codegen generator）无回归；codegen 单元检查全过（含 contiguous-before-guard 顺序不变量）。

未删除任何已有算子或接口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
