### PR TITLE
fix(tests): guard empty cuda default_generators in RNG multi-device test

### DIFF
--- a/tests/integration/ops/test_rng_dispatch.py
+++ b/tests/integration/ops/test_rng_dispatch.py
@@ -358,11 +358,23 @@ class TestRngMultiDevice:
     @pytest.mark.main_ops
     def test_each_device_has_its_own_generator(self):
         dev = self._second_device()
-        assert len(torch.cuda.default_generators) >= 2
+        # Same empty-backend guard as test_default_generators_populated above:
+        # a backend whose kernels seed from the default CPU generator
+        # (Ascend/aclnn) has no per-device CUDA generator to hold distinct, and
+        # `torch.cuda.default_generators` is legitimately empty there. Without
+        # this the `>= 2` assert below is `assert 0 >= 2` on every such backend,
+        # which contradicts the sibling test's stance within the same file.
+        gens = torch.cuda.default_generators
+        if len(gens) == 0:
+            pytest.skip(
+                "no CUDA generator on this backend; RNG kernels seed from the "
+                "default CPU generator instead (see torch_fl.flagos.default_generators)"
+            )
+        assert len(gens) >= 2
         # Same seed on both devices: the draws are allowed to coincide (identical
         # philox inputs), but the generators must be distinct objects, or seeding
         # one device would silently reset another.
-        assert torch.cuda.default_generators[0] is not torch.cuda.default_generators[1]
+        assert gens[0] is not gens[1]
         torch.manual_seed(SEED)
         d0 = torch.randn(64, device=DEVICE).cpu()
         torch.manual_seed(SEED)


### PR DESCRIPTION
## Problem

`.github/configs/ascend.yml` runs the RNG dispatch suite unfiltered:

```yaml
- name: Run Ascend RNG tests
  command: python -m pytest tests/integration/ops/test_rng_dispatch.py -m "main_ops" -v -s --tb=short
```

Exactly one case in that file fails on Ascend, which is enough to redden the whole pipeline:

```
TestRngMultiDevice::test_each_device_has_its_own_generator
E   assert 0 >= 2
E    where 0 = len(torch.cuda.default_generators)
```

## Root cause

The test hard-asserts the CUDA "one independent generator per device" model. The Ascend wheel is built against stock CPU torch (`torch.version.cuda is None`, asserted by the config's own device-availability step), and its aclnn RNG kernels seed from the **default CPU generator** — so `torch.cuda.default_generators` is legitimately an empty tuple there.

The sibling `TestRngSeedSource::test_default_generators_populated` **in the same file** already says exactly this in its comment and skips when the tuple is empty. The two tests took opposite stances on the same fact; this is a test-contract inconsistency, not a backend gap.

## Fix

Apply the sibling's guard to `test_each_device_has_its_own_generator`. Backends that do have per-device CUDA generators (cuda, metax, …) are unaffected — they still run the full `>= 2` and distinct-object assertions.

Nothing is faked and no CPU fallback is added. The multi-device RNG contract Ascend *does* implement stays covered by `test_reproducible_on_second_device[randn/normal_/randint/randperm]`, which pass on `flagos:1`.

## Verification (real 910, two visible cards, torch 2.10.0+cpu, CANN 9.0.0)

All three Ascend CI test steps, run as the config spells them:

| step | result |
|---|---|
| `test_rng_dispatch.py -m main_ops` | **102 passed, 4 skipped, 1 xpassed** (was 1 failed) |
| `tests/integration/ops/ -m ascend` | **38 passed** |
| `tests/integration/test_factory_ops.py` | **43 passed** |

The new skip prints the same reason string as its sibling:

```
SKIPPED [1] test_rng_dispatch.py:369: no CUDA generator on this backend; RNG kernels
seed from the default CPU generator instead (see torch_fl.flagos.default_generators)
```

`ruff 0.15.12`: `check` → All checks passed! · `format --check` → 149 files already formatted.

Fixes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
