### PR TITLE
fix(comm): run collectives on their operand's device

### DIFF
--- a/csrc/runtime/accelerator/cuda/device.cc
+++ b/csrc/runtime/accelerator/cuda/device.cc
@@ -15,13 +15,6 @@
 #include <include/flagos.h>
 #include <cuda_runtime.h>
 
-namespace {
-
-// Current device index (thread local for multi-threading support)
-thread_local int gCurrentDevice = 0;
-
-} // namespace
-
 Error_t GetDeviceCount(int* count) {
   if (!count) {
     return ErrorUnknown;
@@ -38,13 +31,21 @@ Error_t GetDeviceCount(int* count) {
   return Success;
 }
 
+// Ask the driver rather than caching the index ourselves. flagos aliases the
+// same physical device as torch's CUDA backend, and cudaSetDevice's current
+// device is already thread-local, so a shadow copy here can only diverge from
+// it: torch.cuda.set_device() moves the driver's index without going through
+// our SetDevice, leaving the cached value stale. Any DeviceGuard that then
+// reads the stale value as "previous" restores the process to a device that was
+// never current -- observed as a flagos allocation resetting
+// torch.cuda.current_device() back to 0.
 Error_t GetDevice(int* device) {
   if (!device) {
     return ErrorUnknown;
   }
 
-  *device = gCurrentDevice;
-  return Success;
+  cudaError_t err = cudaGetDevice(device);
+  return (err == cudaSuccess) ? Success : ErrorUnknown;
 }
 
 Error_t SetDevice(int device) {
@@ -60,7 +61,6 @@ Error_t SetDevice(int device) {
     return ErrorUnknown;
   }
 
-  gCurrentDevice = device;
   return Success;
 }
 

--- a/tests/manual/test_comm_device_index.py
+++ b/tests/manual/test_comm_device_index.py
@@ -1,0 +1,127 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collectives must run on their operand's device, not the current one.
+
+The comm-side counterpart to tests/integration/test_compute_device_index.py:
+same hazard (work enqueued on the wrong device), different layer.
+``ProcessGroupFlagOS`` hands tensors to an inner backend that resolves its
+device from whatever is *current*, so the wrapper has to pin the current device
+to the operand's before delegating.
+
+Why this needs its own test rather than being covered by
+test_flagos_dist_live.py: that test calls ``torch.cuda.set_device(rank)`` AND
+happened to leave the flagos current device where the collective needed it, so
+it passed even with the bug present. This one deliberately calls ONLY
+``torch.cuda.set_device(rank)`` -- the realistic thing for a caller to do -- and
+never touches ``torch_fl.flagos.set_device``. Allocating a ``flagos:rank``
+tensor then leaves the cuda current device back at 0, so rank 1 enqueued
+device-1 buffers onto a device-0 stream.
+
+FlagCX makes this worse than a wrong answer: ``getStreamByIndex`` lazily creates
+one stream on the current device and caches it by index alone, so the first
+collective binds the comm to that device permanently. On DTK the result was a
+GPU fault (VMFault / "invalid resource handle"), which kills the process instead
+of failing a test -- so a regression here shows up as a dead rank, not an
+assertion. That is still a clear signal.
+
+Manual rather than pytest because it needs a real multi-process world; mirrors
+test_flagos_dist_live.py's harness.
+
+Usage:
+    LD_LIBRARY_PATH=<flagcx build/lib> \
+        python tests/manual/test_comm_device_index.py --world-size 2
+"""
+
+import argparse
+import os
+
+# torch_fl MUST be imported before torch (preloads libtorch_cuda.so).
+import torch_fl  # noqa: F401
+import torch
+
+try:
+    import flagcx  # noqa: F401 -- self-registers the "flagcx" backend
+except ImportError:
+    flagcx = None
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def worker(rank: int, world_size: int):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29617")
+
+    dev = torch.device(f"flagos:{rank}")
+    # Deliberately only the cuda-side bind. Adding
+    # torch_fl.flagos.set_device(rank) here would mask the bug this test exists
+    # to catch.
+    torch.cuda.set_device(rank)
+
+    dist.init_process_group(backend="flagos", rank=rank, world_size=world_size)
+
+    inner = type(getattr(dist.distributed_c10d._get_default_group(), "_inner", None))
+    print(f"[rank {rank}] inner backend = {inner.__name__}", flush=True)
+
+    failures = []
+
+    # --- all_reduce: the collective that faulted ---
+    t = torch.ones(4, device=dev) * (rank + 1)
+    dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    expected = float(sum(range(1, world_size + 1)))
+    got = t.cpu()[0].item()
+    ok = abs(got - expected) < 1e-5
+    failures += [] if ok else [f"all_reduce got {got} want {expected}"]
+    print(
+        f"[rank {rank}] all_reduce -> {got} (expect {expected}) "
+        f"{'OK' if ok else 'FAIL'}",
+        flush=True,
+    )
+
+    # --- barrier: carries no tensor, so the wrapper must reuse the device the
+    # comm was already bound to. FlagCX rejects it otherwise with "flagcx
+    # communicator was initialized with different device".
+    dist.barrier()
+    print(f"[rank {rank}] barrier OK", flush=True)
+
+    # --- the tensor's device must survive the round trip ---
+    ok_dev = t.device.type == "flagos" and t.device.index == rank
+    failures += [] if ok_dev else [f"result on {t.device}, want flagos:{rank}"]
+    print(
+        f"[rank {rank}] result device {t.device} {'OK' if ok_dev else 'FAIL'}",
+        flush=True,
+    )
+
+    # --- and the guard must be scoped: it may not leak the switch ---
+    cur = torch.cuda.current_device()
+    print(f"[rank {rank}] cuda current after collectives = {cur}", flush=True)
+
+    if failures:
+        raise AssertionError(f"[rank {rank}] " + "; ".join(failures))
+
+    dist.destroy_process_group()
+    if rank == 0:
+        print("=== comm device-index checks passed ===", flush=True)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--world-size", type=int, default=2)
+    args = ap.parse_args()
+    if torch_fl.flagos.device_count() < args.world_size:
+        raise SystemExit(
+            f"needs {args.world_size} flagos devices, "
+            f"have {torch_fl.flagos.device_count()}"
+        )
+    mp.spawn(worker, args=(args.world_size,), nprocs=args.world_size, join=True)

--- a/torch_fl/comm/process_group.py
+++ b/torch_fl/comm/process_group.py
@@ -428,19 +428,6 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
             opts,
         )
 
-    def _allgather_base(self, output_tensor, input_tensor, opts=None):
-        # Single-tensor allgather (dist.all_gather_into_tensor). Distinct virtual
-        # from allgather(): if it is not overridden, ProcessGroup's C++ base
-        # resolves a Backend for the tensor's device and raises "No backend type
-        # associated with device type flagos". FSDP / ZeRO go through this path.
-        if opts is None:
-            opts = _c10d.AllgatherOptions()
-        return self._inner._allgather_base(
-            _to_comm(output_tensor, self._view_fn),
-            _to_comm(input_tensor, self._view_fn),
-            opts,
-        )
-
     def allgather_into_tensor_coalesced(self, output_tensors, input_tensors, opts=None):
         if opts is None:
             opts = _c10d.AllgatherOptions()
@@ -451,7 +438,11 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
         )
 
     def _allgather_base(self, output_tensor, input_tensor, opts=None):
-        # Backs the functional all_gather_into_tensor (single flat tensor in/out).
+        # Single-tensor allgather, backing the functional
+        # dist.all_gather_into_tensor. A distinct virtual from allgather(): if it
+        # is not overridden, ProcessGroup's C++ base resolves a Backend for the
+        # tensor's device and raises "No backend type associated with device type
+        # flagos". FSDP / ZeRO go through this path.
         if opts is None:
             opts = _c10d.AllgatherOptions()
         return self._inner._allgather_base(
@@ -480,18 +471,6 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
             opts,
         )
 
-    def _reduce_scatter_base(self, output_tensor, input_tensor, opts=None):
-        # Single-tensor reduce_scatter (dist.reduce_scatter_tensor); same
-        # unoverridden-virtual trap as _allgather_base above. This is the hot
-        # path for FSDP gradient reduction.
-        if opts is None:
-            opts = _c10d.ReduceScatterOptions()
-        return self._inner._reduce_scatter_base(
-            _to_comm(output_tensor, self._view_fn),
-            _to_comm(input_tensor, self._view_fn),
-            opts,
-        )
-
     def reduce_scatter_tensor_coalesced(self, output_tensors, input_tensors, opts=None):
         if opts is None:
             opts = _c10d.ReduceScatterOptions()
@@ -502,7 +481,9 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
         )
 
     def _reduce_scatter_base(self, output_tensor, input_tensor, opts=None):
-        # Backs the functional reduce_scatter_tensor (single flat tensor in/out).
+        # Single-tensor reduce_scatter, backing the functional
+        # dist.reduce_scatter_tensor; same unoverridden-virtual trap as
+        # _allgather_base above. Hot path for FSDP gradient reduction.
         if opts is None:
             opts = _c10d.ReduceScatterOptions()
         return self._inner._reduce_scatter_base(


### PR DESCRIPTION
## Summary

Fixes the device-index bug that causes collectives to enqueue device-N buffers onto a device-0 stream, resulting in VMFault on FlagCX/DCU and silent wrong results on other backends.

## Root Cause

`csrc/runtime/accelerator/cuda/device.cc` maintained a `thread_local int gCurrentDevice` shadow variable that `GetDevice` returned instead of asking the driver. Since flagos aliases the same physical GPUs as torch.cuda, and `cudaSetDevice`'s current device is already thread-local, this shadow copy could only diverge:

- `torch.cuda.set_device(1)` moves the driver's index without going through our `SetDevice`, leaving the shadow at 0
- Any `DeviceGuard` then reads the stale 0 as "previous" and restores the process to a device that was never current
- Observed symptom: allocating a `flagos:1` tensor resets `torch.cuda.current_device()` back to 0

`ProcessGroupFlagOS` delegates to an inner backend (FlagCX or RCCL) that resolves its device from whatever is current, so rank 1's device-1 collective gets enqueued on the device-0 stream FlagCX cached. On DCU this triggers VMFault; on other hardware it silently computes wrong results or hangs.

## Changes

1. **C++ fix (device.cc)**: Delete the shadow variable; make `GetDevice` call `cudaGetDevice` directly
2. **Dedup (process_group.py)**: Remove duplicate `_allgather_base` and `_reduce_scatter_base` definitions that were silently shadowing each other
3. **Regression test**: `tests/manual/test_comm_device_index.py` deliberately calls only `torch.cuda.set_device(rank)` to catch this class of bug

## Verification

- **FlagCX path** (the one that VMFaulted): 2/4 cards, `test_comm_device_index.py` + `test_flagos_dist_live.py` (20/20 collectives + DDP), all pass
- **RCCL path**: 4 cards, 20/20 collectives, exit 0 (confirms no regression)
- **Compute side**: `test_compute_device_index.py` 15 passed (this fix also resolves the twin bug that PR #54 patched in Python)

## Impact

This also fixes the device-index hazard that #54 addressed on the compute side (`CallPythonOp_*`). Both were symptoms of the same C++ accounting bug.
