### PR TITLE
docs(tests): replace machine-local HF_HOME paths with a placeholder

### DIFF
--- a/tests/integration/test_profiler_qwen3_infer.py
+++ b/tests/integration/test_profiler_qwen3_infer.py
@@ -39,9 +39,9 @@ def model_and_tokenizer(request):
     """Load Qwen3 model once for all tests.
 
     Uses the shared --model option (default Qwen/Qwen3-0.6B) like the other
-    integration tests, so a local path can be supplied. The host has no network
-    access, so this requires the offline HF env vars, e.g.:
-        HF_HOME=/nfs/lvyufeng/hf_cache HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+    integration tests, so a local path can be supplied. On a host without
+    network access, point HF at a pre-populated cache and run offline:
+        HF_HOME=<your-hf-cache-dir> HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
     """
     from transformers import AutoModelForCausalLM, AutoTokenizer
 

--- a/tests/manual/test_qwen3_ddp_live.py
+++ b/tests/manual/test_qwen3_ddp_live.py
@@ -25,11 +25,11 @@ training steps. Verifies that:
      (i.e. the ProcessGroupFlagOS all_reduce actually synchronised them).
   4. Loss decreases / stays finite over a handful of steps.
 
-Requires:
-    HF_HOME=/nfs/lvyufeng/hf_cache HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+Requires (point HF_HOME at a pre-populated cache to run without network):
+    HF_HOME=<your-hf-cache-dir> HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
 
 Run:
-    HF_HOME=/nfs/lvyufeng/hf_cache HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+    HF_HOME=<your-hf-cache-dir> HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
         python tests/manual/test_qwen3_ddp_live.py --world-size 2
 """
 


### PR DESCRIPTION
Two test docstrings instructed the reader to run with `HF_HOME=/nfs/lvyufeng/hf_cache`, a
path that exists only on one host. For anyone else that makes the documented invocation a
dead end.

- `tests/integration/test_profiler_qwen3_infer.py` (landed in #55)
- `tests/manual/test_qwen3_ddp_live.py` (pre-existing; same one-line pattern, fixed together)

Both now use `<your-hf-cache-dir>` and state what it should point at.

Docstrings only — no executable lines touched. Verified: both files still parse (`ast.parse`),
`ruff check` and `ruff format --check` clean, and a repo-wide sweep for
`/nfs/`, `/root/`, `/home/<user>` over tracked non-plan files now returns nothing.