### PR TITLE
fix(flagos): run FlagGems Python ops on their operand's device

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -36,25 +36,15 @@ list(FILTER SOURCE_FILES EXCLUDE REGEX ".*/runtime/accelerator/ascend/stream_api
 if(NOT CUDA_KERNEL)
   list(FILTER SOURCE_FILES EXCLUDE REGEX ".*/aten/backends/cuda/.*")
 endif()
-if(NOT FLAGGEMS_KERNEL AND NOT FLAGGEMS_PYTHON AND NOT CUDA_KERNEL)
-  # Nothing needs python_op_caller: exclude entire flagos backend
-  # (only python_op_caller.{h,cc} lives here now). The generated
-  # flaggems_python_kernels.cc stays but is a no-op without FLAGOS_FLAGGEMS_PYTHON.
-  list(FILTER SOURCE_FILES EXCLUDE REGEX ".*/aten/backends/flagos/.*")
-  if(ACCELERATOR STREQUAL "metax" AND FLAGOS_METAX_BOXING)
-    # The MetaX vendor runtime calls this provider even when FlagGems is off.
-    list(APPEND SOURCE_FILES
-      "${CMAKE_CURRENT_SOURCE_DIR}/aten/backends/flagos/python_op_caller.cc")
-  endif()
-endif()
-# CUDA_KERNEL path: cuda_kernels.cc's native RNG kernels unconditionally call
-# GetFlagosDefaultCudaGenerator() (unified-RNG generator injection) regardless
-# of the FlagGems dispatch path, so python_op_caller.cc must stay in the build
-# whenever CUDA_KERNEL is on -- even with FLAGGEMS_KERNEL=OFF FLAGGEMS_PYTHON=OFF.
 # FLAGGEMS_PYTHON path: keep csrc/aten/backends/flagos/python_op_caller.cc and
 # build csrc/aten/generated/flaggems_python_kernels.cc with FLAGOS_FLAGGEMS_PYTHON
 # defined (below). The stale C++/python_wrapper files were removed; nothing to
 # exclude here.
+#
+# The flagos backend (python_op_caller.{h,cc}) is excluded further down, once the
+# per-accelerator rules have settled whether generated/cuda_kernels.cc is in the
+# build -- it calls GetFlagosDefaultCudaGenerator(), which python_op_caller.cc
+# defines.
 if(NOT METAX_KERNEL)
   list(FILTER SOURCE_FILES EXCLUDE REGEX ".*/aten/backends/metax/.*")
 endif()
@@ -88,6 +78,40 @@ if(ACCELERATOR STREQUAL "musa")
   # aten/backends/musa/generated/ replace them.
   list(FILTER SOURCE_FILES EXCLUDE REGEX ".*/aten/backends/cuda/.*")
   list(FILTER SOURCE_FILES EXCLUDE REGEX ".*/aten/generated/cuda_kernels\\.cc$")
+endif()
+
+# Drop the flagos backend (only python_op_caller.{h,cc} lives here) when nothing
+# left in SOURCE_FILES needs it. Three independent consumers:
+#
+#   * the FlagGems dispatch paths (FLAGGEMS_KERNEL / FLAGGEMS_PYTHON), which call
+#     into Python through it;
+#   * generated/cuda_kernels.cc, whose native RNG kernels call
+#     GetFlagosDefaultCudaGenerator() unconditionally since the unified-RNG
+#     generator injection, regardless of the FlagGems dispatch path;
+#   * the MetaX boxing build, whose vendor runtime calls the same provider even
+#     with FlagGems off.
+#
+# The second consumer is why this test runs *here* and looks at the source list
+# instead of at CUDA_KERNEL: cuda_kernels.cc is generated code under
+# aten/generated/, so the CUDA_KERNEL option does not govern it -- the gcu/musa
+# blocks above do, by accelerator. Keying on CUDA_KERNEL instead left dcu
+# (CUDA_KERNEL=OFF, both FLAGGEMS_* OFF, cuda_kernels.cc still compiled, since
+# the DTK torch wheel is hipified and registers HIP kernels under the CUDA key)
+# linking with an undefined GetFlagosDefaultCudaGenerator.
+set(_needs_python_op_caller OFF)
+if(FLAGGEMS_KERNEL OR FLAGGEMS_PYTHON)
+  set(_needs_python_op_caller ON)
+endif()
+if(ACCELERATOR STREQUAL "metax" AND FLAGOS_METAX_BOXING)
+  set(_needs_python_op_caller ON)
+endif()
+foreach(_src IN LISTS SOURCE_FILES)
+  if(_src MATCHES ".*/aten/generated/cuda_kernels\\.cc$")
+    set(_needs_python_op_caller ON)
+  endif()
+endforeach()
+if(NOT _needs_python_op_caller)
+  list(FILTER SOURCE_FILES EXCLUDE REGEX ".*/aten/backends/flagos/.*")
 endif()
 
 set(_torch_fl_sources ${SOURCE_FILES})

--- a/csrc/aten/backends/flagos/python_op_caller.cc
+++ b/csrc/aten/backends/flagos/python_op_caller.cc
@@ -84,6 +84,53 @@ c10::Device ResolveFactoryDevice(std::optional<at::Device> device) {
   return c10::Device(c10::DeviceType::PrivateUse1, c10::flagos::CurrentDevice());
 }
 
+// Resolve the device a *non-factory* Python call must run on: the device of its
+// first indexed flagos tensor operand, or nullopt to leave the current device
+// alone.
+//
+// Same hazard the factory callers guard against, reached from the other side.
+// gems allocates its own intermediates with `device=input.device` but launches
+// Triton on the *current* device, so calling an op on a tensor that lives on
+// device N while the current device is M reads and writes across devices. That
+// does not raise -- it faults the GPU (segfault / VMFault / "Invalid address
+// access"), which is how multinomial on flagos:1 died before this guard.
+//
+// Guarding here also fixes TensorToPython's CPU-scalar hop, which resolves to
+// the current device: under the guard that is now the operand's device rather
+// than whatever was current at entry.
+std::optional<c10::Device> DeviceOfTensor(const at::Tensor& t) {
+  if (t.defined() && t.device().is_privateuseone() && t.device().has_index()) {
+    return t.device();
+  }
+  return std::nullopt;
+}
+
+// Same, for the boxed-argument callers: first tensor (or first tensor in a
+// tensor list) that names a device wins. Non-tensor leading args are skipped,
+// so ops like `topk(values, k)` still resolve correctly.
+std::optional<c10::Device> DeviceOfArgs(const std::vector<c10::IValue>& args) {
+  for (const auto& arg : args) {
+    if (arg.isTensor()) {
+      if (auto dev = DeviceOfTensor(arg.toTensor())) return dev;
+    } else if (arg.isTensorList()) {
+      for (const at::Tensor& t : arg.toTensorList()) {
+        if (auto dev = DeviceOfTensor(t)) return dev;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+// Same, for the fixed-arity callers: first tensor operand naming a device wins.
+template <typename... Ts>
+std::optional<c10::Device> DeviceOfFirst(const at::Tensor& t, const Ts&... rest) {
+  if (auto dev = DeviceOfTensor(t)) return dev;
+  if constexpr (sizeof...(rest) > 0) {
+    return DeviceOfFirst(rest...);
+  }
+  return std::nullopt;
+}
+
 // Convert at::Tensor to Python THPVariable.
 // CPU scalar tensors are moved to the flagos device since FlagGems kernels
 // cannot access CPU memory.
@@ -227,6 +274,7 @@ py::tuple BuildPyArgs(const std::vector<c10::IValue>& args, const char* func_nam
 at::Tensor CallPythonOp_T(const char* func_name, const at::Tensor& self) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfFirst(self));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::object result = func(TensorToPython(self));
@@ -236,6 +284,7 @@ at::Tensor CallPythonOp_T(const char* func_name, const at::Tensor& self) {
 at::Tensor& CallPythonOp_T_inplace(const char* func_name, at::Tensor& self) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfFirst(self));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   func(TensorToPython(self));
@@ -245,6 +294,7 @@ at::Tensor& CallPythonOp_T_inplace(const char* func_name, at::Tensor& self) {
 at::Tensor CallPythonOp_TT(const char* func_name, const at::Tensor& a, const at::Tensor& b) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfFirst(a, b));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::object result = func(TensorToPython(a), TensorToPython(b));
@@ -254,6 +304,7 @@ at::Tensor CallPythonOp_TT(const char* func_name, const at::Tensor& a, const at:
 at::Tensor CallPythonOp_TTS(const char* func_name, const at::Tensor& a, const at::Tensor& b, const at::Scalar& alpha) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfFirst(a, b));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::object result = func(TensorToPython(a), TensorToPython(b), "alpha"_a = ScalarToPython(alpha));
@@ -263,6 +314,7 @@ at::Tensor CallPythonOp_TTS(const char* func_name, const at::Tensor& a, const at
 at::Tensor CallPythonOp_TS(const char* func_name, const at::Tensor& self, const at::Scalar& other) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfFirst(self));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::object result = func(TensorToPython(self), ScalarToPython(other));
@@ -272,6 +324,7 @@ at::Tensor CallPythonOp_TS(const char* func_name, const at::Tensor& self, const 
 at::Tensor CallPythonOp_TIB(const char* func_name, const at::Tensor& self, int64_t dim, bool flag) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfFirst(self));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::object result = func(TensorToPython(self), py::int_(dim), py::bool_(flag));
@@ -283,6 +336,7 @@ at::Tensor CallPythonOp_TOIB(const char* func_name, const at::Tensor& self,
                               std::optional<at::ScalarType> dtype) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfFirst(self));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::object result = func(
@@ -296,6 +350,7 @@ at::Tensor CallPythonOp_TOIB(const char* func_name, const at::Tensor& self,
 at::Tensor CallPythonOp_TTT(const char* func_name, const at::Tensor& a, const at::Tensor& b, const at::Tensor& c) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfFirst(a, b, c));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::object result = func(TensorToPython(a), TensorToPython(b), TensorToPython(c));
@@ -306,6 +361,7 @@ at::Tensor CallPythonOp_TD(const char* func_name, const at::Tensor& self,
                             std::optional<at::ScalarType> dtype) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfFirst(self));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::object result = func(TensorToPython(self), "dtype"_a = OptionalDtypeToPython(dtype));
@@ -316,6 +372,11 @@ at::Tensor CallPythonOp_ListI(const char* func_name,
                               const at::ITensorListRef& tensors, int64_t dim) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  std::optional<c10::Device> list_dev;
+  for (const auto& t : tensors) {
+    if ((list_dev = DeviceOfTensor(t))) break;
+  }
+  const c10::OptionalDeviceGuard device_guard(list_dev);
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::list py_tensors;
@@ -331,6 +392,7 @@ at::Tensor CallPythonOp_Embedding(const char* func_name, const at::Tensor& weigh
                                   bool scale_grad_by_freq, bool sparse) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfFirst(weight, indices));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::object result = func(
@@ -342,6 +404,7 @@ at::Tensor CallPythonOp_Embedding(const char* func_name, const at::Tensor& weigh
 at::Tensor CallPythonOp_Generic(const char* func_name, const std::vector<c10::IValue>& args) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfArgs(args));
 
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
@@ -376,6 +439,7 @@ at::Tensor CallPythonOp_GenericKw(const char* func_name,
                                   const std::vector<PyKwarg>& kwargs) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfArgs(args));
 
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
@@ -459,6 +523,7 @@ at::Tensor CallPythonOp_RandomInplace(const char* func_name,
                                       const std::vector<c10::IValue>& args) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfArgs(args));
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
   py::tuple py_args = BuildPyArgs(args, func_name);
@@ -475,6 +540,7 @@ std::vector<at::Tensor> CallPythonOp_GenericKwTuple(
     const std::vector<PyKwarg>& kwargs, int64_t n) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfArgs(args));
 
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);
@@ -498,6 +564,7 @@ std::vector<at::Tensor> CallPythonOp_GenericTuple(
     const char* func_name, const std::vector<c10::IValue>& args, int64_t n) {
   auto& cache = GetCache();
   cache.EnsureInitialized();
+  const c10::OptionalDeviceGuard device_guard(DeviceOfArgs(args));
 
   py::gil_scoped_acquire gil;
   auto func = cache.GetFunc(func_name);

--- a/tests/integration/test_compute_device_index.py
+++ b/tests/integration/test_compute_device_index.py
@@ -1,0 +1,223 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Multi-device compute regression: a non-factory op must run on its operand's device.
+
+Companion to test_factory_device_index.py, which covers the factory callers.
+This covers the other 16 ``CallPythonOp_*`` callers in
+csrc/aten/backends/flagos/python_op_caller.cc -- the ones that take tensors in
+rather than materializing them.
+
+Same hazard, reached from the other side: gems allocates its intermediates with
+``device=input.device`` but launches Triton on the *current* device. Call an op
+on a tensor living on device 1 while device 0 is current and the kernel reads
+and writes across devices. That does not raise -- it faults the GPU (segfault /
+KERNEL VMFault / "Invalid address access"), which is how
+``torch.multinomial(x_on_flagos_1, ...)`` died before the callers took a
+DeviceGuard.
+
+The fault is a *process kill*, not an exception, so a regression here takes the
+whole pytest process down rather than reporting a failure. That is intentional
+and still a clear signal; ``-x`` is not required to notice it.
+
+Only meaningful with 2+ devices, so it skips otherwise. Worth running both ways:
+with FLAGOS_USE_FLAGGEMS=1 for the path that broke, and unset so the boxing path
+stays covered too.
+
+Usage:
+    FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/test_compute_device_index.py -v
+"""
+
+import pytest
+import torch
+import torch_fl
+
+
+pytestmark = pytest.mark.skipif(
+    torch_fl.flagos.device_count() < 2,
+    reason="needs at least 2 flagos devices",
+)
+
+# Device 1 with device 0 current is the combination that faults: matching indices
+# would pass with or without the guard.
+DEVICE = "flagos:1"
+INDEX = 1
+
+
+@pytest.fixture(autouse=True)
+def current_device_zero():
+    """Pin the current device to 0 for every test in this file.
+
+    This is the whole point: an op on a flagos:1 tensor has to switch to device 1
+    itself. If the test ran with device 1 already current, the missing guard
+    would be invisible.
+    """
+    prev = torch_fl.flagos.current_device()
+    torch_fl.flagos.set_device(0)
+    try:
+        yield
+    finally:
+        torch_fl.flagos.set_device(prev)
+
+
+def _check(out: torch.Tensor, expected: torch.Tensor, what: str) -> None:
+    assert out.device.type == "flagos", f"{what}: got device type {out.device.type}"
+    assert out.device.index == INDEX, (
+        f"{what}: result on flagos:{out.device.index}, expected flagos:{INDEX}"
+    )
+    torch.testing.assert_close(out.cpu(), expected, rtol=1e-3, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# The op that actually crashed
+# ---------------------------------------------------------------------------
+
+
+def test_multinomial_on_nonzero_device():
+    """The original repro: segfaulted under FLAGOS_USE_FLAGGEMS=1 on flagos:1.
+
+    Routes through CallPythonOp_Generic. Uses a one-hot weight vector so the
+    result is deterministic -- a cross-device read returns whatever garbage the
+    other device's memory holds, which random sampling alone would not catch.
+    """
+    weights = torch.zeros(10, device=DEVICE)
+    weights[7] = 1.0
+    out = torch.multinomial(weights, 5, replacement=True)
+    assert out.device.index == INDEX, f"result on flagos:{out.device.index}"
+    assert out.cpu().tolist() == [7] * 5, out.cpu().tolist()
+
+
+# ---------------------------------------------------------------------------
+# One op per caller shape
+# ---------------------------------------------------------------------------
+
+
+def test_unary_op():
+    """CallPythonOp_T."""
+    cpu = torch.randn(64)
+    _check(torch.abs(cpu.to(DEVICE)), torch.abs(cpu), "abs")
+
+
+def test_unary_inplace_op():
+    """CallPythonOp_T_inplace."""
+    cpu = torch.randn(64)
+    t = cpu.to(DEVICE)
+    t.relu_()
+    _check(t, torch.relu(cpu), "relu_")
+
+
+def test_binary_tensor_op():
+    """CallPythonOp_TT."""
+    a, b = torch.randn(32, 16), torch.randn(32, 16)
+    _check(a.to(DEVICE) * b.to(DEVICE), a * b, "mul")
+
+
+def test_binary_tensor_scalar_op():
+    """CallPythonOp_TTS (add with alpha)."""
+    a, b = torch.randn(32, 16), torch.randn(32, 16)
+    out = torch.add(a.to(DEVICE), b.to(DEVICE), alpha=2.0)
+    _check(out, torch.add(a, b, alpha=2.0), "add.alpha")
+
+
+def test_tensor_scalar_op():
+    """CallPythonOp_TS."""
+    cpu = torch.randn(64)
+    _check(cpu.to(DEVICE) + 3.0, cpu + 3.0, "add.Scalar")
+
+
+def test_dim_reduction_op():
+    """CallPythonOp_TIB (dim + keepdim)."""
+    cpu = torch.randn(8, 16)
+    _check(cpu.to(DEVICE).sum(dim=1, keepdim=True), cpu.sum(dim=1, keepdim=True), "sum")
+
+
+def test_ternary_tensor_op():
+    """CallPythonOp_TTT (addmm: 3 tensor operands)."""
+    a, b, c = torch.randn(4, 4), torch.randn(4, 8), torch.randn(8, 4)
+    out = torch.addmm(a.to(DEVICE), b.to(DEVICE), c.to(DEVICE))
+    _check(out, torch.addmm(a, b, c), "addmm")
+
+
+def test_embedding_op():
+    """CallPythonOp_Embedding (weight + indices)."""
+    weight = torch.randn(20, 8)
+    idx = torch.tensor([3, 1, 4, 1, 5])
+    out = torch.nn.functional.embedding(idx.to(DEVICE), weight.to(DEVICE))
+    _check(out, torch.nn.functional.embedding(idx, weight), "embedding")
+
+
+def test_tensor_list_op():
+    """CallPythonOp_ListI (cat over a TensorList)."""
+    xs = [torch.randn(4, 6) for _ in range(3)]
+    out = torch.cat([x.to(DEVICE) for x in xs], dim=0)
+    _check(out, torch.cat(xs, dim=0), "cat")
+
+
+def test_tuple_returning_op():
+    """CallPythonOp_GenericTuple (topk returns values + indices)."""
+    cpu = torch.randn(128)
+    vals, idx = torch.topk(cpu.to(DEVICE), 5)
+    exp_vals, exp_idx = torch.topk(cpu, 5)
+    _check(vals, exp_vals, "topk.values")
+    assert idx.device.index == INDEX, f"topk.indices on flagos:{idx.device.index}"
+    assert idx.cpu().tolist() == exp_idx.tolist()
+
+
+def test_kwarg_op():
+    """CallPythonOp_GenericKw (softmax takes dim as a kwarg)."""
+    cpu = torch.randn(8, 32)
+    out = torch.softmax(cpu.to(DEVICE), dim=-1)
+    _check(out, torch.softmax(cpu, dim=-1), "softmax")
+
+
+def test_random_inplace_op():
+    """CallPythonOp_RandomInplace: writes on the operand's device, plausibly."""
+    t = torch.empty(4096, device=DEVICE)
+    t.normal_(0.0, 1.0)
+    assert t.device.index == INDEX, f"normal_ on flagos:{t.device.index}"
+    c = t.cpu()
+    assert abs(c.mean().item()) < 0.15, c.mean().item()
+    assert 0.8 < c.std().item() < 1.2, c.std().item()
+
+
+# ---------------------------------------------------------------------------
+# CPU-scalar promotion
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_scalar_operand_lands_on_operand_device():
+    """A CPU scalar operand is hopped to the device by TensorToPython.
+
+    That hop resolves to the *current* device, so without the guard it landed on
+    device 0 while the other operand sat on device 1 -- a mixed-device call into
+    gems. Under the guard the current device is the operand's, so both agree.
+    """
+    cpu = torch.randn(32)
+    out = cpu.to(DEVICE) * torch.tensor(2.0)
+    _check(out, cpu * 2.0, "mul with cpu scalar")
+
+
+# ---------------------------------------------------------------------------
+# The current device must be left as it was found
+# ---------------------------------------------------------------------------
+
+
+def test_current_device_is_restored():
+    """The guard is scoped: an op on flagos:1 must not leave 1 current."""
+    assert torch_fl.flagos.current_device() == 0
+    torch.abs(torch.randn(16, device=DEVICE))
+    assert torch_fl.flagos.current_device() == 0, (
+        "an op on flagos:1 leaked the device switch to the caller"
+    )


### PR DESCRIPTION
## Summary

Two independent multi-device bugs, both reached through `csrc/aten/backends/flagos/python_op_caller.cc`.

### 1. Missing `DeviceGuard` in the non-factory callers

#36 gave the two factory callers a `DeviceGuard`. The other 16 never got one, so the same hazard remained reachable from the other side: gems allocates its intermediates with `device=input.device` but launches Triton on the **current** device. Call an op on a tensor living on device 1 while device 0 is current and the kernel reads and writes across devices.

That does not raise — it faults the GPU (segfault / KERNEL VMFault / "Invalid address access"), so it presents as a process kill with no Python traceback. Found via:

```python
torch.multinomial(torch.ones(10, device="flagos:1"), 5, replacement=True)
```

under `FLAGOS_USE_FLAGGEMS=1`, which dies while device 0 works and while the boxing path works on both. `torch_fl.flagos.set_device(1)` makes it pass, which is the guard's effect applied by hand.

Every caller now takes a `c10::OptionalDeviceGuard` resolved from its first tensor operand that names a device (`DeviceOfTensor` / `DeviceOfArgs` / `DeviceOfFirst`). Non-tensor leading args are skipped, so `topk(values, k)` still resolves correctly. `nullopt` leaves the current device alone, so single-device callers are unaffected.

This also fixes `TensorToPython`'s CPU-scalar hop, which resolves to the current device: under the guard that is now the operand's device rather than whatever happened to be current at entry.

**Not DCU-specific** — any backend running the FlagGems Python path on more than one device hits it.

### 2. `dcu` linked with an undefined `GetFlagosDefaultCudaGenerator`

Pre-existing, and the reason the fix above could not be built and tested on dcu at all.

The flagos backend was excluded on `NOT FLAGGEMS_KERNEL AND NOT FLAGGEMS_PYTHON AND NOT CUDA_KERNEL`, but `generated/cuda_kernels.cc` is not governed by `CUDA_KERNEL` — it lives under `aten/generated/` and is dropped per-accelerator (gcu, musa) instead. Since the unified-RNG generator injection its native RNG kernels call `GetFlagosDefaultCudaGenerator()` unconditionally, which `python_op_caller.cc` defines.

| accelerator | `CUDA_KERNEL` | `FLAGGEMS_*` | `cuda_kernels.cc` | `python_op_caller.cc` | |
|---|---|---|---|---|---|
| cuda | ON | ON | built | kept | ok |
| metax / tsingmicro | OFF | PYTHON defaults ON | built | kept | ok |
| gcu | OFF | PYTHON defaults ON | excluded | kept | ok |
| musa | OFF | both OFF | excluded | excluded | ok |
| **dcu** | OFF | **both OFF** | **built** | **excluded** | **undefined symbol** |

dcu is the one combination that referenced it without defining it: `cuda_kernels.cc` still compiles because the DTK torch wheel is hipified and registers its HIP kernels under the CUDA dispatch key. musa sets the same three OFF but also drops `cuda_kernels.cc`, so it escaped.

```
ImportError: libtorch_fl.so: undefined symbol:
_ZN2at6native6flagos29GetFlagosDefaultCudaGeneratorEl
```

The exclusion now runs after the per-accelerator rules and tests the actual source list for `cuda_kernels.cc` rather than the `CUDA_KERNEL` option. Verified by configuring both ways: dcu goes BROKEN → ok, tsingmicro stays ok, gcu/musa still exclude the file.

#42's MetaX case is the same shape of exception, so it becomes a third named consumer of the rewritten condition rather than an append inside the removed block. (Its `cuda_kernels.cc` is in the source list anyway, so the check would already keep the file; the clause stays for intent.) #42's `libtorch_cuda.so` link block is untouched.

## Test plan

New `tests/integration/test_compute_device_index.py` is the non-factory companion to `test_factory_device_index.py`. It pins the current device to 0 and drives one op per caller shape on `flagos:1`, asserting **values** and not just placement — a cross-device read returns whatever the other device's memory holds, which a placement-only assertion accepts.

Confirmed the test actually bites: with the guard removed from `CallPythonOp_Generic` alone and rebuilt, the multinomial case dumps core.

Run on DCU, 8 devices:

| | |
|---|---|
| compute + factory + rng, FlagGems | 140 passed, 1 xpassed |
| compute + factory + rng, boxing | 138 passed, 2 skipped, 1 xpassed |
| ops sweep, FlagGems, per file | 455 passed, 0 failures, 0 crashes |
| conf consistency | 6 passed |
| default dcu build (`FLAGGEMS_PYTHON=OFF`) | builds, links, imports |
| ruff 0.15.12 check + format | clean |

Both new test files skip under 2 devices, so single-device CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
