### PR TITLE
fix(gcu): make nn.Linear work on non-contiguous activations

### DIFF
--- a/tests/integration/ops/test_linear_backward_dispatch.py
+++ b/tests/integration/ops/test_linear_backward_dispatch.py
@@ -1,0 +1,137 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+linear_backward dispatch tests
+
+nn.Linear on a >2-D input is the shape every transformer training step takes,
+and it reaches a different code path than a 2-D one: autograd hands
+linear_backward a grad_output that is routinely non-contiguous, which the
+FlagGems op flattens with `.view(...).contiguous()` -- in that order, so the
+view runs on the original layout and raises "view size is not compatible with
+input tensor's size and stride". A 2-D check never sees it, so the ranks are
+covered explicitly here.
+
+Usage:
+    pytest tests/integration/ops/test_linear_backward_dispatch.py -v
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+import torch_fl  # noqa: F401
+
+
+DEVICE = "flagos:0"
+
+# 2-D is the shape that already worked; 3-D is the transformer case that did
+# not; 4-D confirms the flattening generalises past one batch dimension.
+SHAPES = [(32, 64), (2, 16, 64), (2, 4, 8, 64)]
+
+
+def _grads_for(shape, device):
+    """Run one Linear forward+backward, returning (grad_in, grad_w, grad_b)."""
+    torch.manual_seed(42)
+    layer = nn.Linear(64, 128)
+    layer = layer.to(device)
+    x = torch.randn(*shape, device=device, requires_grad=True)
+    layer(x).sum().backward()
+    if device != "cpu":
+        torch_fl.flagos.synchronize()
+    return x.grad, layer.weight.grad, layer.bias.grad
+
+
+@pytest.mark.parametrize("shape", SHAPES, ids=lambda s: "x".join(map(str, s)))
+def test_linear_backward_matches_cpu(shape):
+    """Gradients through nn.Linear match CPU autograd at every rank."""
+    dev_in, dev_w, dev_b = _grads_for(shape, DEVICE)
+    cpu_in, cpu_w, cpu_b = _grads_for(shape, "cpu")
+
+    # grad_weight/grad_bias accumulate over the flattened batch, so they carry
+    # more summation error than grad_input and get a looser tolerance.
+    assert torch.allclose(dev_in.cpu(), cpu_in, atol=1e-3), "grad_input mismatch"
+    assert torch.allclose(dev_w.cpu(), cpu_w, atol=1e-2), "grad_weight mismatch"
+    assert torch.allclose(dev_b.cpu(), cpu_b, atol=1e-2), "grad_bias mismatch"
+
+
+def test_linear_forward_non_contiguous_input():
+    """A transposed activation makes the *forward* input non-contiguous.
+
+    This is the layout autograd produces inside an attention block, and the one
+    that made the vendor forward's ``input.view(M, K)`` raise.
+    """
+    layer = nn.Linear(64, 64).to(DEVICE)
+    x = torch.randn(2, 64, 16, device=DEVICE, requires_grad=True)
+    out = layer(x.transpose(1, 2))
+    out.transpose(1, 2).sum().backward()
+    torch_fl.flagos.synchronize()
+
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+    assert torch.isfinite(layer.weight.grad).all()
+
+
+def test_linear_backward_non_contiguous_grad_output():
+    """A transposed *output* makes grad_output non-contiguous.
+
+    Distinct from the forward case above: here the input is contiguous and it
+    is the incoming gradient that is strided, which is what reaches
+    linear_backward's own flattening. A plain ``.sum().backward()`` produces a
+    contiguous gradient and does not exercise this.
+    """
+    layer = nn.Linear(64, 128).to(DEVICE)
+    x = torch.randn(2, 16, 64, device=DEVICE, requires_grad=True)
+    (layer(x).transpose(0, 1) * 2).sum().backward()
+    torch_fl.flagos.synchronize()
+
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+    assert torch.isfinite(layer.weight.grad).all()
+
+    # Same computation on CPU, to check the contiguous copy did not reorder.
+    torch.manual_seed(0)
+    cpu_layer = nn.Linear(64, 128)
+    cpu_layer.load_state_dict({k: v.cpu() for k, v in layer.state_dict().items()})
+    xc = x.detach().cpu().requires_grad_(True)
+    (cpu_layer(xc).transpose(0, 1) * 2).sum().backward()
+    assert torch.allclose(x.grad.cpu(), xc.grad, atol=1e-3)
+
+
+def test_transformer_block_trains():
+    """A minimal attention+MLP step, i.e. the case that regressed.
+
+    Guards the whole path rather than the single op: every Linear here is 3-D,
+    so a flattening bug in linear_backward takes the step down.
+    """
+    torch.manual_seed(0)
+    dim = 64
+    qkv = nn.Linear(dim, 3 * dim).to(DEVICE)
+    proj = nn.Linear(dim, dim).to(DEVICE)
+    norm = nn.LayerNorm(dim).to(DEVICE)
+    opt = torch.optim.AdamW(
+        list(qkv.parameters()) + list(proj.parameters()) + list(norm.parameters()),
+        lr=1e-3,
+    )
+
+    x = torch.randn(2, 16, dim, device=DEVICE)
+    q, k, v = qkv(norm(x)).chunk(3, dim=-1)
+    attn = torch.softmax(q @ k.transpose(-2, -1) / dim**0.5, dim=-1)
+    loss = proj(attn @ v).sum()
+    loss.backward()
+    opt.step()
+    torch_fl.flagos.synchronize()
+
+    assert torch.isfinite(loss), "loss went non-finite"
+    assert torch.isfinite(qkv.weight.grad).all(), "qkv grad non-finite"
+    assert torch.isfinite(proj.weight.grad).all(), "proj grad non-finite"

