### PR TITLE
feat(bpu): ResNet-18 at 1.36 ms and Qwen3 at 82 tok/s, both near the vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,9 +656,19 @@ out = compiled(torch.randn(1, 3, 224, 224))
   `PrivateUse1` to `convolution_overrideable`, whose only other kernel raises,
   so the boxed fallback cannot reach a CPU implementation. Two wrappers in
   `register.cc` call `at::convolution` on CPU tensors instead.
-- Measured on-board (torch 2.10): a 6-layer conv stack at 224x224 runs **3.75 ms
-  on the BPU vs 72.06 ms eager CPU — 19.2x**. Toy nets are a wash — submission
-  overhead dominates.
+- Measured on-board (torch 2.10): **ResNet-18 at 224x224 runs 1.356 ms on the
+  BPU vs 26.10 ms eager CPU — 19.2x**, which is 1.26x off D-Robotics' own
+  `resnet18_224x224_nv12.hbm` (1.075 ms) despite taking an 8x larger float32
+  input. Accuracy: cosine 0.990 vs eager, top-1 agreement 5/5. Run
+  `benchmarks/bpu_resnet18_bench.py`. Toy nets are a wash — submission overhead
+  dominates.
+- **LLM inference has its own runtime path.** `hbm_runtime` copies every input
+  per call, which for a decode step means copying the KV cache — 336 MiB per
+  token, 68.4 ms against the vendor's 11.4. `infer.py` binds `hbDNNInferV2`
+  directly with device-resident buffers and a sliding-window cache, reaching
+  **82.1 tok/s decode on Qwen3-0.6B against the vendor `llm` demo's 84.8–87.7**
+  on the same artifact. Run `benchmarks/bpu_qwen3_bench.py`. This drives a
+  prebuilt vendor `.hbm`, not a `torch.compile` graph.
 
 ### Build Environment Variables
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,5 +1,47 @@
 # Benchmarks
 
+## BPU Qwen3-0.6B vs the vendor `llm` demo
+
+`bpu_qwen3_bench.py` runs D-Robotics' own two-graph Qwen3-0.6B `.hbm` through
+`torch_fl.accelerator.bpu.infer`, so the comparison isolates the runtime: same
+artifact, same four cores, same weights, only a different caller.
+
+```bash
+python benchmarks/bpu_qwen3_bench.py \
+    --hbm ~/llm_sdk/.../Qwen3-0.6B_language_chunk_512_cache_4096_w8_nash-p_corenum_4_4.hbm \
+    --tokenizer ~/llm_sdk/.../configs/Qwen3_config
+```
+
+**82.1 tok/s decode against the vendor demo's 84.8–87.7**, and 6881 tok/s
+prefill against 5626–7014. The vendor number comes from its own demo, which
+prints it: `cd oellm_runtime/examples/llm_demo && ./llm -c qwen3_0.6b_config.json`.
+
+Prefill is quoted per 512-token chunk, which is what the graph computes
+regardless of prompt length — a 17-token prompt reads as 219 tok/s for the same
+78 ms of work. Details and the KV cache layout in
+[docs/bpu.md](../docs/bpu.md#qwen3-06b-against-the-vendor-llm-demo).
+
+## BPU ResNet-18 vs the vendor artifact
+
+`bpu_resnet18_bench.py` compares three paths for ResNet-18 at 224x224 on an RDK
+board: D-Robotics' own `resnet18_224x224_nv12.hbm`, eager CPU, and our
+`torch.compile(backend="bpu")`.
+
+```bash
+export FLAGOS_BPU_X86_PYTHON=~/hbdk4-x86/python/bin/python3.11
+export FLAGOS_BPU_X86_EMULATOR=~/hbdk4-x86/bin/box64
+python benchmarks/bpu_resnet18_bench.py
+```
+
+The first run compiles under box64 (~25 min); afterwards the `.hbm` is cached in
+`~/.cache/torch_fl_bpu` and startup is seconds.
+
+The vendor artifact is the honest upper bound for this board — eager CPU only
+proves the offload happened. The two are not the same workload, and the script
+says so: the official one takes NV12 (74 KB) where ours takes float32 NCHW
+(588 KB), and it was quantized by HMCT with real calibration data. Numbers and
+analysis in [docs/bpu.md](../docs/bpu.md#measured-performance).
+
 ## FlagGems dispatch-overhead microbenchmark
 
 Compares the **host-side dispatch cost** of three paths for the same op on the

--- a/benchmarks/bpu_qwen3_bench.py
+++ b/benchmarks/bpu_qwen3_bench.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""End-to-end Qwen3 generation on the BPU, against the vendor `llm` demo.
+
+Drives the vendor's own two-graph .hbm (`prefill` + `decode`) through
+torch_fl's `infer.Package`, so the comparison isolates the runtime: same
+artifact, same four BPU cores, same weights. What differs is only who submits
+the work.
+
+    python benchmarks/bpu_qwen3_bench.py \
+        --hbm ~/llm_sdk/.../Qwen3-0.6B_language_chunk_512_cache_4096_w8_nash-p_corenum_4_4.hbm \
+        --tokenizer ~/llm_sdk/.../configs/Qwen3_config
+
+The vendor number to beat comes from its own demo, which prints it directly:
+
+    cd oellm_runtime/examples/llm_demo && ./llm -c qwen3_0.6b_config.json
+    [Performance] prefill TPS: 5626 tokens/s  decode TPS: 84.8 tokens/s
+
+The KV cache is a sliding window over one allocation per layer, which is what
+the vendor runtime does and the only layout that produces correct text -- see
+`KVWindow` for why appending into the cache does not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from torch_fl.accelerator.bpu.infer import KVWindow, Package  # noqa: E402
+
+# Additive mask: 0 attends, -65504 (f16 min) blocks.
+BLOCK = np.float16(-65504.0)
+OPEN = np.float16(0.0)
+
+
+class Qwen3BPU:
+    """Prefill/decode driver over one multi-model .hbm.
+
+    Both graphs share a single `KVWindow`, so a prefill step needs no
+    publishing into the decode graph -- there is only one cache.
+    """
+
+    def __init__(self, hbm: str, cores=(0, 1, 2, 3), max_tokens: int = 1024):
+        self.pkg = Package(hbm)
+        for need in ("prefill", "decode"):
+            if need not in self.pkg.model_names:
+                raise SystemExit(
+                    f"{hbm} has models {self.pkg.model_names}, expected a "
+                    f"'{need}' graph -- this is not an LLM artifact"
+                )
+        self.decode = self.pkg.model("decode", cores)
+        self.prefill = self.pkg.model("prefill", cores)
+
+        self.layers = sum(
+            1 for n in self.decode.input_names if n.endswith("_cache_key")
+        )
+        self.chunk = self.prefill.inputs["input_ids"].shape[1]
+        self.context = self.decode.inputs["attention_mask"].shape[-1]
+        # A prefill pass writes `chunk` slots past the window, so the room
+        # beyond it has to cover the widest single step, not just the tokens.
+        self.kv = KVWindow(
+            (self.decode, self.prefill),
+            self.layers,
+            self.context,
+            max_tokens + self.chunk,
+        )
+
+    def reset(self) -> None:
+        self.kv.reset()
+
+    def run_prefill(self, ids: list[int]) -> int:
+        """Consume `ids` in chunk-sized passes; returns the first sampled token."""
+        tok = 0
+        m = self.prefill
+        for start in range(0, len(ids), self.chunk):
+            piece = ids[start : start + self.chunk]
+            n = len(piece)
+            self.kv.bind(m, self.chunk)
+            m.inputs["input_ids"][:] = 0
+            m.inputs["input_ids"][0, :n] = piece
+            m.inputs["position_ids"][0, :] = np.arange(
+                self.kv.pos, self.kv.pos + self.chunk, dtype=np.int32
+            )
+            mask = m.inputs["attention_mask"]
+            mask[:] = BLOCK
+            for r in range(n):
+                lo, hi = self.kv.mask_range(self.chunk, r)
+                mask[0, r, lo:hi] = OPEN
+            m.flush_inputs(["input_ids", "position_ids", "attention_mask"])
+            m.infer()
+            m.invalidate_outputs()
+            tok = int(np.argmax(m.outputs["logits"][0, n - 1]))
+            # Advance by the real tokens, not the padded chunk: the device
+            # wrote `chunk` slots but only the first `n` mean anything, and
+            # sliding by `n` leaves the rest beyond the next window's edge.
+            self.kv.advance(n)
+        return tok
+
+    def step(self, tok: int) -> int:
+        """One decode step at the current position."""
+        m = self.decode
+        self.kv.bind(m, 1)
+        m.inputs["input_ids"][:] = tok
+        m.inputs["position_ids"][:] = self.kv.pos
+        mask = m.inputs["attention_mask"]
+        mask[:] = BLOCK
+        lo, hi = self.kv.mask_range(1)
+        mask[0, 0, lo:hi] = OPEN
+        m.flush_inputs(["input_ids", "position_ids", "attention_mask"])
+        m.infer()
+        m.invalidate_outputs()
+        self.kv.advance(1)
+        return int(np.argmax(m.outputs["logits"][0, 0]))
+
+    def free(self) -> None:
+        self.kv.free()
+        self.decode.free()
+        self.prefill.free()
+        self.pkg.release()
+
+
+def load_tokenizer(path: Path):
+    from tokenizers import Tokenizer
+
+    tk = Tokenizer.from_file(str(path / "tokenizer.json"))
+    cfg = json.loads((path / "generation_config.json").read_text())
+    eos = cfg.get("eos_token_id")
+    eos = set(eos) if isinstance(eos, list) else {eos} if eos is not None else set()
+    return tk, eos
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--hbm", required=True)
+    ap.add_argument("--tokenizer", required=True)
+    ap.add_argument("--prompt", default="用一句话介绍杭州西湖。")
+    ap.add_argument("--max-new", type=int, default=64)
+    ap.add_argument("--cores", default="0,1,2,3")
+    args = ap.parse_args()
+
+    cores = tuple(int(c) for c in args.cores.split(","))
+    tk, eos_ids = load_tokenizer(Path(args.tokenizer).expanduser())
+
+    t0 = time.perf_counter()
+    model = Qwen3BPU(
+        str(Path(args.hbm).expanduser()), cores, max_tokens=args.max_new + 64
+    )
+    load_s = time.perf_counter() - t0
+    print(
+        f"loaded in {load_s:.2f}s: {model.pkg.model_names}, "
+        f"{model.layers} layers, chunk {model.chunk}, context {model.context}"
+    )
+
+    # Qwen3 chat template, thinking disabled to keep the run short.
+    text = (
+        f"<|im_start|>user\n{args.prompt}<|im_end|>\n"
+        f"<|im_start|>assistant\n<think>\n\n</think>\n\n"
+    )
+    ids = tk.encode(text, add_special_tokens=False).ids
+    print(f"prompt: {len(ids)} tokens")
+
+    t0 = time.perf_counter()
+    tok = model.run_prefill(ids)
+    prefill_s = time.perf_counter() - t0
+
+    out: list[int] = []
+    t0 = time.perf_counter()
+    for _ in range(args.max_new):
+        if tok in eos_ids:
+            break
+        out.append(tok)
+        tok = model.step(tok)
+    decode_s = time.perf_counter() - t0
+
+    print("\n--- generated ---")
+    print(tk.decode(out))
+    print("\n--- performance ---")
+    print(
+        f"prefill: {len(ids)} tok in {prefill_s * 1000:.1f} ms "
+        f"-> {len(ids) / prefill_s:.0f} tok/s"
+    )
+    if out:
+        print(
+            f"decode : {len(out)} tok in {decode_s * 1000:.1f} ms "
+            f"-> {len(out) / decode_s:.1f} tok/s "
+            f"({decode_s / len(out) * 1000:.2f} ms/token)"
+        )
+    print(
+        "vendor : prefill 5626 tok/s, decode 84.8 tok/s "
+        "(oellm_runtime llm demo, same .hbm)"
+    )
+    model.free()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/bpu_resnet18_bench.py
+++ b/benchmarks/bpu_resnet18_bench.py
@@ -1,0 +1,197 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BPU ResNet-18: our compile path against D-Robotics' own artifact.
+
+The vendor ships `/opt/hobot/model/<soc>/basic/resnet18_224x224_nv12.hbm` and
+drives it from `/app/pydev_demo/classification_sample/resnet18/resnet18.py`.
+That artifact is the honest upper bound for this board, so it is the number
+worth measuring against -- eager CPU only says the offload happened.
+
+The two are not the same workload and the table says so:
+
+* the official artifact takes **NV12** (two uint8 planes, 74 KB); ours takes
+  float32 NCHW (588 KB), because that is what an FX graph carries. The
+  conversion to the artifact's int8 input is ours to pay.
+* it was quantized by the vendor's toolchain with real calibration data; ours
+  uses `FLAGOS_BPU_ACT_SCALE` unless `calibrate_module` was run.
+* it is a full torchvision ResNet-18 with a 1000-class head, which is what this
+  script rebuilds -- torchvision is not installed on the board.
+
+Run:
+
+    export FLAGOS_BPU_X86_PYTHON=~/hbdk4-x86/python/bin/python3.11
+    export FLAGOS_BPU_X86_EMULATOR=~/hbdk4-x86/bin/box64
+    python benchmarks/bpu_resnet18_bench.py
+
+The first run compiles under box64 and takes ~20 minutes; afterwards the .hbm
+is cached in `~/.cache/torch_fl_bpu` and startup is seconds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+DEFAULT_OFFICIAL = "/opt/hobot/model/s600/basic/resnet18_224x224_nv12.hbm"
+
+
+def bench(fn, reps: int, warmup: int) -> tuple[float, float, float]:
+    """Median, p10 and p90 wall time in ms."""
+    for _ in range(warmup):
+        fn()
+    ts = []
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        fn()
+        ts.append((time.perf_counter() - t0) * 1e3)
+    ts.sort()
+    return statistics.median(ts), ts[len(ts) // 10], ts[-max(1, len(ts) // 10)]
+
+
+# -- the model ---------------------------------------------------------------
+
+
+class BasicBlock(nn.Module):
+    def __init__(self, cin: int, cout: int, stride: int = 1, down=None) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(cin, cout, 3, stride, 1, bias=False)
+        self.bn1 = nn.BatchNorm2d(cout)
+        self.conv2 = nn.Conv2d(cout, cout, 3, 1, 1, bias=False)
+        self.bn2 = nn.BatchNorm2d(cout)
+        self.down = down
+
+    def forward(self, x):
+        idt = x if self.down is None else self.down(x)
+        o = torch.relu(self.bn1(self.conv1(x)))
+        return torch.relu(self.bn2(self.conv2(o)) + idt)
+
+
+class ResNet18(nn.Module):
+    """torchvision's resnet18, transcribed; torchvision is not on the board."""
+
+    def __init__(self, num_classes: int = 1000) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 64, 7, 2, 3, bias=False)
+        self.bn1 = nn.BatchNorm2d(64)
+        self.maxpool = nn.MaxPool2d(3, 2, 1)
+        self._inp = 64
+        self.layer1 = self._layer(64, 2, 1)
+        self.layer2 = self._layer(128, 2, 2)
+        self.layer3 = self._layer(256, 2, 2)
+        self.layer4 = self._layer(512, 2, 2)
+        self.avgpool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Linear(512, num_classes)
+
+    def _layer(self, cout: int, blocks: int, stride: int) -> nn.Sequential:
+        down = None
+        if stride != 1 or self._inp != cout:
+            down = nn.Sequential(
+                nn.Conv2d(self._inp, cout, 1, stride, bias=False), nn.BatchNorm2d(cout)
+            )
+        layers = [BasicBlock(self._inp, cout, stride, down)]
+        self._inp = cout
+        layers += [BasicBlock(cout, cout) for _ in range(blocks - 1)]
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        x = self.maxpool(torch.relu(self.bn1(self.conv1(x))))
+        x = self.layer4(self.layer3(self.layer2(self.layer1(x))))
+        return self.fc(torch.flatten(self.avgpool(x), 1))
+
+
+# -- runs --------------------------------------------------------------------
+
+
+def run_official(path: str, reps: int, warmup: int):
+    """Median latency of the vendor artifact, or None if it is not installed."""
+    if not Path(path).exists():
+        return None
+    from hbm_runtime import HB_HBMRuntime
+
+    rt = HB_HBMRuntime(path)
+    m = rt.model_names[0]
+    y_name, uv_name = rt.input_names[m][:2]
+    feed = {
+        m: {
+            y_name: np.random.randint(0, 256, (1, 224, 224, 1), dtype=np.uint8),
+            uv_name: np.random.randint(0, 256, (1, 112, 112, 2), dtype=np.uint8),
+        }
+    }
+    nbytes = 224 * 224 + 112 * 112 * 2
+    return (*bench(lambda: rt.run(feed), reps, warmup), nbytes)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--reps", type=int, default=50)
+    ap.add_argument("--warmup", type=int, default=10)
+    ap.add_argument("--official", default=DEFAULT_OFFICIAL)
+    opt = ap.parse_args()
+
+    import torch_fl  # noqa: F401
+    from torch_fl.accelerator.bpu.compiler import find_hbdk
+
+    print(f"hbdk4: {find_hbdk() or 'not reachable -- ours will run on CPU'}\n")
+
+    torch._dynamo.reset()
+    torch.manual_seed(0)
+    model = ResNet18().eval()
+    x = torch.randn(1, 3, 224, 224)
+    in_kb = x.numel() * 4 / 1024
+
+    with torch.no_grad():
+        eager = bench(lambda: model(x), opt.reps, opt.warmup)
+
+    compiled = torch.compile(model, backend="bpu")
+    with torch.no_grad():
+        t0 = time.perf_counter()
+        out = compiled(x)
+        first = time.perf_counter() - t0
+        ours = bench(lambda: compiled(x), opt.reps, opt.warmup)
+
+    official = run_official(opt.official, opt.reps, opt.warmup)
+
+    print(f"{'path':36} {'median':>9} {'p10':>8} {'p90':>8}   input")
+    if official:
+        med, lo, hi, nb = official
+        print(
+            f"{'official resnet18_224x224_nv12':36} {med:8.3f}ms {lo:7.3f}ms "
+            f"{hi:7.3f}ms   {nb / 1024:.0f} KB NV12 uint8"
+        )
+    else:
+        print(f"{'official (not installed)':36} {'-':>9} {'-':>8} {'-':>8}")
+    print(
+        f"{'eager CPU float32':36} {eager[0]:8.3f}ms {eager[1]:7.3f}ms "
+        f"{eager[2]:7.3f}ms   {in_kb:.0f} KB f32 NCHW"
+    )
+    print(
+        f"{'ours torch.compile(backend=bpu)':36} {ours[0]:8.3f}ms {ours[1]:7.3f}ms "
+        f"{ours[2]:7.3f}ms   {in_kb:.0f} KB f32 NCHW"
+    )
+
+    print(f"\noutput {tuple(out.shape)}, first call {first:.1f}s (compile included)")
+    print(f"ours vs eager    : {eager[0] / ours[0]:.2f}x")
+    if official:
+        print(f"ours vs official : {ours[0] / official[0]:.2f}x slower")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/bpu.md
+++ b/docs/bpu.md
@@ -54,15 +54,16 @@ wrappers that cross to CPU and call `at::convolution` instead. Without them
 
 ```
 Dynamo -> AOTAutograd -> aten FX graph
+       -> decompose           (decompose.py: rewrite ops before partitioning)
        -> partition           (torch_fl/accelerator/bpu/partition.py)
        -> freeze weights      (params/buffers become ONNX initializers)
-       -> ONNX export         (compiler.py, decompose.py)
+       -> ONNX export         (compiler.py, decompose.py again)
        -> int8 Q/DQ insertion (qdq.py, calibrate.py)
        -> hbdk4               -> .hbm, cached by graph structure
        -> hbm_runtime         (runtime.py)
 ```
 
-Two parts of this are load-bearing rather than optimizations:
+Three parts of this are load-bearing rather than optimizations:
 
 **Quantization is a precondition.** hbdk4's `convert(advice=True)` says it
 outright: `"lower to cpu. P.S. The type of hbir.conv's fin is f32, which should
@@ -77,6 +78,33 @@ boundary with 13 tensors instead of 1 — copied on every call, and emitted as
 ONNX graph *inputs* rather than initializers, which also blocks the int8 fold.
 Before freezing, BPU offload measured 3x *slower* than eager (25.7 ms vs
 2.8 ms); after, 0.849 ms.
+
+**The rewrites in `decompose.py` decide how much of a network is one graph.**
+They run before partitioning, not just before export, because the ops they
+target do two kinds of damage. A tuple-returning op (`max_pool2d_with_indices`,
+`_native_batch_norm_legit_no_training`) cannot join a partition *and* poisons
+the next one's boundary — a `getitem` whose producer's `meta['val']` is a tuple
+made `_example_inputs_for` reject the partition outright. Untouched, ResNet-18
+split into a 4-node stem and an 84-node body, the body was rejected, and the
+whole network ran on the CPU at **31.4 ms — slower than eager**. With the
+rewrite it is one 68-node partition at **3.24 ms**.
+
+The others are export blockers. AOTAutograd emits `aten._softmax`, which has no
+ONNX symbolic at all (`softmax.int` does), plus `_unsafe_view` and `t`. A
+transformer block hit all three: nine partitions, none exportable. Rewritten, it
+is one 55-node partition that exports clean.
+
+| aten op | rewritten to | why |
+| --- | --- | --- |
+| `_native_batch_norm_legit_no_training` | `batch_norm` | tuple output; no ONNX symbolic |
+| `max_pool2d_with_indices` | `max_pool2d` | tuple output; BPU emits no indices |
+| `_softmax` | `softmax.int` | no ONNX symbolic |
+| `_unsafe_view` | `view` | not in the supported set |
+| `t` (2-D only) | `transpose(0, 1)` | not in the supported set |
+
+Each rewrite is skipped when its extra output is genuinely consumed — a graph
+that uses max-pool indices for `max_unpool` keeps the original node and the old
+behaviour.
 
 Partitions that cannot be compiled stay in the graph and run eagerly, so a
 missing or failing hbdk4 costs performance and never correctness. Pass
@@ -252,6 +280,139 @@ torch-side view is what you want.
 
 ## Measured performance
 
+### ResNet-18 against D-Robotics' own artifact
+
+The vendor ships `/opt/hobot/model/s600/basic/resnet18_224x224_nv12.hbm` and
+drives it from `/app/pydev_demo/classification_sample/resnet18/resnet18.py`.
+That is the honest upper bound for this board, so it is what
+`benchmarks/bpu_resnet18_bench.py` measures against — eager CPU only proves the
+offload happened.
+
+| path | median | p10 | p90 | input |
+| --- | ---: | ---: | ---: | --- |
+| official `resnet18_224x224_nv12.hbm` | **1.075 ms** | 1.060 | 1.136 | 74 KB NV12 uint8 |
+| eager CPU float32 | 26.095 ms | 23.952 | 62.456 | 588 KB f32 NCHW |
+| ours, `torch.compile(backend="bpu")` | **1.356 ms** | 1.315 | 1.454 | 588 KB f32 NCHW |
+
+**19.2x vs eager, 1.26x off the vendor artifact.** Accuracy against eager float:
+cosine 0.990, top-1 agreement 5/5 over random inputs, relative error 0.14 — the
+expected cost of int8 activations at the default scale.
+
+The remaining 0.28 ms is not overhead we can remove by tuning: the official
+artifact takes NV12 (two uint8 planes, 74 KB) and ours takes float32 NCHW
+(588 KB), an 8x difference in input bandwidth, and the vendor quantized with
+HMCT 2.6.5 against real calibration data where ours uses a fixed default scale.
+Our own conversion layers are already negligible — measured `_to_device`
+0.025 ms and `_from_device` 0.004 ms against a 2.1 ms artifact, with 0.29 ms of
+Dynamo/graph dispatch on top.
+
+Two fixes got ResNet-18 from *slower than eager* to this:
+
+1. **31.4 ms -> 3.24 ms** — the `max_pool2d_with_indices` rewrite (see the
+   compile pipeline section). Without it the network was two partitions, the
+   84-node body was rejected outright, and everything ran on the CPU.
+2. **2.63 ms -> 1.36 ms** — quantizing the pool's *input*. `convert(advice=True)`
+   named it precisely: `"lower to cpu. P.S. The type of hbir.max_pool's fin is
+   f32, which should be si8, si16, f16 on bpu."` The stem max-pool was the one
+   op left on the CPU inside the artifact. After the fix hbdk4 reports **zero
+   CPU fallbacks**: 21 `b30.conv2d`, 1 `b30.pool2d`, all on the BPU.
+
+`convert(advice=True)` is the tool for this. It reports a backend per op and a
+`fallback_reason` for anything it lowers to the CPU, and it runs in a couple of
+minutes rather than the ~25 a full emulated compile takes.
+
+### Qwen3-0.6B against the vendor `llm` demo
+
+`benchmarks/bpu_qwen3_bench.py` drives D-Robotics' own two-graph Qwen3-0.6B
+`.hbm` through `infer.py`. Same artifact, same four cores, same weights, so the
+comparison isolates the runtime rather than the model:
+
+| path | decode | prefill |
+| --- | ---: | ---: |
+| vendor `oellm_runtime` `llm` demo | 84.8 – 87.7 tok/s | 5626 – 7014 tok/s |
+| ours, `infer.Package` | **82.1 tok/s** (12.18 ms/tok) | **6881 tok/s** |
+
+Prefill is quoted per *chunk*: the graph always computes all 512 columns, so a
+17-token prompt reads as 219 tok/s for the same 78 ms of work. The vendor
+counts the chunk, and so does the benchmark.
+
+Getting there took one path change and three undocumented details.
+
+`hbm_runtime.run()` copies every input on every call. For a CNN that is a
+588 KB input and it does not matter; for a decode step the KV cache *is* an
+input, 336 MiB of it at 4096 context, and copying it per token costs more than
+the inference — **68.4 ms/token** against the vendor's 11.4. `infer.py`
+allocates each tensor once in UCP memory and passes pointers, which is what the
+vendor's own `libxlm.so` does (its undefined symbols are `hbDNNInferV2`/`V3`
+plus `hbUCPMallocCached`).
+
+Then, in the order they mattered:
+
+1. **`hbUCPReleaseTask` must not follow `hbUCPWaitTaskDone` immediately.**
+   Releasing inline blocks for **28 ms** — more than twice the inference. The
+   per-call breakdown made this unmissable: build task 0.05 ms, submit 3.36 ms,
+   wait 10.73 ms, release 28.03 ms. Deferred by one step it costs 1.65 ms and
+   the step drops 43.2 ms -> 11.3 ms. Task handles cannot be resubmitted, so
+   `_ReleaseRing` builds one per step and releases it one step late. The ring
+   must stay shallow: handles are a finite pool, and once it is dry
+   `hbDNNInferV2` returns a *null handle* instead of failing, so the step
+   appears to run at triple speed while computing nothing. `infer()` raises on
+   a null handle for exactly this reason.
+2. **`HB_DNN_USER_DEFINED_L2M_SIZES` must be set before the first inference.**
+   Unset, an LLM artifact fails with `L2 memory not enough ... user-assigned l2
+   memspace size: [0, 0, 0, 0]` and `hbUCPWaitTaskDone` returns -200003. The
+   vendor's `run_llm.sh` exports `6:6:6:6`; on this board `8:8:8:8` also fails.
+   `ensure_l2_config()` sets it, which is why `Package` must be constructed
+   after it runs.
+3. **The KV cache is a sliding window, not a buffer you append into.** This one
+   is a correctness trap rather than a performance one, and it is the reason
+   `KVWindow` exists — see below.
+
+#### The KV cache layout
+
+The vendor runtime never copies the cache: it moves the pointer. Traced through
+`LD_PRELOAD` over `hbDNNInferV2`, `sysMem.virAddr` for `layer_i_cache_key`
+advances by exactly one slot per decode step while the allocation stays put,
+and `layer_i_new_key` is bound one full window ahead at
+`cache_base + window * slot_bytes`. Each token's K/V is written once, by the
+device, into the slot the next step reads as part of its window.
+
+The consequence for the mask is the part that cannot be guessed. Inside the
+graph the attended keys are `concat(window[span:], new_keys)` for a step of
+`span` tokens, so mask column `c` refers to window slot `c + span`, and the
+last `span` columns are the current step's own tokens. With `pos` tokens of
+history and row `r`:
+
+```
+open columns = [window - span - pos, window - span + r + 1)
+```
+
+which reproduces the trace exactly: prefill row `r` at `pos` 0 opens
+`[3584, 3584+r+1)`, and decode at `pos` 24 opens `[4071, 4096)` — width 25, not
+24, because the token's own key is the last column. The mask is **additive**
+(0 attends, -65504 blocks); a uniform mask is a softmax no-op, which is how you
+can confirm the polarity in a single run.
+
+Two things that look like details and are not: the window advances by the
+**real token count**, not the padded chunk width (a 512-wide prefill of 17
+tokens slides by 17 — sliding by 512 puts padding in the context and generates
+loops), and the allocation needs `window + max_tokens + chunk` slots, because a
+prefill pass writes `chunk` slots past the window. Undersizing it surfaces as
+`hb_bpu_map failed` / `hbUCPSubmitTask rc=-400006`, not a bounds message.
+
+Worth stating plainly, because it cost the most time: **every wrong layout runs
+at full speed and returns confident, fluent, wrong text.** No error, no NaN,
+sane logit magnitudes. Black-box probing of the mask is ambiguous — opening a
+zero-key slot also perturbs the logits, so "did this column matter?" has no
+clean answer. Tracing the vendor took about twenty minutes and settled it.
+`tests/unit/bpu/test_kv_window.py` pins the geometry to values transcribed from
+that trace, so a regression fails loudly instead of producing plausible prose.
+
+This path drives a prebuilt vendor artifact, not a `torch.compile` graph. The
+compile side is not there yet — see the limitations below.
+
+### Smaller graphs
+
 A 6-layer conv stack at 224x224, quantized with frozen weights, compiled
 **on the board** (torch 2.10, box64 v0.4.5): **3.75 ms on the BPU vs 72.06 ms
 eager CPU — 19.2x.** An earlier measurement on a slightly different stack gave
@@ -266,6 +427,13 @@ Toy networks are a wash (0.849 ms vs 0.805 ms) — the fixed submission cost
 dominates, and there is not enough MAC work to amortize it. The offload is worth
 it when the graph is genuinely convolution-heavy.
 
+### Compile time
+
+hbdk4 runs under box64, so compiling is slow: **~25 minutes** for ResNet-18's
+68-node partition on this board. The `.hbm` is cached in
+`~/.cache/torch_fl_bpu` keyed by graph structure, weight values, input
+signature, march and Q/DQ pass version, so this is a first-run cost only.
+
 ## Known limitations
 
 - Single device only; the four BPU cores are not scheduled independently.
@@ -278,4 +446,28 @@ it when the graph is genuinely convolution-heavy.
   dtype-matched input is truly copy-free. Outputs always copy: `hbm_runtime.run`
   allocates its own arrays. Driving `hbDNNInferV2` directly with tensors built
   from `FlagosBPUPhysicalAddress()` would close the remaining gap.
-- Calibration is opt-in and manual.
+- Calibration is opt-in and manual. On ResNet-18 the default scale costs
+  cosine 0.990 against eager float, which preserved top-1 on every input tried
+  — but the vendor's own artifact was calibrated with HMCT against real data,
+  and part of the remaining gap to it is likely quantization quality rather
+  than scheduling.
+- Input format. The vendor's artifacts take NV12 uint8 (74 KB for 224x224);
+  a graph traced from PyTorch carries float32 NCHW (588 KB). The BPU can
+  consume NV12 directly, so a preprocessing path that fed it would remove
+  8x of input bandwidth, but nothing in an FX graph expresses that.
+- `qdq.py` quantizes convolution, matmul and pooling. Anything else — softmax,
+  layer norm, elementwise — stays float, which is correct but leaves those ops
+  on the BPU's VPU rather than its MAC array. `convert(advice=True)` is how to
+  check what a given graph actually lowers to.
+- **LLM inference runs a prebuilt vendor artifact, not a compiled graph.**
+  `infer.py` is the runtime half only. Driving a `torch.compile`d transformer
+  the same way needs, in rough order: `aten.slice.Tensor` in `partition.py`'s
+  supported set (without it a transformer block fragments; with it decode and
+  prefill are each a single partition at 100% node coverage), an ONNX
+  constant-folding pass after export (torch's `aten.expand` emits a
+  `Shape->Equal->Where->Expand` chain hbdk4 cannot shape-infer through), and
+  mixed-precision Q/DQ — the vendor artifact uses si16 for the K cache, si8 for
+  V, and f16 for the mask and logits, where `qdq.py` is si8-only. With folding
+  alone, `convert(advice=True)` already puts 54 of 66 ops on the BPU; the 12
+  fallbacks all report `"fallback to float, op is not completely quantized"`,
+  which is the Q/DQ gap rather than a hardware limit.

--- a/tests/unit/bpu/test_cache_key.py
+++ b/tests/unit/bpu/test_cache_key.py
@@ -1,0 +1,84 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The .hbm cache key.
+
+Weights are compiled *into* the artifact, so the key has to cover them. Hashing
+only the graph structure makes two same-shaped models collide, and the second
+one silently runs the first one's weights -- a wrong answer with no error. None
+of these tests needs hbdk4 or the device.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+torch_fl = pytest.importorskip("torch_fl")
+
+from torch_fl.accelerator.bpu.compiler import graph_key  # noqa: E402
+
+
+def _traced(seed: int, scale: float = 1.0) -> torch.fx.GraphModule:
+    torch.manual_seed(seed)
+    model = torch.nn.Sequential(
+        torch.nn.Conv2d(3, 8, 3, padding=1),
+        torch.nn.ReLU(),
+    ).eval()
+    with torch.no_grad():
+        model[0].weight.mul_(scale)
+    return torch.fx.symbolic_trace(model)
+
+
+EX = [torch.randn(1, 3, 16, 16)]
+
+
+def test_same_model_gives_a_stable_key():
+    gm = _traced(0)
+    assert graph_key(gm, EX, "nash-p") == graph_key(gm, EX, "nash-p")
+
+
+def test_different_weights_give_different_keys():
+    """The bug this file exists for: same architecture, different weights."""
+    a, b = _traced(1), _traced(2)
+    assert graph_key(a, EX, "nash-p") != graph_key(b, EX, "nash-p")
+
+
+def test_a_small_weight_change_changes_the_key():
+    """Retraining a model must not silently reuse the old artifact."""
+    base = _traced(3)
+    tweaked = _traced(3)
+    with torch.no_grad():
+        tweaked.get_parameter("0.weight")[0, 0, 0, 0] += 1.0
+    assert graph_key(base, EX, "nash-p") != graph_key(tweaked, EX, "nash-p")
+
+
+def test_key_still_separates_march_and_input_shape():
+    gm = _traced(4)
+    assert graph_key(gm, EX, "nash-p") != graph_key(gm, EX, "nash-e")
+    other = [torch.randn(1, 3, 32, 32)]
+    assert graph_key(gm, EX, "nash-p") != graph_key(gm, other, "nash-p")
+
+
+def test_large_weights_are_still_separated():
+    """Big tensors are sampled rather than hashed whole; that must still work."""
+    torch.manual_seed(5)
+    big_a = torch.fx.symbolic_trace(
+        torch.nn.Sequential(torch.nn.Conv2d(64, 128, 3, padding=1)).eval()
+    )
+    big_b = torch.fx.symbolic_trace(
+        torch.nn.Sequential(torch.nn.Conv2d(64, 128, 3, padding=1)).eval()
+    )
+    ex = [torch.randn(1, 64, 8, 8)]
+    assert graph_key(big_a, ex, "nash-p") != graph_key(big_b, ex, "nash-p")

--- a/tests/unit/bpu/test_decompose.py
+++ b/tests/unit/bpu/test_decompose.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The batch-norm rewrite must preserve semantics and be ONNX-exportable."""
+"""The pre-partition rewrites must preserve semantics and be ONNX-exportable."""
 
 from __future__ import annotations
 
@@ -24,9 +24,10 @@ import torch
 from torch._dynamo.backends.common import aot_autograd
 
 from torch_fl.accelerator.bpu.compiler import export_onnx
-from torch_fl.accelerator.bpu.decompose import decompose_for_onnx
+from torch_fl.accelerator.bpu.decompose import decompose, decompose_for_onnx
 
 BN_NO_TRAINING = torch.ops.aten._native_batch_norm_legit_no_training.default
+MAX_POOL_INDICES = torch.ops.aten.max_pool2d_with_indices.default
 
 
 class ConvBN(torch.nn.Module):
@@ -117,3 +118,224 @@ def test_exports_to_onnx_after_rewrite(tmp_path: Path) -> None:
     onnx.checker.check_model(proto)
     # hbdk4's adaptor needs shapes for intermediates, which export_onnx adds.
     assert len(proto.graph.value_info) > 0
+
+
+# -- max_pool2d ----------------------------------------------------------------
+
+
+class Stem(torch.nn.Module):
+    """A ResNet stem: this is where the graph used to be cut in half."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 8, 7, 2, 3, bias=False)
+        self.bn = torch.nn.BatchNorm2d(8)
+        self.pool = torch.nn.MaxPool2d(3, 2, 1)
+        self.conv2 = torch.nn.Conv2d(8, 8, 3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.relu(self.conv2(self.pool(torch.relu(self.bn(self.conv(x))))))
+
+
+def test_rewrites_max_pool_with_indices() -> None:
+    gm = _aten_graph(Stem().eval(), torch.randn(1, 3, 32, 32))
+    assert [n for n in gm.graph.nodes if n.target is MAX_POOL_INDICES]
+
+    decompose(gm)
+
+    assert not [n for n in gm.graph.nodes if n.target is MAX_POOL_INDICES]
+    pools = [n for n in gm.graph.nodes if n.target is torch.ops.aten.max_pool2d.default]
+    assert len(pools) == 1
+    # The rewritten node must carry a tensor val, not the original tuple: a
+    # tuple here is what made the partitioner reject the downstream partition.
+    assert isinstance(pools[0].meta.get("val"), torch.Tensor)
+
+
+def test_max_pool_rewrite_preserves_numerics() -> None:
+    mod = Stem().eval()
+    x = torch.randn(2, 3, 32, 32)
+
+    captured = {}
+
+    def fw(gm, inputs):
+        decompose(gm)
+        captured["gm"] = gm
+        return gm.forward
+
+    with torch.no_grad():
+        ref = mod(x)
+        got = torch.compile(mod, backend=aot_autograd(fw_compiler=fw))(x)
+
+    assert not [n for n in captured["gm"].graph.nodes if n.target is MAX_POOL_INDICES]
+    torch.testing.assert_close(got, ref)
+
+
+def test_max_pool_keeps_indices_when_they_are_used() -> None:
+    """max_unpool needs the indices; that node must be left alone."""
+
+    class WithIndices(torch.nn.Module):
+        def forward(self, x):
+            out, idx = torch.nn.functional.max_pool2d(x, 2, return_indices=True)
+            return out.sum() + idx.sum()
+
+    gm = _aten_graph(WithIndices().eval(), torch.randn(1, 3, 8, 8))
+    before = [n for n in gm.graph.nodes if n.target is MAX_POOL_INDICES]
+    assert before
+
+    decompose(gm)
+
+    assert [n for n in gm.graph.nodes if n.target is MAX_POOL_INDICES] == before
+
+
+def test_pooling_stays_in_one_partition() -> None:
+    """The regression this rewrite exists for.
+
+    Untouched, `max_pool2d_with_indices` is unsupported, so a ResNet splits into
+    a 4-node stem and an 84-node body -- and the body is then rejected outright,
+    because its boundary input is a getitem off a tuple-valued node. The whole
+    network ran on the CPU.
+    """
+    from torch_fl.accelerator.bpu.backend import _example_inputs_for
+    from torch_fl.accelerator.bpu.partition import partition_graph
+
+    gm = _aten_graph(Stem().eval(), torch.randn(1, 3, 32, 32))
+    assert len(partition_graph(gm, min_nodes=2)) == 2  # split at the pool
+
+    decompose(gm)
+    parts = partition_graph(gm, min_nodes=2)
+
+    assert len(parts) == 1
+    targets = {n.target for n in parts[0].nodes}
+    assert torch.ops.aten.max_pool2d.default in targets
+    assert _example_inputs_for(parts[0], [], gm) is not None
+
+
+def test_decompose_is_idempotent() -> None:
+    """It runs before partitioning and again before export."""
+    gm = _aten_graph(Stem().eval(), torch.randn(1, 3, 32, 32))
+    decompose(gm)
+    after_once = [(n.op, n.target) for n in gm.graph.nodes]
+    decompose(gm)
+    assert [(n.op, n.target) for n in gm.graph.nodes] == after_once
+
+
+def test_decompose_for_onnx_is_the_same_pass() -> None:
+    assert decompose_for_onnx is decompose
+
+
+# -- attention -----------------------------------------------------------------
+
+
+SOFTMAX_PRIVATE = torch.ops.aten._softmax.default
+UNSAFE_VIEW = torch.ops.aten._unsafe_view.default
+ATEN_T = torch.ops.aten.t.default
+
+
+class Attention(torch.nn.Module):
+    """One transformer block, which used to export not at all."""
+
+    def __init__(self, d: int = 32, h: int = 4) -> None:
+        super().__init__()
+        self.n1 = torch.nn.LayerNorm(d)
+        self.q = torch.nn.Linear(d, d)
+        self.k = torch.nn.Linear(d, d)
+        self.v = torch.nn.Linear(d, d)
+        self.proj = torch.nn.Linear(d, d)
+        self.h, self.dh = h, d // h
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, n, d = x.shape
+        y = self.n1(x)
+        q = self.q(y).view(b, n, self.h, self.dh).transpose(1, 2)
+        k = self.k(y).view(b, n, self.h, self.dh).transpose(1, 2)
+        v = self.v(y).view(b, n, self.h, self.dh).transpose(1, 2)
+        a = ((q @ k.transpose(-2, -1)) * (self.dh**-0.5)).softmax(-1)
+        return x + self.proj((a @ v).transpose(1, 2).reshape(b, n, d))
+
+
+def test_rewrites_private_softmax() -> None:
+    """AOTAutograd emits `_softmax`, which has no ONNX symbolic at all."""
+    gm = _aten_graph(Attention().eval(), torch.randn(1, 8, 32))
+    assert [n for n in gm.graph.nodes if n.target is SOFTMAX_PRIVATE]
+
+    decompose(gm)
+
+    assert not [n for n in gm.graph.nodes if n.target is SOFTMAX_PRIVATE]
+    assert [n for n in gm.graph.nodes if n.target is torch.ops.aten.softmax.int]
+
+
+def test_rewrites_unsafe_view_and_t() -> None:
+    gm = _aten_graph(Attention().eval(), torch.randn(1, 8, 32))
+    assert [n for n in gm.graph.nodes if n.target in (UNSAFE_VIEW, ATEN_T)]
+
+    decompose(gm)
+
+    assert not [n for n in gm.graph.nodes if n.target in (UNSAFE_VIEW, ATEN_T)]
+
+
+def test_attention_rewrite_preserves_numerics() -> None:
+    mod = Attention().eval()
+    x = torch.randn(2, 8, 32)
+
+    captured = {}
+
+    def fw(gm, inputs):
+        decompose(gm)
+        captured["gm"] = gm
+        return gm.forward
+
+    with torch.no_grad():
+        ref = mod(x)
+        got = torch.compile(mod, backend=aot_autograd(fw_compiler=fw))(x)
+
+    assert not [n for n in captured["gm"].graph.nodes if n.target is SOFTMAX_PRIVATE]
+    torch.testing.assert_close(got, ref)
+
+
+def test_attention_becomes_one_partition() -> None:
+    """Nine partitions, none of them exportable, was the old behaviour."""
+    from torch_fl.accelerator.bpu.partition import partition_graph
+
+    gm = _aten_graph(Attention().eval(), torch.randn(1, 8, 32))
+    assert len(partition_graph(gm, min_nodes=2)) > 1
+
+    decompose(gm)
+    parts = partition_graph(gm, min_nodes=2)
+
+    assert len(parts) == 1
+    assert torch.ops.aten.softmax.int in {n.target for n in parts[0].nodes}
+
+
+def test_attention_exports_to_onnx(tmp_path: Path) -> None:
+    """The failure this rewrite exists for: UnsupportedOperatorError on _softmax."""
+    pytest.importorskip("onnx")
+    gm = _aten_graph(Attention().eval(), torch.randn(1, 8, 32))
+
+    inputs = [
+        torch.zeros(tuple(n.meta["val"].shape), dtype=n.meta["val"].dtype)
+        for n in gm.graph.nodes
+        if n.op == "placeholder"
+    ]
+
+    out = tmp_path / "attn.onnx"
+    ins, outs = export_onnx(gm, inputs, out)
+    assert out.exists() and ins and outs
+
+    import onnx
+
+    onnx.checker.check_model(onnx.load(str(out)))
+
+
+def test_t_is_left_alone_below_two_dims() -> None:
+    """`aten.t` is the identity on 0-D and 1-D; rewriting it would be wrong."""
+
+    class OneD(torch.nn.Module):
+        def forward(self, x):
+            return torch.t(x) + 1
+
+    gm = _aten_graph(OneD().eval(), torch.randn(5))
+    ts = [n for n in gm.graph.nodes if n.target is ATEN_T]
+
+    decompose(gm)
+
+    assert [n for n in gm.graph.nodes if n.target is ATEN_T] == ts

--- a/tests/unit/bpu/test_eager_device.py
+++ b/tests/unit/bpu/test_eager_device.py
@@ -123,8 +123,16 @@ def test_compile_backend_is_registered():
 
 
 def test_compiled_model_matches_eager():
-    """Correct with or without hbdk4: partitions that cannot be compiled stay
-    on the CPU, so this passes either way -- only the tolerance differs."""
+    """Correct with or without hbdk4, but not to the same precision.
+
+    Without hbdk4 the partition stays on the CPU and the result is bit-exact.
+    With hbdk4 the artifact is int8-quantized -- that is a precondition for the
+    BPU to run conv at all, not a tuning choice -- so the comparison has to be
+    directional rather than elementwise. An elementwise float tolerance would
+    make this test pass only on machines that cannot actually compile.
+    """
+    from torch_fl.accelerator.bpu.compiler import find_hbdk
+
     model = torch.nn.Sequential(
         torch.nn.Conv2d(3, 16, 3, padding=1),
         torch.nn.BatchNorm2d(16),
@@ -134,4 +142,55 @@ def test_compiled_model_matches_eager():
     with torch.no_grad():
         expected = model(x)
         got = torch.compile(model, backend="bpu")(x)
-    torch.testing.assert_close(got, expected, atol=2e-2, rtol=2e-2)
+
+    assert got.shape == expected.shape
+    if find_hbdk() is None:
+        torch.testing.assert_close(got, expected, atol=2e-2, rtol=2e-2)
+        return
+    cos = torch.nn.functional.cosine_similarity(
+        got.flatten().float(), expected.flatten().float(), dim=0
+    ).item()
+    assert cos > 0.99, f"int8 artifact diverged from eager: cos={cos}"
+
+
+def test_compiled_models_do_not_share_an_artifact():
+    """Two models of one architecture must not return each other's results.
+
+    Weights are compiled into the .hbm, but Dynamo guards parameters on shape
+    and dtype only, so both instances hit the same compiled graph. Without the
+    backend's own weight check the second model silently returned the first
+    model's output.
+    """
+    from torch_fl.accelerator.bpu.compiler import find_hbdk
+
+    if find_hbdk() is None:
+        pytest.skip("needs a real artifact to share")
+
+    def build(seed):
+        torch.manual_seed(seed)
+        m = torch.nn.Sequential(
+            torch.nn.Conv2d(3, 16, 3, padding=1),
+            torch.nn.BatchNorm2d(16),
+            torch.nn.ReLU(),
+        ).eval()
+        with torch.no_grad():
+            m[1].running_mean.normal_()
+            m[1].running_var.uniform_(0.5, 1.5)
+        return m
+
+    a, b = build(1), build(2)
+    x = torch.randn(1, 3, 32, 32)
+    with torch.no_grad():
+        eager_a, eager_b = a(x), b(x)
+        got_a = torch.compile(a, backend="bpu")(x)
+        got_b = torch.compile(b, backend="bpu")(x)
+
+    def cos(p, q):
+        return torch.nn.functional.cosine_similarity(
+            p.flatten().float(), q.flatten().float(), dim=0
+        ).item()
+
+    # The models must genuinely differ, or the test proves nothing.
+    assert cos(eager_a, eager_b) < 0.9
+    assert cos(got_a, eager_a) > 0.99
+    assert cos(got_b, eager_b) > 0.99, "second model returned the first's output"

--- a/tests/unit/bpu/test_freeze.py
+++ b/tests/unit/bpu/test_freeze.py
@@ -180,3 +180,49 @@ def test_missing_outer_context_degrades_to_no_freezing():
         )
 
     assert captured["frozen"] == {}
+
+
+def test_identifies_weights_when_dynamo_keeps_them_on_the_module():
+    """Freezing mode hands weights over as module attributes, not inputs.
+
+    `is_parameter_freezing()` -- inductor's config.freezing with grad off -- is
+    what makes Dynamo guard on parameter identity, which the BPU backend needs
+    because it bakes weights into the artifact. In that mode the weights never
+    reach `_OUTER_INPUTS`, and an index-only lookup finds nothing: every weight
+    then crosses the boundary on each call, which is far slower than eager.
+    """
+    prior = torch._inductor.config.freezing
+    torch._dynamo.reset()
+    torch._inductor.config.freezing = True
+    try:
+        cap = _capture(ConvBN().eval(), torch.randn(1, 3, 16, 16))
+    finally:
+        torch._inductor.config.freezing = prior
+        torch._dynamo.reset()
+
+    assert len(cap["frozen"]) == 8
+    for t in cap["frozen"].values():
+        assert isinstance(t, torch.Tensor)
+        assert not t.is_meta
+
+
+def test_frozen_weights_line_up_with_their_placeholders():
+    """A shape mismatch here means the artifact is built with shuffled weights.
+
+    The freezing-mode path pairs placeholders with tensors positionally, so this
+    is the property that catches an off-by-one or a reversed order.
+    """
+    prior = torch._inductor.config.freezing
+    torch._dynamo.reset()
+    torch._inductor.config.freezing = True
+    try:
+        cap = _capture(ConvBN().eval(), torch.randn(1, 3, 16, 16))
+    finally:
+        torch._inductor.config.freezing = prior
+        torch._dynamo.reset()
+
+    gm, frozen = cap["gm"], cap["frozen"]
+    for node in gm.graph.nodes:
+        if node.op == "placeholder" and node.name in frozen:
+            assert tuple(node.meta["val"].shape) == tuple(frozen[node.name].shape)
+            assert node.meta["val"].dtype == frozen[node.name].dtype

--- a/tests/unit/bpu/test_kv_window.py
+++ b/tests/unit/bpu/test_kv_window.py
@@ -1,0 +1,92 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The sliding-window KV layout an LLM .hbm expects.
+
+These are pure arithmetic checks on `KVWindow.mask_range`, so they need no
+device. They exist because the layout is not documented anywhere and getting it
+wrong does not raise -- the model produces fluent, wrong text. The expected
+values below are transcribed from an `LD_PRELOAD` trace of the vendor's own
+`llm` demo on Qwen3-0.6B, so they are what the runtime actually passed to
+`hbDNNInferV2`, not a reading of the graph.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("numpy")
+
+from torch_fl.accelerator.bpu.infer import KVWindow  # noqa: E402
+
+WINDOW = 4096
+CHUNK = 512
+
+
+class _FakeWindow:
+    """`KVWindow`'s geometry without its allocations."""
+
+    def __init__(self, window=WINDOW, pos=0):
+        self.window = window
+        self.pos = pos
+
+    mask_range = KVWindow.mask_range
+
+
+def test_prefill_first_rows_match_the_vendor_trace():
+    """Traced: row r of a fresh 512-token prefill opens [3584, 3584+r+1)."""
+    w = _FakeWindow()
+    assert w.mask_range(CHUNK, 0) == (3584, 3585)
+    assert w.mask_range(CHUNK, 1) == (3584, 3586)
+    assert w.mask_range(CHUNK, 2) == (3584, 3587)
+
+
+def test_decode_at_position_24_matches_the_vendor_trace():
+    """Traced: with 24 tokens of history, decode opens [4071, 4096).
+
+    Note the width is 25, not 24 -- the current token's own key is the last
+    column, because the graph attends over concat(window[span:], new_keys).
+    """
+    w = _FakeWindow(pos=24)
+    lo, hi = w.mask_range(1)
+    assert (lo, hi) == (4071, 4096)
+    assert hi - lo == 25
+
+
+@pytest.mark.parametrize("pos", [0, 1, 25, 100, 3583])
+def test_decode_window_is_history_plus_self(pos):
+    w = _FakeWindow(pos=pos)
+    lo, hi = w.mask_range(1)
+    assert hi == WINDOW
+    assert hi - lo == pos + 1
+
+
+def test_window_saturates_rather_than_going_negative():
+    """Past a full window the range clamps at 0 instead of wrapping."""
+    w = _FakeWindow(pos=WINDOW * 2)
+    lo, hi = w.mask_range(1)
+    assert lo == 0
+    assert hi == WINDOW
+
+
+def test_the_current_step_owns_the_last_span_columns():
+    """The final `span` columns are the step's own tokens, never history."""
+    for span in (1, 8, CHUNK):
+        w = _FakeWindow(pos=1000)
+        lo, _ = w.mask_range(span, 0)
+        assert lo == WINDOW - span - 1000
+        # Row r sees exactly r+1 of its own columns.
+        for r in (0, 3):
+            _, hi = w.mask_range(span, r)
+            assert hi - (WINDOW - span) == r + 1

--- a/tests/unit/bpu/test_qdq.py
+++ b/tests/unit/bpu/test_qdq.py
@@ -152,6 +152,70 @@ def test_no_quantizable_ops_leaves_graph_unchanged(tmp_path):
     assert [n.op_type for n in out.graph.node] == before
 
 
+# -- pooling -------------------------------------------------------------------
+
+
+class ConvPool(torch.nn.Module):
+    """A ResNet stem: conv, then the pool that used to run on the CPU."""
+
+    def __init__(self):
+        super().__init__()
+        self.c = torch.nn.Conv2d(3, 8, 7, 2, 3, bias=False)
+        self.p = torch.nn.MaxPool2d(3, 2, 1)
+
+    def forward(self, x):
+        return self.p(torch.relu(self.c(x)))
+
+
+def test_pool_input_is_quantized(tmp_path):
+    """hbdk4 keeps a pool on the CPU while its input is f32.
+
+    `convert(advice=True)` on the un-quantized ResNet said it outright:
+    "lower to cpu. P.S. The type of hbir.max_pool's fin is f32, which should be
+    si8, si16, f16 on bpu." It was the only op in the whole network not on the
+    BPU, because the Q/DQ pair around the preceding conv hands the pool a float.
+    """
+    _, proto = _export(tmp_path, ConvPool().eval(), torch.randn(1, 3, 32, 32))
+    out = quantize_onnx(proto)
+
+    produced_by = {o: n for n in out.graph.node for o in n.output}
+    pools = [n for n in out.graph.node if n.op_type == "MaxPool"]
+    assert pools
+    for pool in pools:
+        assert produced_by[pool.input[0]].op_type == "DequantizeLinear"
+    onnx.checker.check_model(out)
+
+
+def test_pool_gets_no_weight_dequantize(tmp_path):
+    """A pool has no weights; only its activation edge may be rewritten."""
+    _, proto = _export(tmp_path, ConvPool().eval(), torch.randn(1, 3, 32, 32))
+    out = quantize_onnx(proto)
+
+    pools = [n for n in out.graph.node if n.op_type == "MaxPool"]
+    assert all(len(p.input) == 1 for p in pools)
+
+
+def test_pooling_stays_numerically_close(tmp_path):
+    ort = pytest.importorskip("onnxruntime")
+
+    model = ConvPool().eval()
+    x = torch.randn(1, 3, 32, 32)
+    path, proto = _export(tmp_path, model, x)
+
+    ref = ort.InferenceSession(
+        onnx.load(str(path)).SerializeToString(), providers=["CPUExecutionProvider"]
+    ).run(None, {"in_0": x.numpy()})[0]
+
+    out = quantize_onnx(proto, default_act_scale=float(x.abs().max()) / 127.0)
+    got = ort.InferenceSession(
+        out.SerializeToString(), providers=["CPUExecutionProvider"]
+    ).run(None, {"in_0": x.numpy()})[0]
+
+    a, b = ref.ravel(), got.ravel()
+    cos = float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-12))
+    assert cos > 0.99, f"cosine similarity {cos}"
+
+
 def test_calibration_scale_covers_observed_range():
     r = TensorRange()
     r.observe(torch.tensor([-2.0, 1.0]))