--- a/torch_fl/__init__.py
+++ b/torch_fl/__init__.py
@@ -1195,9 +1195,14 @@ def _register_flaggems_operators():
                 bind_vendor_ops_in_generic_modules,
                 device_guarded_config,
                 patch_flaggems_device_name,
+                patch_linear_contiguity,
             )
 
             patch_flaggems_device_name()
+            # Order-independent: this wraps the `linear`/`linear_backward`
+            # module functions, while the rebinding below swaps the `mm` those
+            # originals resolve as a module global at call time.
+            patch_linear_contiguity(flag_gems)
             bind_vendor_ops_in_generic_modules(flag_gems)
             excluded = _flaggems_exclusion_names(
                 flag_gems, _EXCLUDED_OPS | _GCU_EXCLUDED_OPS

--- a/torch_fl/accelerator/gcu/_gcu_compat.py
+++ b/torch_fl/accelerator/gcu/_gcu_compat.py
@@ -475,6 +475,99 @@ def device_guarded_config(flag_gems):
     )
 
 
+def patch_linear_contiguity(flag_gems) -> int:
+    """Make the ``linear`` ops accept non-contiguous activations.
+
+    Both halves of ``nn.Linear`` flatten their batch dimensions with a bare
+    ``view``: the vendor's forward does ``input.view(M, K)``
+    (``_enflame/gcu300/ops/linear.py:158``) and the generic backward does
+    ``.view(batch_size, n).contiguous()`` -- in that order, so the ``view`` runs
+    on the original layout either way. ``view`` requires a layout it can
+    reinterpret without copying, and a transposed or otherwise strided
+    activation has none, so it raises "view size is not compatible with input
+    tensor's size and stride".
+
+    Any ``nn.Linear`` on a >2-D input hits this, i.e. every transformer training
+    step, while the same layer on 2-D input works -- which is why a plain
+    ``torch.mm`` or 2-D ``Linear`` check does not catch it.
+
+    Making the operands contiguous first is behaviour-preserving: both functions
+    only use the flattened tensors as ``mm`` operands, and the backward already
+    asked for ``.contiguous()`` right after its view. ``.contiguous()`` is a
+    no-op when the layout already permits the view, so the previously-working
+    2-D path is unaffected. Verified against CPU autograd at ranks 2, 3 and 4.
+
+    These are defects in FlagGems rather than anything GCU-specific, but they
+    are patched here because GCU is where they are reachable: the C++ FlagGems
+    path never routes through these Python functions.
+
+    Returns the number of functions wrapped.
+    """
+    import sys
+
+    import torch
+
+    def _wrap(module_name, func_name, arg_count):
+        """Wrap module.func so its first ``arg_count`` tensor args are contiguous."""
+        module = sys.modules.get(module_name)
+        if module is None:
+            return False
+        original = getattr(module, func_name, None)
+        if original is None or getattr(original, "_flagos_contiguous", False):
+            return False
+
+        @functools.wraps(original)
+        def wrapper(*args, **kwargs):
+            args = list(args)
+            for i in range(min(arg_count, len(args))):
+                value = args[i]
+                if isinstance(value, torch.Tensor) and not value.is_contiguous():
+                    args[i] = value.contiguous()
+            return original(*args, **kwargs)
+
+        wrapper._flagos_contiguous = True
+        setattr(module, func_name, wrapper)
+
+        # _FULL_CONFIG holds the function by value, so rebind it there too.
+        config = getattr(flag_gems, "_FULL_CONFIG", None)
+        if config:
+            flag_gems._FULL_CONFIG = tuple(
+                (entry[0], wrapper) + tuple(entry[2:])
+                if len(entry) > 1 and entry[1] is original
+                else entry
+                for entry in config
+            )
+        return True
+
+    # linear(input, weight, bias) -- only `input` carries a batch layout.
+    # linear_backward(grad_output, input, weight, output_mask) -- both of the
+    # first two are flattened.
+    #
+    # Which module implements each is read off _FULL_CONFIG rather than
+    # hardcoded: the vendor override is imported under a bare arch-prefixed
+    # name ("gcu300.ops.linear"), so the arch would otherwise have to be
+    # guessed, and whether an op is overridden at all differs per release.
+    targets = {"linear": 1, "linear_backward": 2}
+    # Collected before wrapping: _wrap rebuilds _FULL_CONFIG, so iterating it
+    # while wrapping would read entries that are already stale.
+    plan = []
+    for entry in getattr(flag_gems, "_FULL_CONFIG", ()):
+        if len(entry) < 2:
+            continue
+        arg_count = targets.get(entry[0])
+        if arg_count is None:
+            continue
+        module_name = getattr(entry[1], "__module__", None)
+        func_name = getattr(entry[1], "__name__", None)
+        if module_name and func_name:
+            plan.append((module_name, func_name, arg_count))
+
+    wrapped = 0
+    for module_name, func_name, arg_count in plan:
+        wrapped += _wrap(module_name, func_name, arg_count)
+    return wrapped
+
+
 def bind_vendor_ops_in_generic_modules(flag_gems) -> int:
     """Make generic FlagGems ops call the vendor kernel for their sub-ops.
 


### PR DESCRIPTION
## Summary

`nn.Linear` fails on a non-contiguous activation, which in practice means every
transformer training step. Follow-up to #65, which is what made this path
reachable on GCU.

Both halves flatten their batch dimensions with a bare `view`:

```
_enflame/gcu300/ops/linear.py:158   input.view(M, K)
flag_gems/ops/linear_backward.py:73-74
                                    input.view(batch_size, in_features).contiguous()
                                    grad_output.view(batch_size, out_features).contiguous()
```

The backward one has `.contiguous()` in the wrong place — after the view, so the
view still runs on the original layout. `view` needs a layout it can reinterpret
without copying, and a transposed or otherwise strided tensor has none:

```
RuntimeError: view size is not compatible with input tensor's size and stride
(at least one dimension spans across two contiguous subspaces). Use .reshape(...)
```

Attention transposes both on the way in (`q/k/v` reshape) and on the way out, so
both the forward's input and the backward's `grad_output` arrive strided.

## Why #65 missed it

The multi-device verification there used a direct `torch.mm` and a 2-D
`nn.Linear`, both of which are contiguous and both of which work. The failure
needs a >2-D input *and* a strided layout, so nothing in the suite reached it.

## Fix

`patch_linear_contiguity()` makes the flattened operands contiguous before the
view. Behaviour-preserving: both functions only use them as `mm` operands, and
the backward already wanted `.contiguous()` one line later. `.contiguous()` is a
no-op when the layout already permits the view, so the 2-D path is untouched.

The implementing module for each op is read off `_FULL_CONFIG` rather than
hardcoded — the vendor override is imported under a bare arch-prefixed name
(`gcu300.ops.linear`), so the arch would otherwise have to be guessed, and
whether an op is overridden at all differs per FlagGems release.

These are FlagGems defects rather than anything GCU-specific, but they are
patched here because GCU is where they are reachable: the C++ FlagGems path
never routes through these Python functions. Worth reporting upstream
separately; the same `view`-before-`contiguous` pattern appears in 41 places
across FlagGems 5.3.2, though only these two are on a reachable path here.

## Test plan

`tests/integration/ops/test_linear_backward_dispatch.py`, 6 cases. The two
non-contiguous ones are deliberately separate: a transposed *input* hits the
forward's view, a transposed *output* hits the backward's, and a plain
`.sum().backward()` produces a contiguous gradient that exercises neither.

Verified by A/B rather than by assertion:

| | forward case | backward case | total |
|---|---|---|---|
| patch disabled | FAIL | FAIL | 2 failed, 4 passed |
| patch enabled | pass | pass | **6 passed** |

- Gradients match CPU autograd at ranks 2, 3 and 4 (`atol=1e-3` on `grad_input`,
  `1e-2` on the accumulated `grad_weight`/`grad_bias`).
- The transformer training loop that regressed now completes: 27 ops on device,
  0 CPU fallbacks.
- Multi-device: 3-D backward on `flagos:0` and `flagos:1`, no Sip error.
- Full suite: **728 passed, 26 failed, 293 skipped, 11 errors** — the failure set
  is unchanged from before the fix (profiler/CUPTI, inductor, conv, RNG,
  `transformers`); the +6 are the new tests.
- Lint clean with the pinned `ruff==0.15.12`.

Run with `--ignore=tests/manual/metax`: `test_qwen3_fsdp2_metax.py` calls
`argparse.parse_args()` at module scope and aborts collection for the whole
suite. Unrelated to this change.