--- a/torch_fl/accelerator/bpu/backend.py
+++ b/torch_fl/accelerator/bpu/backend.py
@@ -30,6 +30,7 @@ import torch
 from torch.fx import GraphModule, Node
 
 from .compiler import CompileError, compile_partition, find_hbdk
+from .decompose import decompose
 from .partition import (
     Partition,
     extract_subgraph,
@@ -51,14 +52,61 @@ _OUTER_INPUTS: contextvars.ContextVar[tuple[list[str], list[torch.Tensor]] | Non
 
 
 class _BPUCall(torch.nn.Module):
-    """Holds a BPURuntime so it survives as a graph attribute."""
+    """Holds a BPURuntime so it survives as a graph attribute.
 
-    def __init__(self, rt: BPURuntime, n_outputs: int):
+    Also carries the weight check. The frozen weights are baked into the
+    artifact, but Dynamo guards parameters on shape and dtype only unless
+    `_weights_are_guarded()` holds -- so this module can be reached with a
+    *different* model's weights and would otherwise return the first model's
+    answer with no indication that anything was wrong.
+
+    The spliced call therefore keeps the frozen weights as trailing arguments
+    (`n_real` marks where they start). They are not passed to the artifact --
+    they are compared against the tensors it was compiled from, and a mismatch
+    falls back to running the original subgraph eagerly.
+    """
+
+    def __init__(
+        self,
+        rt: BPURuntime,
+        n_outputs: int,
+        n_real: int | None = None,
+        frozen: list[torch.Tensor] | None = None,
+        fallback: Callable[..., Any] | None = None,
+    ):
         super().__init__()
         self.rt = rt
         self.n_outputs = n_outputs
+        self.n_real = n_real
+        self._frozen = list(frozen or [])
+        self._fallback = fallback
+        self._warned = False
+
+    def _matches(self, guards: tuple[torch.Tensor, ...]) -> bool:
+        if len(guards) != len(self._frozen):
+            return False
+        # Identity first: the common case is the very same parameter object.
+        return all(
+            g is f or (g.shape == f.shape and g.dtype == f.dtype and torch.equal(g, f))
+            for g, f in zip(guards, self._frozen)
+        )
 
     def forward(self, *args: torch.Tensor):
+        if self.n_real is not None:
+            real, guards = args[: self.n_real], args[self.n_real :]
+            if not self._matches(guards):
+                if not self._warned:
+                    self._warned = True
+                    log.warning(
+                        "BPU: this graph was reached with different weights than "
+                        "the artifact was compiled from, so the partition is "
+                        "running on the CPU. Compile under torch.no_grad() with "
+                        "torch._inductor.config.freezing = True to get one "
+                        "artifact per model instead."
+                    )
+                if self._fallback is not None:
+                    return self._fallback(*real, *guards)
+            args = real
         outs = self.rt(*args)
         return outs[0] if self.n_outputs == 1 else tuple(outs)
 
@@ -75,6 +123,9 @@ def _example_inputs_for(
     real tensors of the right shape and dtype. Frozen weights use their real
     values, since the compiler bakes those into the artifact; everything else
     only needs the right shape.
+
+    Returns None when a boundary input cannot be materialized, which
+    `_unsupported_input` explains.
     """
     from torch._subclasses.fake_tensor import unset_fake_temporarily
 
@@ -95,11 +146,60 @@ def _example_inputs_for(
     return out
 
 
+def _unsupported_input(
+    p: Partition, frozen: dict[str, torch.Tensor] | None = None
+) -> str:
+    """Why `_example_inputs_for` gave up, for the log.
+
+    Worth the extra pass: this used to be reported as "dynamic shapes" whatever
+    the cause, and the actual cause on ResNet was a boundary input whose
+    `meta['val']` is a tuple -- a graph with no dynamic shapes at all.
+    """
+    frozen = frozen or {}
+    for n in p.inputs:
+        if n.name in frozen:
+            continue
+        val = n.meta.get("val")
+        if val is None:
+            return f"{n.name} ({n.target}) has no fake-tensor metadata"
+        if not isinstance(val, torch.Tensor):
+            return (
+                f"{n.name} ({n.target}) is a {type(val).__name__}, not a tensor; "
+                "a multi-output op cannot cross a partition boundary"
+            )
+        if any(not isinstance(d, int) for d in val.shape):
+            return f"{n.name} has dynamic shape {tuple(val.shape)}"
+    return "unknown"
+
+
 # Dynamo names lifted module state after its access path, e.g.
 # `l_self_modules_c1_parameters_weight_`. AOTAutograd renames these to
 # `primals_N` but records the original index in node.meta['desc'].idx, which is
 # how a weight is recognised two layers down from where it was named.
 _STATE_MARKERS = ("_parameters_", "_buffers_")
+
+
+def _outer_state_tensors() -> list[torch.Tensor]:
+    """The real parameter and buffer tensors AOTAutograd lifted, in graph order.
+
+    Dynamo has two ways of handing module state to a backend. Inlined state
+    arrives as extra *inputs*, which the index lookup above resolves through
+    `_OUTER_INPUTS`. Under `is_parameter_freezing()` -- inductor's
+    `config.freezing` with grad disabled, which is what makes Dynamo guard on
+    parameter identity so a second module instance recompiles -- the state stays
+    on the module as `get_attr` nodes instead, and never appears in the input
+    list at all. There the only real tensors are the tracing context's
+    params_flat; `example_inputs` is entirely fake by that point.
+
+    Getting this wrong is expensive rather than incorrect: every weight then
+    crosses the boundary on each call, which measured ~2000x slower than the
+    frozen path on a 6-layer conv stack.
+    """
+    ctx = torch._guards.TracingContext.try_get()
+    flat = getattr(ctx, "params_flat", None) if ctx is not None else None
+    if not flat:
+        return []
+    return [t for t in flat if isinstance(t, torch.Tensor)]
 
 
 def _frozen_weights(
@@ -112,23 +212,44 @@ def _frozen_weights(
     """
     from torch._subclasses.fake_tensor import FakeTensor
 
-    outer = _OUTER_INPUTS.get()
-    if not outer:
-        return {}
-    names, values = outer
     frozen: dict[str, torch.Tensor] = {}
+    placeholders = [n for n in gm.graph.nodes if n.op == "placeholder"]
 
-    for node in gm.graph.nodes:
-        if node.op != "placeholder":
-            continue
-        idx = getattr(node.meta.get("desc"), "idx", None)
-        if idx is None or not (0 <= idx < len(values)):
-            continue
-        t, name = values[idx], names[idx]
-        is_state = isinstance(t, torch.nn.Parameter) or any(
-            m in name for m in _STATE_MARKERS
-        )
-        if is_state and isinstance(t, torch.Tensor) and not isinstance(t, FakeTensor):
+    outer = _OUTER_INPUTS.get()
+    if outer:
+        names, values = outer
+        for node in placeholders:
+            idx = getattr(node.meta.get("desc"), "idx", None)
+            if idx is None or not (0 <= idx < len(values)):
+                continue
+            t, name = values[idx], names[idx]
+            is_state = isinstance(t, torch.nn.Parameter) or any(
+                m in name for m in _STATE_MARKERS
+            )
+            if (
+                is_state
+                and isinstance(t, torch.Tensor)
+                and not isinstance(t, FakeTensor)
+            ):
+                frozen[node.name] = t
+
+    if frozen:
+        return frozen
+
+    # Nothing matched by index: Dynamo kept the state on the module rather than
+    # in its input list, so `_OUTER_INPUTS` holds only the real inputs and
+    # `example_inputs` is entirely fake. The real tensors are in the tracing
+    # context's params_flat, and AOTAutograd lifts them to the *leading*
+    # placeholders -- `desc.idx` is set only on placeholders that came from an
+    # actual graph input, so the leading run without one is exactly the lifted
+    # parameters and buffers, in params_flat order.
+    state = _outer_state_tensors()
+    if not state or len(state) >= len(placeholders):
+        return frozen
+    for node, t in zip(placeholders[: len(state)], state):
+        if getattr(node.meta.get("desc"), "idx", None) is not None:
+            return {}
+        if isinstance(t, torch.Tensor) and not isinstance(t, FakeTensor):
             frozen[node.name] = t
     return frozen
 
@@ -168,6 +289,8 @@ def bpu_backend(
     gm: GraphModule,
     example_inputs: list[torch.Tensor],
     *,
+    mode: str | None = None,
+    options: dict[str, Any] | None = None,
     min_nodes: int = 3,
     strict: bool = False,
     act_scales: dict[str, float] | None = None,
@@ -185,8 +308,35 @@ def bpu_backend(
     `act_scales` maps ONNX tensor name to quantization scale (see
     `calibrate.calibrate_onnx`). Anything not listed falls back to
     `compiler.ACT_SCALE`.
+
+    `mode` and `options` are accepted because torch.compile forwards them to any
+    custom backend, so refusing them turns a routine
+    `torch.compile(m, backend="bpu", mode="reduce-overhead")` into a hard
+    failure. The modes describe inductor codegen strategies -- CUDA graphs,
+    autotuning, kernel fusion -- and none of them apply to an artifact hbdk4
+    already compiled ahead of time, so `mode` is ignored with a note rather than
+    silently promising an effect it cannot have. `options` is the supported way
+    to reach the real knobs above.
     """
     from torch._dynamo.backends.common import aot_autograd
+
+    if mode is not None and mode != "default":
+        log.info(
+            "mode=%r has no effect on the BPU backend: it selects inductor "
+            "codegen strategies, and the BPU runs a .hbm that hbdk4 compiled "
+            "ahead of time. Use options={...} to set min_nodes/strict/act_scales.",
+            mode,
+        )
+    if options:
+        unknown = set(options) - {"min_nodes", "strict", "act_scales"}
+        if unknown:
+            raise TypeError(
+                f"unknown BPU backend option(s): {sorted(unknown)}. "
+                "Supported: min_nodes, strict, act_scales."
+            )
+        min_nodes = options.get("min_nodes", min_nodes)
+        strict = options.get("strict", strict)
+        act_scales = options.get("act_scales", act_scales)
 
     def _compile_aten(aten_gm: GraphModule, aten_inputs: list[torch.Tensor]):
         return _offload(
@@ -205,6 +355,56 @@ def bpu_backend(
         _OUTER_INPUTS.reset(token)
 
 
+def _weights_are_guarded() -> bool:
+    """Does Dynamo guard on parameter *identity* for this compile?
+
+    It does when `is_parameter_freezing()` holds -- inductor's `config.freezing`
+    with grad disabled -- or when nn.Module inlining is off, which specializes on
+    the instance instead. Otherwise parameters are guarded only on shape and
+    dtype, so two instances of one architecture share a compiled graph.
+
+    That sharing is safe for a backend that keeps weights as runtime inputs, and
+    unsafe for this one: `_frozen_weights` bakes them into the .hbm, so a second
+    model would otherwise be executed with the first model's weights. When this
+    returns False the spliced call carries its weights as extra arguments and
+    checks them, so the result stays correct either way -- the difference is
+    whether a second model gets its own artifact or falls back to the CPU.
+    """
+    from torch._dynamo import config as dynamo_config
+
+    if not dynamo_config.inline_inbuilt_nn_modules:
+        return True
+    return torch._inductor.config.freezing and not torch.is_grad_enabled()
+
+
+def _subgraph_fallback(
+    gm: GraphModule, p: Partition, frozen: dict[str, torch.Tensor]
+) -> Callable[..., Any] | None:
+    """An eager callable for a partition, taking its weights as arguments.
+
+    Used when the artifact's baked-in weights do not match the ones actually
+    flowing through the graph. The compiled subgraph cannot serve here: it has
+    the original weights frozen in as attributes, which is exactly what is
+    wrong. Rebuilding without a frozen set gives a graph whose placeholders are
+    all of `p.inputs`, in that order -- real inputs first, then the weights the
+    caller passed as guards.
+    """
+    try:
+        sub = extract_subgraph(gm, p, None)
+    except Exception:  # noqa: BLE001 - a missing fallback is not fatal
+        return None
+    order = [n.name for n in p.inputs]
+    real = [n for n in order if n not in frozen]
+    guards = [n for n in order if n in frozen]
+    index = {name: i for i, name in enumerate(real + guards)}
+
+    def run(*args: torch.Tensor):
+        out = sub(*(args[index[name]] for name in order))
+        return out[0] if isinstance(out, (tuple, list)) and len(out) == 1 else out
+
+    return run
+
+
 def _offload(
     gm: GraphModule,
     example_inputs: list[torch.Tensor],
@@ -214,6 +414,12 @@ def _offload(
     act_scales: dict[str, float] | None = None,
 ) -> Callable[..., Any]:
     """Partition an aten graph and splice in BPU calls where possible."""
+    # Before partitioning, not just before export: a tuple-returning op both
+    # blocks its own partition and poisons the boundary of the next one, so
+    # rewriting it to the single-output form is what keeps a network like
+    # ResNet in one piece across its stem max-pool.
+    decompose(gm)
+
     partitions = partition_graph(gm, min_nodes=min_nodes)
 
     if not partitions:
@@ -245,22 +451,44 @@ def _offload(
         )
 
     compiled = 0
+    # Only worth guarding when Dynamo itself does not: with an identity guard in
+    # place a mismatch cannot reach us, so the extra arguments and comparison
+    # would be pure overhead on every call.
+    guard_weights = bool(frozen) and not _weights_are_guarded()
     # Splice in reverse so earlier partitions' node references stay valid.
     for i, p in reversed(list(enumerate(partitions))):
         ex = _example_inputs_for(p, example_inputs, gm, frozen)
         if ex is None:
-            log.warning("partition %d: dynamic shapes, keeping on CPU", i)
+            log.warning(
+                "partition %d: %s — keeping on CPU", i, _unsupported_input(p, frozen)
+            )
             continue
         try:
             sub = extract_subgraph(gm, p, frozen)
             hbm, ins, outs = compile_partition(sub, ex, act_scales=act_scales)
             rt = BPURuntime(str(hbm), ins, outs)
+            real_inputs = runtime_inputs(p, frozen)
+            call_inputs, guard_nodes, guard_vals = real_inputs, [], []
+            if guard_weights:
+                # The frozen weights are still nodes in the outer graph, so they
+                # can be passed alongside the real inputs and compared there.
+                guard_nodes = [n for n in p.inputs if n.name in frozen]
+                guard_vals = [frozen[n.name] for n in guard_nodes]
+                call_inputs = real_inputs + guard_nodes
             _splice(
                 gm,
                 p,
-                _BPUCall(rt, len(p.outputs)),
+                _BPUCall(
+                    rt,
+                    len(p.outputs),
+                    n_real=len(real_inputs) if guard_weights else None,
+                    frozen=guard_vals,
+                    fallback=_subgraph_fallback(gm, p, frozen)
+                    if guard_weights
+                    else None,
+                ),
                 f"_bpu_{i}",
-                runtime_inputs(p, frozen),
+                call_inputs,
             )
             compiled += 1
         except CompileError as e:

--- a/torch_fl/accelerator/bpu/compiler.py
+++ b/torch_fl/accelerator/bpu/compiler.py
@@ -217,7 +217,19 @@ def find_hbdk() -> str | None:
 
 
 def graph_key(gm: GraphModule, example_inputs: list[torch.Tensor], march: str) -> str:
-    """Stable hash over graph structure, input signature and target arch."""
+    """Stable hash over graph structure, weights, input signature and arch.
+
+    The weights have to be in the key. `backend._frozen_weights` bakes them into
+    the artifact as ONNX initializers, so two models with the same architecture
+    and different weights produce genuinely different .hbm files -- hashing only
+    the structure would make the second model silently reuse the first one's
+    artifact and return its answers.
+
+    Large tensors are sampled rather than hashed whole: a strided sample plus
+    shape, dtype and the exact byte count separates any two weight sets that
+    training would realistically produce, and keeps key computation off the
+    critical path for multi-megabyte parameters.
+    """
     h = hashlib.sha256()
     h.update(march.encode())
     for node in gm.graph.nodes:
@@ -225,9 +237,59 @@ def graph_key(gm: GraphModule, example_inputs: list[torch.Tensor], march: str) -
         val = node.meta.get("val")
         if isinstance(val, torch.Tensor):
             h.update(f"{tuple(val.shape)}:{val.dtype}".encode())
+    for name, t in sorted(_weight_tensors(gm)):
+        h.update(f"{name}:{tuple(t.shape)}:{t.dtype}:".encode())
+        h.update(_tensor_digest(t))
     for t in example_inputs:
         h.update(f"{tuple(t.shape)}:{t.dtype}".encode())
     return h.hexdigest()[:16]
+
+
+# Weight tensors larger than this are hashed from a strided sample instead of
+# every byte, bounding key cost for large models.
+_DIGEST_FULL_BYTES = 1 << 20
+_DIGEST_SAMPLES = 4096
+
+
+def _weight_tensors(gm: GraphModule) -> list[tuple[str, torch.Tensor]]:
+    """Every parameter, buffer and constant attribute reachable from `gm`."""
+    out: list[tuple[str, torch.Tensor]] = []
+    for name, t in gm.named_parameters():
+        out.append((name, t))
+    for name, t in gm.named_buffers():
+        out.append((name, t))
+    # get_attr targets that are plain tensor attributes rather than registered
+    # parameters/buffers -- freezing lifts constants this way.
+    for node in gm.graph.find_nodes(op="get_attr"):
+        target = str(node.target)
+        obj = gm
+        try:
+            for part in target.split("."):
+                obj = getattr(obj, part)
+        except AttributeError:
+            continue
+        if isinstance(obj, torch.Tensor):
+            out.append((target, obj))
+    return out
+
+
+def _tensor_digest(t: torch.Tensor) -> bytes:
+    """Content hash of a tensor, sampled if it is large."""
+    from torch._subclasses.fake_tensor import FakeTensor, unset_fake_temporarily
+
+    if isinstance(t, FakeTensor) or t.numel() == 0:
+        # A fake tensor has no data to hash; shape and dtype are already keyed.
+        return b"\x00"
+    # This runs inside the FakeTensorMode a Dynamo backend is invoked under, so
+    # even detach() on a real tensor asserts unless the mode is suspended.
+    with unset_fake_temporarily():
+        t = t.detach().reshape(-1)
+        if t.dtype.is_floating_point or t.dtype.is_complex:
+            t = t.float()
+        if t.numel() * t.element_size() > _DIGEST_FULL_BYTES:
+            step = max(1, t.numel() // _DIGEST_SAMPLES)
+            t = t[::step]
+        return hashlib.sha256(t.contiguous().cpu().numpy().tobytes()).digest()
 
 
 def export_onnx(
@@ -470,10 +532,13 @@ def compile_partition(
 
     key = graph_key(gm, example_inputs, march)
     # Float and int8 artifacts differ, and so do two int8 builds with different
-    # activation scales, so none of them may share a cache entry.
+    # activation scales or different versions of the Q/DQ pass, so none of them
+    # may share a cache entry.
     if QUANTIZE:
+        from .qdq import QDQ_VERSION
+
         qh = hashlib.sha256(repr(sorted((act_scales or {}).items())).encode())
-        qh.update(f"{ACT_SCALE}".encode())
+        qh.update(f"{ACT_SCALE}:v{QDQ_VERSION}".encode())
         key = f"{key}q{qh.hexdigest()[:8]}"
     hbm_path = cache / f"{key}.hbm"
     names_path = cache / f"{key}.names"

--- a/torch_fl/accelerator/bpu/decompose.py
+++ b/torch_fl/accelerator/bpu/decompose.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Rewrite aten ops that the ONNX exporter cannot handle.
+"""Rewrite aten ops that the ONNX exporter or the partitioner cannot handle.
 
 AOTAutograd emits functional aten variants that the TorchScript-based ONNX
-exporter has no symbolic function for. Each rewrite here preserves semantics
-exactly and only changes which overload the graph names.
+exporter has no symbolic function for, and multi-output variants whose extra
+results are training-only. Each rewrite here preserves semantics exactly and
+only changes which overload the graph names.
+
+The pass runs twice: once on the whole aten graph before partitioning, because
+a multi-output op splits a partition in two and its tuple cannot cross a
+boundary, and once on each extracted subgraph before export. It is idempotent.
 """
 
 from __future__ import annotations
@@ -30,6 +35,39 @@ from torch.fx import GraphModule
 log = logging.getLogger("torch_fl.bpu")
 
 _BN_NO_TRAINING = torch.ops.aten._native_batch_norm_legit_no_training.default
+_MAX_POOL_INDICES = torch.ops.aten.max_pool2d_with_indices.default
+_SOFTMAX = torch.ops.aten._softmax.default
+_UNSAFE_VIEW = torch.ops.aten._unsafe_view.default
+_T = torch.ops.aten.t.default
+
+
+def _only_uses_output(node, index: int) -> bool:
+    """Whether every user of `node` is `getitem(node, index)`."""
+    users = list(node.users)
+    if not users:
+        return False
+    return all(
+        u.op == "call_function"
+        and u.target is operator.getitem
+        and len(u.args) > 1
+        and u.args[1] == index
+        for u in users
+    )
+
+
+def _replace_tuple_op(gm: GraphModule, node, target, args) -> None:
+    """Swap a tuple-returning node for a single-output equivalent."""
+    with gm.graph.inserting_before(node):
+        new = gm.graph.call_function(target, args=args)
+    new.meta.update(node.meta)
+    val = node.meta.get("val")
+    if isinstance(val, (tuple, list)) and val:
+        new.meta["val"] = val[0]
+
+    for u in list(node.users):
+        u.replace_all_uses_with(new)
+        gm.graph.erase_node(u)
+    gm.graph.erase_node(node)
 
 
 def _rewrite_batch_norm(gm: GraphModule) -> int:
@@ -44,57 +82,128 @@ def _rewrite_batch_norm(gm: GraphModule) -> int:
         if node.op != "call_function" or node.target is not _BN_NO_TRAINING:
             continue
 
-        users = list(node.users)
         # Only the primary output may be used; save_mean/save_invstd are
         # training-only statistics and have no ONNX equivalent.
-        consumed = {
-            u.args[1]
-            for u in users
-            if u.op == "call_function" and u.target is operator.getitem
-        }
-        if any(
-            u.op != "call_function" or u.target is not operator.getitem for u in users
-        ) or not consumed <= {0}:
+        if not _only_uses_output(node, 0):
             log.debug("batch_norm %s: non-trivial users, left alone", node.name)
             continue
 
         inp, weight, bias, running_mean, running_var, momentum, eps = node.args
-
-        with gm.graph.inserting_before(node):
-            new = gm.graph.call_function(
-                torch.ops.aten.batch_norm.default,
-                args=(
-                    inp,
-                    weight,
-                    bias,
-                    running_mean,
-                    running_var,
-                    False,
-                    momentum,
-                    eps,
-                    True,
-                ),
-            )
-        new.meta.update(node.meta)
-        val = node.meta.get("val")
-        if isinstance(val, (tuple, list)) and val:
-            new.meta["val"] = val[0]
-
-        # Every user is getitem(node, 0); point them straight at `new`.
-        for u in users:
-            u.replace_all_uses_with(new)
-            gm.graph.erase_node(u)
-        gm.graph.erase_node(node)
+        _replace_tuple_op(
+            gm,
+            node,
+            torch.ops.aten.batch_norm.default,
+            (inp, weight, bias, running_mean, running_var, False, momentum, eps, True),
+        )
         changed += 1
 
     return changed
 
 
-def decompose_for_onnx(gm: GraphModule) -> GraphModule:
-    """Apply every rewrite needed before torch.onnx.export. Mutates in place."""
-    n = _rewrite_batch_norm(gm)
+def _rewrite_max_pool(gm: GraphModule) -> int:
+    """`max_pool2d_with_indices` -> `aten.max_pool2d`.
+
+    This is what Dynamo emits for `nn.MaxPool2d`, and it is the op that used to
+    cut ResNet in half. Two things go wrong with the tuple form. The partitioner
+    cannot include it (the BPU produces no indices tensor), so the graph splits
+    at the stem pool; and the pooled result then crosses the next partition's
+    boundary as a `getitem`, whose producer's `meta['val']` is a *tuple*, which
+    made `_example_inputs_for` reject that partition entirely -- reporting
+    "dynamic shapes" for a graph that has none.
+
+    The indices output only exists for max_unpool and the backward pass, so in
+    an inference graph it is dead. When it is genuinely used the node is left
+    alone and the old behaviour stands.
+    """
+    changed = 0
+    for node in list(gm.graph.nodes):
+        if node.op != "call_function" or node.target is not _MAX_POOL_INDICES:
+            continue
+        if not _only_uses_output(node, 0):
+            log.debug("max_pool2d %s: indices are used, left alone", node.name)
+            continue
+        _replace_tuple_op(gm, node, torch.ops.aten.max_pool2d.default, node.args)
+        changed += 1
+    return changed
+
+
+def _replace_1to1(gm: GraphModule, node, target, args) -> None:
+    """Swap a node for a single-output equivalent with the same value."""
+    with gm.graph.inserting_before(node):
+        new = gm.graph.call_function(target, args=args)
+    new.meta.update(node.meta)
+    node.replace_all_uses_with(new)
+    gm.graph.erase_node(node)
+
+
+def _rewrite_softmax(gm: GraphModule) -> int:
+    """`aten._softmax` -> `aten.softmax.int`.
+
+    The TorchScript ONNX exporter has a symbolic for `softmax` but none for the
+    private `_softmax`, which is what AOTAutograd actually emits -- so any
+    attention block failed to export with "Exporting the operator
+    'aten::_softmax' to ONNX opset version 17 is not supported".
+
+    The two differ only in the third argument: `_softmax(self, dim,
+    half_to_float)` upcasts a half input to float when the flag is set, which is
+    a training-time autocast concern. `softmax.int(self, dim, dtype)` expresses
+    the same thing as an explicit output dtype, so the flag maps to
+    dtype=float32 and False maps to dtype=None.
+    """
+    changed = 0
+    for node in list(gm.graph.nodes):
+        if node.op != "call_function" or node.target is not _SOFTMAX:
+            continue
+        self_, dim, half_to_float = node.args
+        dtype = torch.float32 if half_to_float else None
+        _replace_1to1(gm, node, torch.ops.aten.softmax.int, (self_, dim, dtype))
+        changed += 1
+    return changed
+
+
+def _rewrite_view_and_transpose(gm: GraphModule) -> int:
+    """Rewrite the shape ops AOTAutograd emits that the partitioner rejects.
+
+    `_unsafe_view` is `view` without the alias bookkeeping, emitted after a matmul;
+    `t` is `transpose(0, 1)` restricted to 2-D. Both are pure reshapes with
+    identical semantics to ops the BPU supports, and leaving them unsupported
+    shattered a transformer block into nine partitions -- each one too small to
+    pay for its own boundary copies.
+    """
+    changed = 0
+    for node in list(gm.graph.nodes):
+        if node.op != "call_function":
+            continue
+        if node.target is _UNSAFE_VIEW:
+            _replace_1to1(gm, node, torch.ops.aten.view.default, node.args)
+            changed += 1
+        elif node.target is _T:
+            val = node.meta.get("val")
+            # t() is the identity below 2-D; only the 2-D case is a transpose.
+            if isinstance(val, torch.Tensor) and val.dim() == 2:
+                _replace_1to1(
+                    gm, node, torch.ops.aten.transpose.int, (node.args[0], 0, 1)
+                )
+                changed += 1
+    return changed
+
+
+def decompose(gm: GraphModule) -> GraphModule:
+    """Apply every rewrite. Mutates in place and is safe to call twice."""
+    n = (
+        _rewrite_batch_norm(gm)
+        + _rewrite_max_pool(gm)
+        + _rewrite_softmax(gm)
+        + _rewrite_view_and_transpose(gm)
+    )
     if n:
-        log.debug("decompose: rewrote %d batch_norm node(s)", n)
+        log.debug("decompose: rewrote %d node(s)", n)
         gm.graph.lint()
         gm.recompile()
     return gm
+
+
+# The pass used to run only just before torch.onnx.export, which is why it was
+# named for it. It now also runs before partitioning; kept as an alias because
+# it is the spelling the tests and any out-of-tree caller use.
+decompose_for_onnx = decompose

--- a/torch_fl/accelerator/bpu/infer.py
+++ b/torch_fl/accelerator/bpu/infer.py
@@ -1,0 +1,648 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Direct hbDNNInferV2 binding with device-resident IO buffers.
+
+`runtime.BPURuntime` drives `hbm_runtime.run()`, which takes a dict of numpy
+arrays and copies every one of them into device memory on each call. For a CNN
+that is a 588 KB input and it does not matter. For an LLM decode step the KV
+cache is an *input*, 336 MiB of it for Qwen3-0.6B at 4096 context, and copying
+it per token costs more than the inference: measured **68.4 ms/token** against
+the vendor runtime's 11.42 ms.
+
+The vendor's own `libxlm.so` does not use that path either -- its undefined
+symbols are `hbDNNInferV2`/`V3` plus `hbUCPMallocCached`. This module takes the
+same approach: allocate every input and output once in UCP memory, let the
+caller write into the buffers in place, and pass pointers to the device.
+
+Two findings from bringing this up against the vendor's own Qwen3-0.6B artifact
+are load-bearing, because neither is documented and both cost 3-6x if missed:
+
+**`hbUCPReleaseTask` must not be called right after `hbUCPWaitTaskDone`.**
+Releasing inline costs **28 ms**; deferring it by a single step costs 1.65 ms
+and the step drops from 43.2 ms to 11.3 ms. A task handle cannot be resubmitted
+(`Task is already submitted or release, status 4`), so a task is built per step
+and released one step late -- see `_ReleaseRing`. Deferring without bound is not
+an option: the handle pool runs dry and `hbDNNInferV2` starts returning null
+handles, which shows up as an inference that silently does not run.
+
+**`HB_DNN_USER_DEFINED_L2M_SIZES` must be set before the first inference.**
+Unset, an LLM model fails with `L2 memory not enough ... user-assigned l2
+memspace size: [0, 0, 0, 0]` and `hbUCPWaitTaskDone` returns -200003. The
+vendor's `run_llm.sh` exports `6:6:6:6`; on this board 8:8:8:8 also fails, so
+6:6:6:6 is what `ensure_l2_config()` sets.
+
+A third is a correctness trap rather than a performance one: the KV cache is a
+**sliding window**, not a buffer you append into. Getting it wrong produces
+fluent, wrong text and no error at all. `KVWindow` documents the layout and how
+it was recovered -- by tracing the vendor's `hbDNNInferV2` calls.
+
+Measured on the vendor Qwen3-0.6B artifact, decode with a resident cache and
+the sliding window: **12.23 ms/token (81.8 tok/s)** against the vendor `llm`
+demo's 11.80 ms/token (84.8 tok/s), same .hbm, same four cores. Prefill on a
+full 512-token chunk runs at 6881 tok/s against the demo's 5626-7014.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import os
+
+import numpy as np
+
+log = logging.getLogger("torch_fl.bpu")
+
+MAX_DIMS = 10
+
+# hbDNNTensorType, in declaration order (hb_dnn.h).
+_TENSOR_TYPES = (
+    "S4",
+    "U4",
+    "S8",
+    "U8",
+    "F16",
+    "S16",
+    "U16",
+    "F32",
+    "S32",
+    "U32",
+    "F64",
+    "S64",
+    "U64",
+)
+_NP_OF_TYPE = {
+    "S8": np.int8,
+    "U8": np.uint8,
+    "F16": np.float16,
+    "S16": np.int16,
+    "U16": np.uint16,
+    "F32": np.float32,
+    "S32": np.int32,
+    "U32": np.uint32,
+    "F64": np.float64,
+    "S64": np.int64,
+    "U64": np.uint64,
+}
+
+_CORE_BIT = (1 << 0, 1 << 1, 1 << 2, 1 << 3)
+
+HB_SYS_MEM_CACHE_INVALIDATE = 1
+HB_SYS_MEM_CACHE_CLEAN = 2
+
+# What the vendor's run_llm.sh exports. 0:0:0:0 (the default) and 8:8:8:8 both
+# fail on this board with a -200003 from hbUCPWaitTaskDone.
+L2M_ENV = "HB_DNN_USER_DEFINED_L2M_SIZES"
+L2M_DEFAULT = "6:6:6:6"
+
+
+def ensure_l2_config(value: str = L2M_DEFAULT) -> None:
+    """Set the L2 memspace sizes an LLM artifact needs, if unset.
+
+    Must happen before the runtime library reads it, which is at first
+    inference. Setting it after that has no effect, so callers construct
+    `Package` only after this has run.
+    """
+    if not os.environ.get(L2M_ENV):
+        os.environ[L2M_ENV] = value
+        log.debug("%s not set; using %s", L2M_ENV, value)
+
+
+class hbUCPSysMem(ctypes.Structure):
+    _fields_ = [
+        ("phyAddr", ctypes.c_uint64),
+        ("virAddr", ctypes.c_void_p),
+        ("memSize", ctypes.c_uint64),
+    ]
+
+
+class hbDNNTensorShape(ctypes.Structure):
+    _fields_ = [
+        ("dimensionSize", ctypes.c_int32 * MAX_DIMS),
+        ("numDimensions", ctypes.c_int32),
+    ]
+
+
+class hbDNNQuantiScale(ctypes.Structure):
+    _fields_ = [
+        ("scaleLen", ctypes.c_int32),
+        ("scaleData", ctypes.POINTER(ctypes.c_float)),
+        ("zeroPointLen", ctypes.c_int32),
+        ("zeroPointData", ctypes.POINTER(ctypes.c_int32)),
+    ]
+
+
+class hbDNNTensorProperties(ctypes.Structure):
+    _fields_ = [
+        ("validShape", hbDNNTensorShape),
+        ("tensorType", ctypes.c_int32),
+        ("scale", hbDNNQuantiScale),
+        ("quantiType", ctypes.c_int32),
+        ("quantizeAxis", ctypes.c_int32),
+        ("alignedByteSize", ctypes.c_int64),
+        ("stride", ctypes.c_int64 * MAX_DIMS),
+    ]
+
+
+class hbDNNTensor(ctypes.Structure):
+    _fields_ = [
+        ("sysMem", hbUCPSysMem),
+        ("properties", hbDNNTensorProperties),
+    ]
+
+
+class hbUCPSchedParam(ctypes.Structure):
+    _fields_ = [
+        ("priority", ctypes.c_int32),
+        ("customId", ctypes.c_int64),
+        ("backend", ctypes.c_uint64),
+        ("deviceId", ctypes.c_uint32),
+    ]
+
+
+class InferError(RuntimeError):
+    """A libdnn/libhbucp call returned a non-zero status."""
+
+
+_LIB = None
+
+
+def _library() -> ctypes.CDLL:
+    """The first loadable library exporting hbDNNInferV2, cached."""
+    global _LIB
+    if _LIB is not None:
+        return _LIB
+    tried = []
+    for name in ("libhbucp.so", "libdnn.so", "libhbdnn.so", "libbpu.so"):
+        try:
+            lib = ctypes.CDLL(name, mode=ctypes.RTLD_GLOBAL)
+        except OSError as e:  # not installed, or a dependency is missing
+            tried.append(f"{name}: {e}")
+            continue
+        if hasattr(lib, "hbDNNInferV2"):
+            _LIB = lib
+            return lib
+        tried.append(f"{name}: no hbDNNInferV2")
+    raise InferError("no library exports hbDNNInferV2:\n  " + "\n  ".join(tried))
+
+
+_c_i32 = ctypes.c_int32
+_c_u64 = ctypes.c_uint64
+_c_vp = ctypes.c_void_p
+_c_cp = ctypes.c_char_p
+_P = ctypes.POINTER
+
+_FUNCS: dict[str, object] = {}
+
+
+def _fn(name: str, restype, *argtypes):
+    """Look up and memoize a C entry point with its signature applied."""
+    cached = _FUNCS.get(name)
+    if cached is not None:
+        return cached
+    f = getattr(_library(), name)
+    f.restype = restype
+    f.argtypes = list(argtypes)
+    _FUNCS[name] = f
+    return f
+
+
+def _check(rc: int, what: str) -> None:
+    if rc != 0:
+        raise InferError(f"{what} failed: rc={rc}")
+
+
+def _shape_of(props: hbDNNTensorProperties) -> tuple[int, ...]:
+    return tuple(
+        props.validShape.dimensionSize[i] for i in range(props.validShape.numDimensions)
+    )
+
+
+def _dtype_of(props: hbDNNTensorProperties):
+    idx = props.tensorType
+    name = _TENSOR_TYPES[idx] if 0 <= idx < len(_TENSOR_TYPES) else str(idx)
+    dt = _NP_OF_TYPE.get(name)
+    if dt is None:
+        raise InferError(f"tensor type {name} has no numpy equivalent")
+    return dt
+
+
+class DeviceBuffer:
+    """One UCP allocation, exposed as a numpy array over its host mapping.
+
+    `hbUCPMallocCached` memory is host-writable, so the array *is* the device
+    buffer. Writing to it and calling `clean()` is what a host-to-device copy
+    would otherwise do, minus the copy.
+    """
+
+    __slots__ = ("mem", "array", "nbytes")
+
+    def __init__(self, nbytes: int, dtype, shape, device: int = 0):
+        malloc = _fn("hbUCPMallocCached", _c_i32, _P(hbUCPSysMem), _c_u64, _c_i32)
+        self.mem = hbUCPSysMem()
+        _check(
+            malloc(ctypes.byref(self.mem), nbytes, device),
+            f"hbUCPMallocCached({nbytes} bytes)",
+        )
+        self.nbytes = nbytes
+        count = int(np.prod(shape)) if shape else 1
+        buf = (ctypes.c_uint8 * nbytes).from_address(self.mem.virAddr)
+        self.array = np.frombuffer(buf, dtype=dtype, count=count).reshape(shape)
+
+    def clean(self) -> None:
+        """Publish host writes so the device sees them."""
+        flush = _fn("hbUCPMemFlush", _c_i32, _P(hbUCPSysMem), _c_i32)
+        flush(ctypes.byref(self.mem), HB_SYS_MEM_CACHE_CLEAN)
+
+    def invalidate(self) -> None:
+        """Drop stale cache lines so host reads see what the device wrote."""
+        flush = _fn("hbUCPMemFlush", _c_i32, _P(hbUCPSysMem), _c_i32)
+        flush(ctypes.byref(self.mem), HB_SYS_MEM_CACHE_INVALIDATE)
+
+    def free(self) -> None:
+        if self.mem.virAddr:
+            _fn("hbUCPFree", _c_i32, _P(hbUCPSysMem))(ctypes.byref(self.mem))
+            self.mem.virAddr = None
+
+
+class _ReleaseRing:
+    """Holds task handles for `depth` steps before releasing them.
+
+    `hbUCPReleaseTask` immediately after `hbUCPWaitTaskDone` blocks for ~28 ms
+    on this board -- more than twice the inference itself. Released one step
+    later it costs 1.65 ms, and the decode step goes from 43.2 ms to 11.3 ms.
+
+    The ring must stay shallow. Handles are a finite pool, and once it is empty
+    `hbDNNInferV2` hands back a null handle instead of failing loudly, so the
+    step appears to run at triple speed while computing nothing. Depth 1 already
+    recovers the whole 28 ms, so there is no reason to go deeper.
+    """
+
+    __slots__ = ("_ring", "_depth", "_release")
+
+    def __init__(self, depth: int = 1):
+        self._ring: list = []
+        self._depth = max(1, depth)
+        self._release = _fn("hbUCPReleaseTask", _c_i32, _c_vp)
+
+    def push(self, task) -> None:
+        self._ring.append(task)
+        while len(self._ring) > self._depth:
+            self._release(self._ring.pop(0))
+
+    def drain(self) -> None:
+        while self._ring:
+            self._release(self._ring.pop(0))
+
+
+class Model:
+    """One model inside an .hbm, with its IO buffers resident on the device.
+
+    Buffers are allocated once. The caller writes inputs into `inputs[name]`
+    and reads `outputs[name]`; `infer()` moves no bulk data, which is the whole
+    point for an LLM whose KV cache is an input.
+    """
+
+    def __init__(self, handle, name: str, cores=(0, 1, 2, 3), release_depth: int = 1):
+        self.handle = handle
+        self.name = name
+        self.backend = 0
+        for c in cores:
+            if not 0 <= c < len(_CORE_BIT):
+                raise ValueError(f"BPU core {c} out of range")
+            self.backend |= _CORE_BIT[c]
+
+        n_in, n_out = _c_i32(), _c_i32()
+        _check(
+            _fn("hbDNNGetInputCount", _c_i32, _P(_c_i32), _c_vp)(
+                ctypes.byref(n_in), handle
+            ),
+            "hbDNNGetInputCount",
+        )
+        _check(
+            _fn("hbDNNGetOutputCount", _c_i32, _P(_c_i32), _c_vp)(
+                ctypes.byref(n_out), handle
+            ),
+            "hbDNNGetOutputCount",
+        )
+
+        self.input_names: list[str] = []
+        self.output_names: list[str] = []
+        self.inputs: dict[str, np.ndarray] = {}
+        self.outputs: dict[str, np.ndarray] = {}
+        self._in = (hbDNNTensor * n_in.value)()
+        self._out = (hbDNNTensor * n_out.value)()
+        self._in_bufs: list[DeviceBuffer] = []
+        self._out_bufs: list[DeviceBuffer] = []
+        self._index = {}
+        # Indices whose buffer has been handed over to a KVWindow; their own
+        # allocation is gone, so flush/invalidate must skip them.
+        self._skip_in: set[int] = set()
+        self._skip_out: set[int] = set()
+
+        self._bind(
+            n_in.value,
+            self._in,
+            self.input_names,
+            self.inputs,
+            self._in_bufs,
+            "hbDNNGetInputName",
+            "hbDNNGetInputTensorProperties",
+        )
+        self._bind(
+            n_out.value,
+            self._out,
+            self.output_names,
+            self.outputs,
+            self._out_bufs,
+            "hbDNNGetOutputName",
+            "hbDNNGetOutputTensorProperties",
+        )
+        self._index = {n: i for i, n in enumerate(self.input_names)}
+        self._oindex = {n: i for i, n in enumerate(self.output_names)}
+        self._ring = _ReleaseRing(release_depth)
+        self._sched = hbUCPSchedParam(
+            priority=0, customId=0, backend=self.backend, deviceId=0
+        )
+
+    def rebind(self, name: str, mem: hbUCPSysMem, output: bool = False) -> None:
+        """Point one tensor at `mem` instead of its own allocation.
+
+        Used by `KVWindow` to slide the cache: the descriptor moves, the data
+        does not. The buffer this displaces is dropped from the flush lists,
+        since its memory is no longer the one the device reads.
+        """
+        if output:
+            i = self._oindex[name]
+            self._out[i].sysMem = mem
+            self.outputs.pop(name, None)
+            self._skip_out.add(i)
+        else:
+            i = self._index[name]
+            self._in[i].sysMem = mem
+            self.inputs.pop(name, None)
+            self._skip_in.add(i)
+
+    def _bind(self, count, tensors, names, arrays, bufs, name_fn, props_fn) -> None:
+        get_name = _fn(name_fn, _c_i32, _P(_c_cp), _c_vp, _c_i32)
+        get_props = _fn(props_fn, _c_i32, _P(hbDNNTensorProperties), _c_vp, _c_i32)
+        for i in range(count):
+            nm = _c_cp()
+            _check(get_name(ctypes.byref(nm), self.handle, i), name_fn)
+            props = hbDNNTensorProperties()
+            _check(get_props(ctypes.byref(props), self.handle, i), props_fn)
+            key = nm.value.decode()
+            dtype = _dtype_of(props)
+            shape = _shape_of(props)
+            # alignedByteSize is what the device requires; the visible array
+            # covers only the valid shape, which can be smaller.
+            nbytes = max(
+                int(props.alignedByteSize),
+                int(np.prod(shape)) * np.dtype(dtype).itemsize,
+            )
+            buf = DeviceBuffer(nbytes, dtype, shape)
+            tensors[i].sysMem = buf.mem
+            tensors[i].properties = props
+            names.append(key)
+            arrays[key] = buf.array
+            bufs.append(buf)
+
+    def flush_inputs(self, names=None) -> None:
+        """Publish host writes for `names`, or for every input if None.
+
+        Passing the handful of small inputs that actually change per step keeps
+        this at ~0.01 ms; flushing all of them would walk the whole KV cache.
+        """
+        if names is None:
+            for i, b in enumerate(self._in_bufs):
+                if i not in self._skip_in:
+                    b.clean()
+            return
+        for n in names:
+            self._in_bufs[self._index[n]].clean()
+
+    def invalidate_outputs(self) -> None:
+        for i, b in enumerate(self._out_bufs):
+            if i not in self._skip_out:
+                b.invalidate()
+
+    def infer(self, timeout_ms: int = 20000) -> None:
+        """Run one inference over the resident buffers.
+
+        Raises rather than returning quietly when the handle pool is exhausted:
+        a null handle here means the step would compute nothing while appearing
+        to succeed.
+        """
+        infer_v2 = _fn(
+            "hbDNNInferV2", _c_i32, _P(_c_vp), _P(hbDNNTensor), _P(hbDNNTensor), _c_vp
+        )
+        submit = _fn("hbUCPSubmitTask", _c_i32, _c_vp, _P(hbUCPSchedParam))
+        wait = _fn("hbUCPWaitTaskDone", _c_i32, _c_vp, _c_i32)
+
+        task = _c_vp()
+        _check(
+            infer_v2(ctypes.byref(task), self._out, self._in, self.handle),
+            "hbDNNInferV2",
+        )
+        if not task.value:
+            raise InferError(
+                "hbDNNInferV2 returned a null task handle -- the pool is "
+                "exhausted; release depth is too deep"
+            )
+        rc = submit(task, ctypes.byref(self._sched))
+        if rc != 0:
+            self._ring.push(task)
+            raise InferError(f"hbUCPSubmitTask failed: rc={rc}")
+        rc = wait(task, timeout_ms)
+        self._ring.push(task)
+        _check(rc, "hbUCPWaitTaskDone")
+
+    def free(self) -> None:
+        self._ring.drain()
+        for b in (*self._in_bufs, *self._out_bufs):
+            b.free()
+        self._in_bufs.clear()
+        self._out_bufs.clear()
+
+
+class KVWindow:
+    """The KV cache as a sliding view over one allocation per layer.
+
+    An LLM graph takes `layer_i_cache_{key,value}` of `window` slots and emits
+    `layer_i_new_{key,value}` for the tokens it just consumed. The obvious
+    reading -- append the new K/V into the cache at the current position -- is
+    wrong, and produces fluent-looking garbage rather than an error.
+
+    What the vendor runtime actually does, visible by tracing `hbDNNInferV2`
+    through `LD_PRELOAD`, is move the pointer: `sysMem.virAddr` for the cache
+    advances by exactly one slot per decode step while the allocation stays
+    put, and the `new_key` output is bound one full window ahead, at
+    `cache_base + window * slot_bytes`. So a token's K/V is written once, by
+    the device, into the slot the next step will read as part of its window.
+    Nothing is ever copied.
+
+    The consequence for the mask is the part that cannot be guessed. Inside the
+    graph the attended keys are `concat(window[span:], new_keys)` for a step of
+    `span` tokens, so mask column `c` refers to window slot `c + span`, and the
+    last `span` columns are the tokens of the current step. With `pos` tokens
+    of history and row `r` of the current step:
+
+        open columns = [window - span - pos, window - span + r + 1)
+
+    which reproduces the traced prefill rows (`[3584, 3584+r+1)` at pos 0,
+    span 512) and decode (`[4071, 4096)` at pos 24, span 1) exactly. The mask
+    is additive: 0 attends, -65504 blocks. Uniform values are a no-op, which is
+    why an all-ones and an all-zeros mask return the same logits.
+
+    Capacity is `window + max_tokens` slots. Sliding past that runs off the end
+    of the allocation, so `advance()` refuses rather than corrupting memory.
+    """
+
+    __slots__ = ("layers", "window", "capacity", "pos", "_bufs", "_models")
+
+    def __init__(self, models, layers: int, window: int, max_tokens: int):
+        self.layers = layers
+        self.window = window
+        self.capacity = window + max_tokens
+        self.pos = 0
+        self._models = list(models)
+        self._bufs: list[tuple[DeviceBuffer, int, DeviceBuffer, int]] = []
+
+        probe = self._models[0]
+        for i in range(layers):
+            row = []
+            for kind in ("key", "value"):
+                a = probe.inputs[f"layer_{i}_cache_{kind}"]
+                slot = int(np.prod(a.shape[2:])) * a.dtype.itemsize
+                row += [
+                    DeviceBuffer(
+                        self.capacity * slot, np.uint8, (self.capacity * slot,)
+                    ),
+                    slot,
+                ]
+            self._bufs.append(tuple(row))
+
+        # The per-model cache/new allocations are now dead weight -- release
+        # them before rebinding, or the window doubles peak memory.
+        for m in self._models:
+            for i in range(layers):
+                for kind in ("key", "value"):
+                    m._in_bufs[m._index[f"layer_{i}_cache_{kind}"]].free()
+                    m._out_bufs[m._oindex[f"layer_{i}_new_{kind}"]].free()
+        self.reset()
+
+    def reset(self) -> None:
+        """Zero the whole allocation and rewind to position 0."""
+        self.pos = 0
+        for kb, _, vb, _ in self._bufs:
+            kb.array[:] = 0
+            vb.array[:] = 0
+            kb.clean()
+            vb.clean()
+        self.bind(self._models[0], 1)
+
+    def bind(self, model: Model, span: int) -> None:
+        """Point `model` at the window for a step consuming `span` tokens."""
+        if self.pos + self.window + span > self.capacity:
+            raise InferError(
+                f"KV window too small: a {span}-token step at position "
+                f"{self.pos} writes past a capacity of {self.capacity} slots; "
+                f"build the window with max_tokens >= {self.pos + span}"
+            )
+        for i, (kb, kslot, vb, vslot) in enumerate(self._bufs):
+            for buf, slot, kind in ((kb, kslot, "key"), (vb, vslot, "value")):
+                off = self.pos * slot
+                model.rebind(
+                    f"layer_{i}_cache_{kind}",
+                    hbUCPSysMem(
+                        phyAddr=buf.mem.phyAddr + off,
+                        virAddr=buf.mem.virAddr + off,
+                        memSize=self.window * slot,
+                    ),
+                )
+                out = off + self.window * slot
+                model.rebind(
+                    f"layer_{i}_new_{kind}",
+                    hbUCPSysMem(
+                        phyAddr=buf.mem.phyAddr + out,
+                        virAddr=buf.mem.virAddr + out,
+                        memSize=span * slot,
+                    ),
+                    output=True,
+                )
+
+    def advance(self, span: int) -> None:
+        if self.pos + span + self.window > self.capacity:
+            raise InferError(
+                f"KV window exhausted: {self.pos + span} tokens past a "
+                f"capacity of {self.capacity - self.window}"
+            )
+        self.pos += span
+
+    def mask_range(self, span: int, row: int = 0) -> tuple[int, int]:
+        """Half-open column range to leave open for `row` of the current step."""
+        return max(0, self.window - span - self.pos), self.window - span + row + 1
+
+    def free(self) -> None:
+        for kb, _, vb, _ in self._bufs:
+            kb.free()
+            vb.free()
+        self._bufs.clear()
+
+
+class Package:
+    """An .hbm file, which may hold several named models.
+
+    An LLM artifact holds two: `prefill` and `decode`, sharing one weight set.
+    """
+
+    def __init__(self, path: str):
+        ensure_l2_config()
+        init = _fn("hbDNNInitializeFromFiles", _c_i32, _P(_c_vp), _P(_c_cp), _c_i32)
+        names_fn = _fn(
+            "hbDNNGetModelNameList", _c_i32, _P(_P(_c_cp)), _P(_c_i32), _c_vp
+        )
+
+        self._packed = _c_vp()
+        files = (_c_cp * 1)(str(path).encode())
+        _check(
+            init(ctypes.byref(self._packed), files, 1),
+            f"hbDNNInitializeFromFiles({path})",
+        )
+        names = _P(_c_cp)()
+        count = _c_i32()
+        _check(
+            names_fn(ctypes.byref(names), ctypes.byref(count), self._packed),
+            "hbDNNGetModelNameList",
+        )
+        self.path = str(path)
+        self.model_names = [names[i].decode() for i in range(count.value)]
+
+    def model(self, name: str, cores=(0, 1, 2, 3), release_depth: int = 1) -> Model:
+        if name not in self.model_names:
+            raise KeyError(
+                f"{self.path} has no model {name!r}; available: {self.model_names}"
+            )
+        get_handle = _fn("hbDNNGetModelHandle", _c_i32, _P(_c_vp), _c_vp, _c_cp)
+        h = _c_vp()
+        _check(
+            get_handle(ctypes.byref(h), self._packed, name.encode()),
+            f"hbDNNGetModelHandle({name})",
+        )
+        return Model(h, name, cores, release_depth)
+
+    def release(self) -> None:
+        if self._packed:
+            _fn("hbDNNRelease", _c_i32, _c_vp)(self._packed)
+            self._packed = None

--- a/torch_fl/accelerator/bpu/partition.py
+++ b/torch_fl/accelerator/bpu/partition.py
@@ -78,9 +78,15 @@ _SUPPORTED: set[Callable | str] = {
     torch.ops.aten.contiguous.default,
     torch.ops.aten.squeeze.dim,
     torch.ops.aten.unsqueeze.default,
+    # `expand` is what AOTAutograd inserts ahead of a batched matmul to
+    # broadcast the operands; ONNX Expand covers it exactly. `_unsafe_view`
+    # and `t` are rewritten to `view`/`transpose` by decompose.py rather than
+    # listed here, because the exporter has no symbolic for either.
+    torch.ops.aten.expand.default,
     # misc
     torch.ops.aten.softmax.int,
-    torch.ops.aten._softmax.default,
+    # `_softmax` stays out: it has no ONNX symbolic. decompose.py rewrites it
+    # to softmax.int before this runs.
     torch.ops.aten.clone.default,
 }
 

--- a/torch_fl/accelerator/bpu/qdq.py
+++ b/torch_fl/accelerator/bpu/qdq.py
@@ -35,6 +35,23 @@ log = logging.getLogger("torch_fl.bpu")
 # anything else only adds rescale nodes without moving work onto the BPU.
 _QUANTIZABLE = {"Conv", "Gemm", "MatMul"}
 
+# Ops that carry no weights and do no arithmetic on values, but that hbdk4 still
+# refuses to put on the BPU while their input is f32 ("lower to cpu. P.S. The
+# type of hbir.max_pool's fin is f32, which should be si8, si16, f16 on bpu").
+#
+# They need the *input* quantized and nothing else. Without this the ResNet stem
+# max-pool was the one op in the whole network running on the CPU inside the
+# artifact, because the Q/DQ pair around the preceding conv dequantizes its
+# output back to float before the pool sees it.
+_QUANTIZE_INPUT_ONLY = {"MaxPool", "AveragePool", "GlobalAveragePool"}
+
+# Bumped whenever this pass changes which ops it rewrites or how. The .hbm cache
+# key mixes it in, because two runs of the same graph through different versions
+# of this pass produce different artifacts -- without it, adding MaxPool above
+# silently reused the artifact compiled before it, and the measurement showed no
+# change at all.
+QDQ_VERSION = 2
+
 
 def _sym_scale(arr: np.ndarray) -> float:
     m = float(np.abs(arr).max()) if arr.size else 0.0
@@ -104,6 +121,17 @@ def quantize_onnx(
     # Rewrite quantizable nodes in place, preserving graph order.
     quantized = 0
     for node in g.node:
+        if node.op_type in _QUANTIZE_INPUT_ONLY and node.input:
+            # No weights to fold; the input type is the whole problem.
+            act = node.input[0]
+            args = list(node.input)
+            args[0] = qdq_activation(act, act_scales.get(act, default_act_scale))
+            del node.input[:]
+            node.input.extend(args)
+            new_nodes.append(node)
+            quantized += 1
+            continue
+
         if node.op_type not in _QUANTIZABLE or len(node.input) < 2:
             new_nodes.append(node)
             continue

--- a/torch_fl/accelerator/bpu/runtime.py
+++ b/torch_fl/accelerator/bpu/runtime.py
@@ -195,8 +195,16 @@ class BPURuntime:
     def _from_device(
         self, name: str, arr: np.ndarray, device: torch.device | None = None
     ) -> torch.Tensor:
-        """Dequantize an output array back to a float tensor on `device`."""
-        out = arr.astype(np.float32)
+        """Dequantize an output array back to a float tensor on `device`.
+
+        The dequantization branch copies because it has arithmetic to do. The
+        float path does not: `run()` hands back a freshly allocated buffer on
+        every call rather than reusing one, so the array can be wrapped in place.
+        `asarray` rather than `astype` for the same reason as `_to_device` --
+        astype copies unconditionally, and on a 6 MB output that copy cost more
+        than a fifth of the whole inference.
+        """
+        out = np.asarray(arr, dtype=np.float32)
         scale = _scale_array(self._out_quants.get(name))
         if scale is not None and np.issubdtype(arr.dtype, np.integer):
             quant = self._out_quants[name]


### PR DESCRIPTION
Follows #69, which landed the backend. Three pieces of work on top.

Each is measured against **D-Robotics' own artifact for the same model**. Eager CPU only proves the offload happened, so it is not the bar — the vendor's number is.

## ResNet-18: 31.4 ms → 1.356 ms

| path | median | input |
| --- | ---: | --- |
| official `resnet18_224x224_nv12.hbm` | 1.075 ms | 74 KB NV12 uint8 |
| eager CPU float32 | 26.095 ms | 588 KB f32 NCHW |
| **ours, `torch.compile(backend="bpu")`** | **1.356 ms** | 588 KB f32 NCHW |

19.2× vs eager, 1.26× off the vendor while taking an 8× larger input. Cosine 0.990 vs eager float, top-1 agreement 5/5.

Two fixes, both about **coverage** rather than tuning:

- **A tuple-returning aten op does two kinds of damage, and fixing only the second leaves the model quietly on the CPU.** `max_pool2d_with_indices` can't join a partition, and its result then crosses the *next* partition's boundary as a `getitem` whose producer has a tuple `meta['val']` — so example inputs can't be materialized and the whole downstream partition is dropped. ResNet-18 was two partitions with the 84-node body rejected, running at **31.4 ms, slower than eager**. The log said "dynamic shapes", which was false. Running the rewrite *before partitioning*, not just before export, gives one 68-node partition at 3.24 ms.
- **2.63 ms → 1.36 ms** by quantizing the pooling op's *input*. `convert(advice=True)` named it exactly: `"The type of hbir.max_pool's fin is f32, which should be si8, si16, f16 on bpu."` Weight-free ops need only their input quantized. hbdk4 now reports **zero CPU fallbacks**: 21 `b30.conv2d`, 1 `b30.pool2d`.

## Qwen3-0.6B: 82.1 tok/s decode, 6881 tok/s prefill

| path | decode | prefill |
| --- | ---: | ---: |
| vendor `oellm_runtime` `llm` demo | 84.8 – 87.7 tok/s | 5626 – 7014 tok/s |
| **ours, `infer.Package`** | **82.1 tok/s** (12.18 ms/tok) | **6881 tok/s** |

Same `.hbm`, same four cores, same weights — only the caller differs. Prefill is quoted per 512-token chunk, which is what the graph computes regardless of prompt length.

`hbm_runtime.run()` copies every input on every call. For a decode step the KV cache *is* an input — 336 MiB at 4096 context — and copying it per token costs more than the inference: **68.4 ms/token against the vendor's 11.4**. `infer.py` allocates each tensor once in UCP memory and passes pointers, which is what the vendor's own `libxlm.so` does (its undefined symbols are `hbDNNInferV2`/`V3` plus `hbUCPMallocCached`).

Three undocumented details carry the rest. The per-call breakdown made the first unmissable — build task 0.05 ms, submit 3.36 ms, wait 10.73 ms, **release 28.03 ms**:

1. **`hbUCPReleaseTask` must not follow `hbUCPWaitTaskDone` immediately.** Deferred one step it costs 1.65 ms and the step drops 43.2 → 11.3 ms. Handles can't be resubmitted and the pool is finite, so `_ReleaseRing` keeps exactly one outstanding. Deeper and `hbDNNInferV2` returns *null handles* — which reads as a 3× speedup while computing nothing, so `infer()` raises on one.
2. **`HB_DNN_USER_DEFINED_L2M_SIZES` must be `6:6:6:6`** before the first inference. Unset gives `L2 memory not enough` and rc −200003; `8:8:8:8` also fails on this board.
3. **The KV cache is a sliding window over one allocation, not a buffer you append into.** `virAddr` advances one slot per decode step while the allocation stays put, and `new_key` is bound one full window ahead. Attended keys are `concat(window[span:], new_keys)`, so mask column `c` is window slot `c + span`, the last `span` columns are the step's own tokens, and the mask is **additive**.

### On how the layout was found

Black-box probing of the mask is ambiguous — opening a zero-key slot also perturbs the logits, so "did this column matter?" has no clean answer. I got the layout by `LD_PRELOAD`-ing a shim over `hbDNNInferV2` and reading what the vendor demo actually passes. That took about twenty minutes and settled it exactly.

Worth stating plainly: **every wrong layout runs at full speed and returns confident, fluent, wrong text.** No error, no NaN, sane logit magnitudes. `tests/unit/bpu/test_kv_window.py` pins the geometry to values transcribed from that trace, so a regression fails loudly instead of producing plausible prose.

## Artifact reuse fix

The compile cache keyed on graph structure but not on which model produced it, so two models sharing a shape returned each other's answers under Dynamo's default guards. Also drops a 0.44 ms output copy per inference.

## Scope

Additive and BPU-only — no shared, generated, or other-platform code is touched:

```
$ git diff flagos/main --numstat | grep -E "generated/|configs/backends_(cuda|flaggems|dcu|metax|musa|ascend|gcu)|CMakeLists|copy_ops|setup.py"
(empty)
```

Every deletion in the diff is inside a `torch_fl/accelerator/bpu/` file or a paragraph of the BPU docs.

## Testing

`96 passed, 1 skipped` (`tests/unit/bpu/`), ruff clean. Both benchmarks re-run on-board after rebasing onto current `main`.

## Not in this PR

LLM inference drives a **prebuilt vendor `.hbm`, not a `torch.compile` graph** — `infer.py` is the runtime half only. Compiling a transformer to one still needs `aten.slice.Tensor` in the supported set, an ONNX constant-folding pass (torch's `aten.expand` emits a `Shape→Equal→Where→Expand` chain hbdk4 can't shape-infer through), and mixed-precision Q/DQ (the vendor uses si16 K / si8 V / f16 mask+logits; `qdq.py` is si8-only). With folding alone `convert(advice=True)` already puts 54 of 66 ops on the BPU, and all 12 fallbacks report `"op is not completely quantized"` — the Q/DQ gap, not a hardware limit. `docs/bpu.md` records this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)