### PR TITLE
[CICD] Add Hygon DCU wheel build and integration pipeline

### DIFF
--- a/.github/configs/dcu.yml
+++ b/.github/configs/dcu.yml
@@ -1,0 +1,88 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+display_name: Hygon DCU
+
+# Platform-specific preparation is implemented outside the common workflows.
+setup_script: .github/scripts/set_env_dcu.sh
+
+ci_image: harbor.baai.ac.cn/flagos-dev/flagos:ubuntu22.04-dtk26.04-py3.10
+
+runner_labels:
+  - hg-8g-cicd-pytorch
+
+container_volumes: []
+
+integration_environment: {}
+
+# DCU is non-NVIDIA: expose the /dev/kfd and /dev/dri device nodes through
+# --privileged (mirrors the MetaX layout) instead of --gpus all.
+container_options: >-
+  --privileged
+  --ipc=host
+  --shm-size=512g
+  --ulimit memlock=-1
+  --cap-add=SYS_PTRACE
+
+timeout_minutes: 60
+wheel_artifact_name: wheel-dcu
+# Keep DCU integration self-contained; transferring the bundled libtorch wheel
+# through the Actions artifact service can exceed the self-hosted runner job
+# timeout.
+integration_wheel_source: local-build
+
+# The common workflow only executes this platform-provided test manifest.
+# DCU is a boxing build (DTK torch is hipified, HIP kernels live under the CUDA
+# dispatch key), so the vendor backend path and the FlagGems runtime path
+# (backends_dcu_flaggems.conf, DTK triton hcu + cuda boxing fallback) mirror
+# CUDA's manifest. Inference/training are deferred until the runner has a model
+# mount and the first CI run confirms the card count.
+integration_tests:
+  - name: Check device availability
+    command: |
+      python - <<'PY'
+      from pathlib import Path
+
+      import torch_fl
+      import torch
+
+      torch_path = Path(torch.__file__).resolve()
+      package_lib = Path(torch_fl.__file__).resolve().parent / "lib"
+
+      assert torch.version.cuda is None, torch.version.cuda
+      assert "/opt/conda/" not in str(torch_path), torch_path
+      assert (package_lib / "libtorch_fl.so").is_file(), package_lib
+      assert torch_fl.flagos.is_available(), "flagos device is unavailable"
+      assert torch_fl.flagos.device_count() > 0, torch_fl.flagos.device_count()
+      print(f"CPU PyTorch: {torch.__version__}")
+      print(f"torch path: {torch_path}")
+      print(f"DCU assets: {package_lib}")
+      print(f"flagos devices: {torch_fl.flagos.device_count()}")
+      PY
+  - name: Run operator tests (vendor backend, main ops)
+    command: >-
+      python -m pytest tests/integration/ops/
+      -m "main_ops and not flaggems_python and not flaggems_cpp"
+      -v -s --tb=short
+  - name: Run operator tests (FlagGems runtime path, main ops)
+    command: >-
+      FLAGOS_USE_FLAGGEMS=1
+      python -m pytest tests/integration/ops/
+      -m "flaggems and main_ops" -v -s --tb=short
+  - name: Run general tests
+    command: python -m pytest tests/integration/test_factory_ops.py -v -s --tb=short
+  - name: Profiler parity test
+    command: >-
+      python -m pytest tests/integration/test_profiler_parity.py
+      -v -m main_ops --tb=short

--- a/.github/configs/dcu.yml
+++ b/.github/configs/dcu.yml
@@ -17,12 +17,23 @@ display_name: Hygon DCU
 # Platform-specific preparation is implemented outside the common workflows.
 setup_script: .github/scripts/set_env_dcu.sh
 
-ci_image: harbor.baai.ac.cn/flagos-dev/flagos:ubuntu22.04-dtk26.04-py3.10
+# Pinned CI image: the base flagos image plus python3.10-venv and patchelf
+# (set_env_dcu.sh needs both; the base image ships neither). Built locally on
+# a DCU host from Dockerfile.dcu-fix and pushed to harbor as manual-<date>-dcu.
+ci_image: harbor.baai.ac.cn/flagos-dev/pytorch-plugin-fl:manual-20260810-dcu-dev
 
 runner_labels:
   - hg-8g-cicd-pytorch
 
-container_volumes: []
+# Bind-mount the host hyhal driver into the container. libhydmi.so (Hygon DMI
+# device management) and its sibling driver libs live here on the host, not in
+# the flagos image; set_env_dcu.sh probes /usr/local/hyhal/lib and prepends it
+# to LD_LIBRARY_PATH so flagos device init can dlopen libhydmi.so. Mount the
+# real path /usr/local/hyhal (not the /opt/hyhal symlink) -- docker does not
+# follow a symlink bind source. The runner host installs hyhal at the same
+# standard layout as any DCU box, so the source path is portable across hosts.
+container_volumes:
+  - /usr/local/hyhal:/usr/local/hyhal:ro
 
 integration_environment: {}
 

--- a/.github/scripts/set_env_dcu.sh
+++ b/.github/scripts/set_env_dcu.sh
@@ -190,7 +190,10 @@ if [[ ! -x "$VENV_PYTHON" ]]; then
   exit 1
 fi
 
-"$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake
+# patchelf is required by setup.py (rewrites _C.so RPATH to $ORIGIN/lib and
+# $ORIGIN/lib_dcu after copy) and by bundle_dcu_libtorch.sh (sets RPATH on the
+# bundled DTK .so). The flagos DCU image does not ship it, unlike the CUDA image.
+"$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake patchelf
 "$VENV_PYTHON" -m pip install \
   --index-url "$CPU_TORCH_INDEX_URL" \
   "torch==$CPU_TORCH_VERSION"

--- a/.github/scripts/set_env_dcu.sh
+++ b/.github/scripts/set_env_dcu.sh
@@ -26,14 +26,42 @@ esac
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CPU_TORCH_INDEX_URL="${TORCH_FL_CPU_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}"
 
-# Source DTK's env.sh first. The DTK torch wheel imports librocm_smi64.so.2
-# and other DTK driver libs that live under $DTK_ROOT/.hyhal/rocm_smi/lib, so
-# the vendor torch can only be imported after env.sh extends LD_LIBRARY_PATH.
-DTK_ROOT="${DTK_ROOT:-/opt/dtk-26.04}"
-if [[ ! -f "$DTK_ROOT/env.sh" ]]; then
-  echo "::error::DTK env.sh not found at $DTK_ROOT/env.sh"
+# Locate the DTK install root. The image may ship DTK under /opt/dtk,
+# /opt/dtk-26.04, or a versioned directory; honor an explicit DTK_ROOT or
+# ROCM_PATH, then probe common roots, then fall back to a filesystem search.
+discover_dtk_root() {
+  local candidate
+  local -a candidates=(
+    "${DTK_ROOT:-}"
+    "${ROCM_PATH:-}"
+    "/opt/dtk"
+    "/opt/dtk-26.04"
+    "/opt/dtk26.04"
+    "/opt/dtk-26.04.4"
+    "/opt/dtk-25.04.4"
+  )
+  for candidate in "${candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ -f "$candidate/env.sh" ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  local found
+  found="$(find /opt /usr/local -maxdepth 3 -type f -name env.sh \
+    \( -path '*dtk*' -o -path '*rocm*' \) -print -quit 2>/dev/null | head -n1)"
+  if [[ -n "$found" ]]; then
+    printf '%s' "$(dirname "$found")"
+    return 0
+  fi
+  return 1
+}
+
+if ! DTK_ROOT="$(discover_dtk_root)"; then
+  echo "::error::DTK env.sh not found under /opt or /usr/local; set DTK_ROOT explicitly"
   exit 1
 fi
+echo "DTK_ROOT discovered: $DTK_ROOT"
 set +u
 # shellcheck disable=SC1091
 source "$DTK_ROOT/env.sh"

--- a/.github/scripts/set_env_dcu.sh
+++ b/.github/scripts/set_env_dcu.sh
@@ -198,7 +198,9 @@ fi
   --index-url "$CPU_TORCH_INDEX_URL" \
   "torch==$CPU_TORCH_VERSION"
 if [[ "$CI_STAGE" == "integration" ]]; then
-  "$VENV_PYTHON" -m pip install pytest transformers
+  # Pin numpy<2: the CPU torch wheel is built against the NumPy 1.x ABI, and
+  # transformers pulls numpy 2.x which breaks torch's C extensions at import.
+  "$VENV_PYTHON" -m pip install pytest transformers "numpy<2"
 fi
 
 # Carry the vendor FlagGems/FlagCX Python packages into the venv so the DTK

--- a/.github/scripts/set_env_dcu.sh
+++ b/.github/scripts/set_env_dcu.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+case "${CI_STAGE:-}" in
+  build|integration) ;;
+  *)
+    echo "::error::CI_STAGE must be either 'build' or 'integration'"
+    exit 1
+    ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CPU_TORCH_INDEX_URL="${TORCH_FL_CPU_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}"
+
+# Source DTK's env.sh first. The DTK torch wheel imports librocm_smi64.so.2
+# and other DTK driver libs that live under $DTK_ROOT/.hyhal/rocm_smi/lib, so
+# the vendor torch can only be imported after env.sh extends LD_LIBRARY_PATH.
+DTK_ROOT="${DTK_ROOT:-/opt/dtk-26.04}"
+if [[ ! -f "$DTK_ROOT/env.sh" ]]; then
+  echo "::error::DTK env.sh not found at $DTK_ROOT/env.sh"
+  exit 1
+fi
+set +u
+# shellcheck disable=SC1091
+source "$DTK_ROOT/env.sh"
+set -u
+export DTK_ROOT
+export ROCM_PATH="${ROCM_PATH:-$DTK_ROOT}"
+
+select_vendor_python() {
+  local candidate="${TORCH_FL_VENDOR_PYTHON:-}"
+  if [[ -n "$candidate" && "$candidate" != */* ]]; then
+    candidate="$(command -v "$candidate" 2>/dev/null || true)"
+  fi
+  if [[ -z "$candidate" ]]; then
+    candidate="$(command -v python 2>/dev/null || true)"
+  fi
+  if [[ -z "$candidate" || ! -x "$candidate" ]]; then
+    echo "::error::Unable to find the vendor Python interpreter" >&2
+    exit 1
+  fi
+  if ! "$candidate" -c "import torch" >/dev/null 2>&1; then
+    echo "::error::Vendor Python cannot import torch: $candidate (was DTK env.sh sourced?)" >&2
+    exit 1
+  fi
+  printf '%s' "$candidate"
+}
+
+VENDOR_PYTHON="$(select_vendor_python)"
+VENDOR_INFO="$("$VENDOR_PYTHON" - <<'PY'
+import json
+from pathlib import Path
+import site
+import sys
+
+import torch
+
+print(json.dumps({
+    "version": torch.__version__,
+    "base_version": torch.__version__.split("+", 1)[0],
+    "root": str(Path(torch.__file__).resolve().parent),
+    "site": site.getsitepackages()[0],
+    "python": sys.version.split()[0],
+}, sort_keys=True))
+PY
+)"
+
+readarray -t VENDOR_FIELDS < <(
+  VENDOR_INFO="$VENDOR_INFO" "$VENDOR_PYTHON" - <<'PY'
+import json
+import os
+
+info = json.loads(os.environ["VENDOR_INFO"])
+for key in ("version", "base_version", "root", "site", "python"):
+    print(info.get(key) or "")
+PY
+)
+VENDOR_TORCH_VERSION="${VENDOR_FIELDS[0]}"
+VENDOR_TORCH_BASE_VERSION="${VENDOR_FIELDS[1]}"
+VENDOR_TORCH_ROOT="${VENDOR_FIELDS[2]}"
+VENDOR_SITE="${VENDOR_FIELDS[3]}"
+VENDOR_PYTHON_VERSION="${VENDOR_FIELDS[4]}"
+VENDOR_TORCH_LIB="$VENDOR_TORCH_ROOT/lib"
+
+# DCU is a boxing build: the DTK torch wheel is a hipified build whose HIP
+# kernels are registered under the CUDA dispatch key, so torch_fl reaches them
+# via PrivateUse1->CUDA boxing kernels without shipping its own kernels.
+# libtorch_hip.so is the DTK analogue of CUDA's libtorch_cuda.so; the bundle
+# script stages it (plus the core .so) into torch_fl/lib_dcu for a
+# self-contained wheel.
+if [[ ! -f "$VENDOR_TORCH_LIB/libtorch_hip.so" ]]; then
+  echo "::error::$VENDOR_TORCH_LIB has no libtorch_hip.so, not a DTK torch/lib" >&2
+  exit 1
+fi
+export FLAGOS_DCU_TORCH_LIB="$VENDOR_TORCH_LIB"
+
+# CPU torch base version must match the vendor's for ABI compatibility. DTK
+# 26.04 ships torch 2.9.0+das (unlike CUDA/MetaX images on 2.10.0), so derive
+# the target from the vendor wheel instead of hard-coding it.
+CPU_TORCH_VERSION="${TORCH_FL_CPU_TORCH_VERSION:-$VENDOR_TORCH_BASE_VERSION}"
+
+# FlagGems C++ package is optional for DCU (FLAGGEMS_KERNEL=OFF in setup.py);
+# the flaggems runtime path uses the DTK triton hcu backend + Python flag_gems.
+# Probe it for CMAKE_PREFIX_PATH but never fail when absent.
+VENDOR_FLAGGEMS_DIR="$("$VENDOR_PYTHON" - <<'PY'
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.find_spec("flag_gems")
+if spec is None or not spec.submodule_search_locations:
+    print("")
+else:
+    root = Path(next(iter(spec.submodule_search_locations))).resolve()
+    candidate = root / "lib" / "cmake" / "FlagGems"
+    print(candidate if (candidate / "FlagGemsConfig.cmake").is_file() else "")
+PY
+)"
+VENDOR_FLAGGEMS_LIB=""
+if [[ -n "$VENDOR_FLAGGEMS_DIR" ]]; then
+  VENDOR_FLAGGEMS_LIB="$(cd "$VENDOR_FLAGGEMS_DIR/../.." && pwd)"
+  if ! compgen -G "$VENDOR_FLAGGEMS_LIB/liboperators.so*" >/dev/null; then
+    echo "::notice::FlagGems C++ liboperators.so not found under $VENDOR_FLAGGEMS_LIB (optional for DCU)"
+    VENDOR_FLAGGEMS_LIB=""
+  fi
+else
+  echo "::notice::FlagGems C++ package not found in vendor image (optional for DCU)"
+fi
+
+echo "Vendor Python: $VENDOR_PYTHON ($VENDOR_PYTHON_VERSION)"
+echo "Vendor PyTorch: $VENDOR_TORCH_VERSION (base $VENDOR_TORCH_BASE_VERSION)"
+echo "Vendor torch root: $VENDOR_TORCH_ROOT"
+echo "CPU torch target: $CPU_TORCH_VERSION+cpu"
+
+# Isolated venv with the matching CPU-only torch wheel. Unlike CUDA, DCU does
+# not stage libtorch_cuda.so into .libtorch_cuda_assets; the DTK forked libtorch
+# .so are bundled into torch_fl/lib_dcu by bundle_dcu_libtorch.sh below.
+VENV_ROOT="${TORCH_FL_VENV_ROOT:-${RUNNER_TEMP:-$REPO_ROOT/.ci}/torch-fl-dcu-${CI_STAGE}}"
+if ! "$VENDOR_PYTHON" -m venv --clear "$VENV_ROOT"; then
+  echo "::warning::Vendor Python cannot create a venv; trying uv"
+  if ! command -v uv >/dev/null 2>&1; then
+    "$VENDOR_PYTHON" -m pip install --upgrade uv
+  fi
+  uv venv --clear --seed --python "$VENDOR_PYTHON" "$VENV_ROOT"
+fi
+VENV_PYTHON="$VENV_ROOT/bin/python"
+if [[ ! -x "$VENV_PYTHON" ]]; then
+  echo "::error::Isolated Python was not created at $VENV_ROOT"
+  exit 1
+fi
+
+"$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake
+"$VENV_PYTHON" -m pip install \
+  --index-url "$CPU_TORCH_INDEX_URL" \
+  "torch==$CPU_TORCH_VERSION"
+if [[ "$CI_STAGE" == "integration" ]]; then
+  "$VENV_PYTHON" -m pip install pytest transformers
+fi
+
+# Carry the vendor FlagGems/FlagCX Python packages into the venv so the DTK
+# triton (hcu backend) and flag_gems runtime path work under the CPU torch.
+VENV_SITE="$("$VENV_PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+for package in flag_gems triton triton_kernels flagcx sqlalchemy; do
+  if [[ -d "$VENDOR_SITE/$package" ]]; then
+    cp -a "$VENDOR_SITE/$package" "$VENV_SITE/"
+  fi
+  for metadata in "$VENDOR_SITE"/"$package"-*.dist-info; do
+    [[ -e "$metadata" ]] || continue
+    cp -a "$metadata" "$VENV_SITE/"
+  done
+done
+
+CPU_TORCH_ROOT="$(CPU_TORCH_VERSION="$CPU_TORCH_VERSION" "$VENV_PYTHON" - <<'PY'
+import os
+from pathlib import Path
+import torch
+
+print(Path(torch.__file__).resolve().parent)
+assert torch.__version__.split("+", 1)[0] == os.environ["CPU_TORCH_VERSION"], torch.__version__
+assert torch.version.cuda is None, torch.version.cuda
+PY
+)"
+
+strip_vendor_paths() {
+  local value="${1:-}"
+  local entry
+  local -a entries=()
+  local -a kept=()
+  IFS=: read -ra entries <<< "$value"
+  for entry in "${entries[@]}"; do
+    [[ -z "$entry" ]] && continue
+    case "$entry" in
+      "$VENDOR_TORCH_ROOT"|"$VENDOR_TORCH_ROOT"/*) ;;
+      *) kept+=("$entry") ;;
+    esac
+  done
+  local joined=""
+  for entry in "${kept[@]}"; do
+    joined="${joined:+$joined:}$entry"
+  done
+  printf '%s' "$joined"
+}
+
+export VIRTUAL_ENV="$VENV_ROOT"
+export PATH="$VENV_ROOT/bin:$PATH"
+export PYTHONNOUSERSITE=1
+export PYTHONPATH=""
+export ACCELERATOR=dcu
+export FLAGGEMS_DIR="$VENDOR_FLAGGEMS_DIR"
+export FLAGCX_PATH="${FLAGCX_PATH:-/opt/FlagCX}"
+
+CLEAN_CMAKE_PREFIX_PATH="$(strip_vendor_paths "${CMAKE_PREFIX_PATH:-}")"
+CLEAN_LIBRARY_PATH="$(strip_vendor_paths "${LIBRARY_PATH:-}")"
+CLEAN_LD_LIBRARY_PATH="$(strip_vendor_paths "${LD_LIBRARY_PATH:-}")"
+export CMAKE_PREFIX_PATH="$CPU_TORCH_ROOT/share/cmake${VENDOR_FLAGGEMS_DIR:+:$VENDOR_FLAGGEMS_DIR}${CLEAN_CMAKE_PREFIX_PATH:+:$CLEAN_CMAKE_PREFIX_PATH}"
+export LIBRARY_PATH="$CPU_TORCH_ROOT/lib${VENDOR_FLAGGEMS_LIB:+:$VENDOR_FLAGGEMS_LIB}${CLEAN_LIBRARY_PATH:+:$CLEAN_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="$CPU_TORCH_ROOT/lib${VENDOR_FLAGGEMS_LIB:+:$VENDOR_FLAGGEMS_LIB}${CLEAN_LD_LIBRARY_PATH:+:$CLEAN_LD_LIBRARY_PATH}"
+
+cd "$REPO_ROOT"
+if [[ "$CI_STAGE" == "build" || "$CI_STAGE" == "integration" ]]; then
+  # Prebuild so package_data sees libtorch_fl.so before python -m build.
+  python setup.py build_ext --inplace
+fi
+
+# Bundle DTK's forked libtorch core + HIP .so into torch_fl/lib_dcu for a
+# self-contained wheel (replaces CUDA's .libtorch_cuda_assets staging step).
+DTK_ROOT="$DTK_ROOT" FLAGOS_DCU_TORCH_LIB="$FLAGOS_DCU_TORCH_LIB" \
+  bash scripts/bundle_dcu_libtorch.sh
+
+if ! command -v rocm-smi >/dev/null 2>&1; then
+  echo "::error::rocm-smi is unavailable"
+  exit 1
+fi
+rocm-smi
+
+python - <<'PY'
+import os
+from pathlib import Path
+import sys
+import torch
+
+torch_path = Path(torch.__file__).resolve()
+assert sys.executable.startswith("/"), sys.executable
+assert torch.version.cuda is None, torch.version.cuda
+assert "/opt/conda/" not in str(torch_path), torch_path
+assert Path("torch_fl/lib/libtorch_fl.so").is_file()
+print(f"Isolated Python: {sys.executable}")
+print(f"CPU PyTorch: {torch.__version__}")
+print(f"CPU torch path: {torch_path}")
+print(f"DCU torch lib: {os.environ.get('FLAGOS_DCU_TORCH_LIB', '?')}")
+PY
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  printf '%s\n' "$VENV_ROOT/bin" >> "$GITHUB_PATH"
+fi
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  for name in \
+    PATH VIRTUAL_ENV PYTHONNOUSERSITE PYTHONPATH ACCELERATOR DTK_ROOT ROCM_PATH \
+    FLAGOS_DCU_TORCH_LIB FLAGGEMS_DIR FLAGCX_PATH \
+    CMAKE_PREFIX_PATH LIBRARY_PATH LD_LIBRARY_PATH; do
+    printf '%s=%s\n' "$name" "${!name}" >> "$GITHUB_ENV"
+  done
+fi

--- a/.github/scripts/set_env_dcu.sh
+++ b/.github/scripts/set_env_dcu.sh
@@ -136,9 +136,10 @@ if [[ ! -f "$VENDOR_TORCH_LIB/libtorch_hip.so" ]]; then
 fi
 export FLAGOS_DCU_TORCH_LIB="$VENDOR_TORCH_LIB"
 
-# CPU torch base version must match the vendor's for ABI compatibility. DTK
-# 26.04 ships torch 2.9.0+das (unlike CUDA/MetaX images on 2.10.0), so derive
-# the target from the vendor wheel instead of hard-coding it.
+# CPU torch base version must match the vendor's for ABI compatibility. The
+# DTK wheel version (e.g. 2.10.0+das on the current CI image) may differ across
+# DTK releases and from the CUDA/MetaX images, so derive the target from the
+# vendor wheel instead of hard-coding it.
 CPU_TORCH_VERSION="${TORCH_FL_CPU_TORCH_VERSION:-$VENDOR_TORCH_BASE_VERSION}"
 
 # FlagGems C++ package is optional for DCU (FLAGGEMS_KERNEL=OFF in setup.py);
@@ -192,7 +193,8 @@ fi
 
 # patchelf is required by setup.py (rewrites _C.so RPATH to $ORIGIN/lib and
 # $ORIGIN/lib_dcu after copy) and by bundle_dcu_libtorch.sh (sets RPATH on the
-# bundled DTK .so). The flagos DCU image does not ship it, unlike the CUDA image.
+# bundled DTK .so). The pinned CI image ships it at /usr/bin/patchelf; the pip
+# install here is a redundant fallback in case the image lacks it.
 "$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake patchelf
 "$VENV_PYTHON" -m pip install \
   --index-url "$CPU_TORCH_INDEX_URL" \
@@ -252,15 +254,48 @@ export PATH="$VENV_ROOT/bin:$PATH"
 export PYTHONNOUSERSITE=1
 export PYTHONPATH=""
 export ACCELERATOR=dcu
+# DTK's Triton (hcu backend) is copied into the venv without its dist-info
+# (the vendor image ships none), so Triton's entry-point backend discovery
+# finds nothing and the hcu backend never loads. Force in-tree loading so the
+# backend under triton/backends is used -- required for the FlagGems runtime
+# path (integration [3/5]). See README "Enabling FlagGems on DCU".
+export TRITON_BACKENDS_IN_TREE=1
 export FLAGGEMS_DIR="$VENDOR_FLAGGEMS_DIR"
 export FLAGCX_PATH="${FLAGCX_PATH:-/opt/FlagCX}"
 
 CLEAN_CMAKE_PREFIX_PATH="$(strip_vendor_paths "${CMAKE_PREFIX_PATH:-}")"
 CLEAN_LIBRARY_PATH="$(strip_vendor_paths "${LIBRARY_PATH:-}")"
 CLEAN_LD_LIBRARY_PATH="$(strip_vendor_paths "${LD_LIBRARY_PATH:-}")"
+
+# libhydmi.so (Hygon DMI device management) ships in the host hyhal driver,
+# which dcu.yml bind-mounts into the container at the standard hyhal root.
+# DTK's env.sh does not add it to the search path, so flagos device init's
+# dlopen(libhydmi.so) fails with "cannot open shared object file". Probe the
+# standard roots (honoring an explicit HYHAL_ROOT) and prepend them so the
+# loader finds libhydmi.so plus its sibling driver libs (libhydrm, libamd_smi).
+HYHAL_LD_PATH=""
+for hyhal_root in "${HYHAL_ROOT:-}" /usr/local/hyhal /opt/hyhal; do
+  [[ -z "$hyhal_root" ]] && continue
+  [[ -d "$hyhal_root/lib" ]] || continue
+  HYHAL_LD_PATH="${HYHAL_LD_PATH:+$HYHAL_LD_PATH:}$hyhal_root/lib"
+done
+# Recreate the host's /opt/hyhal -> /usr/local/hyhal symlink inside the
+# container (the flagos image lacks it). dlopen(libhydmi.so) goes through
+# LD_LIBRARY_PATH above, but sibling hyhal libs or host code may resolve .so
+# by absolute /opt/hyhal/... paths; mirror the host layout so those resolve.
+if [[ -d /usr/local/hyhal && ! -e /opt/hyhal ]]; then
+  ln -sf /usr/local/hyhal /opt/hyhal 2>/dev/null || \
+    echo "::warning::failed to create /opt/hyhal -> /usr/local/hyhal symlink"
+fi
+if [[ -n "$HYHAL_LD_PATH" ]]; then
+  echo "hyhal lib path: $HYHAL_LD_PATH"
+else
+  echo "::warning::No hyhal/lib found; flagos device init may fail to dlopen libhydmi.so"
+fi
+
 export CMAKE_PREFIX_PATH="$CPU_TORCH_ROOT/share/cmake${VENDOR_FLAGGEMS_DIR:+:$VENDOR_FLAGGEMS_DIR}${CLEAN_CMAKE_PREFIX_PATH:+:$CLEAN_CMAKE_PREFIX_PATH}"
-export LIBRARY_PATH="$CPU_TORCH_ROOT/lib${VENDOR_FLAGGEMS_LIB:+:$VENDOR_FLAGGEMS_LIB}${CLEAN_LIBRARY_PATH:+:$CLEAN_LIBRARY_PATH}"
-export LD_LIBRARY_PATH="$CPU_TORCH_ROOT/lib${VENDOR_FLAGGEMS_LIB:+:$VENDOR_FLAGGEMS_LIB}${CLEAN_LD_LIBRARY_PATH:+:$CLEAN_LD_LIBRARY_PATH}"
+export LIBRARY_PATH="${HYHAL_LD_PATH:+$HYHAL_LD_PATH:}$CPU_TORCH_ROOT/lib${VENDOR_FLAGGEMS_LIB:+:$VENDOR_FLAGGEMS_LIB}${CLEAN_LIBRARY_PATH:+:$CLEAN_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="${HYHAL_LD_PATH:+$HYHAL_LD_PATH:}$CPU_TORCH_ROOT/lib${VENDOR_FLAGGEMS_LIB:+:$VENDOR_FLAGGEMS_LIB}${CLEAN_LD_LIBRARY_PATH:+:$CLEAN_LD_LIBRARY_PATH}"
 
 cd "$REPO_ROOT"
 if [[ "$CI_STAGE" == "build" || "$CI_STAGE" == "integration" ]]; then
@@ -302,7 +337,7 @@ fi
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   for name in \
     PATH VIRTUAL_ENV PYTHONNOUSERSITE PYTHONPATH ACCELERATOR DTK_ROOT ROCM_PATH \
-    FLAGOS_DCU_TORCH_LIB FLAGGEMS_DIR FLAGCX_PATH \
+    FLAGOS_DCU_TORCH_LIB FLAGGEMS_DIR FLAGCX_PATH TRITON_BACKENDS_IN_TREE \
     CMAKE_PREFIX_PATH LIBRARY_PATH LD_LIBRARY_PATH; do
     printf '%s=%s\n' "$name" "${!name}" >> "$GITHUB_ENV"
   done

--- a/.github/workflows/build-wheel-dcu.yml
+++ b/.github/workflows/build-wheel-dcu.yml
@@ -1,0 +1,40 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build Wheel (DCU)
+
+on:
+  workflow_call:
+    inputs:
+      upload-artifact:
+        description: "Whether to upload the built wheel as an artifact"
+        required: false
+        type: boolean
+        default: true
+  workflow_dispatch:
+    inputs:
+      upload-artifact:
+        description: "Whether to upload the built wheel as an artifact"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/all-tests-common.yml
+    with:
+      platform: dcu
+      run_build: true
+      run_integration_tests: false
+      upload_artifact: ${{ inputs['upload-artifact'] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, devops]
+    branches: [main, dev, devops, dev-hygon]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -24,7 +24,7 @@ on:
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/PULL_REQUEST_TEMPLATE.md"
   pull_request:
-    branches: [main, dev, devops]
+    branches: [main, dev, devops, dev-hygon]
     paths-ignore:
       - "**.md"
       - "docs/**"

--- a/.github/workflows/integration-test-dcu.yml
+++ b/.github/workflows/integration-test-dcu.yml
@@ -1,0 +1,41 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Integration Tests (DCU)
+
+on:
+  workflow_call:
+    inputs:
+      timeout-minutes:
+        description: "Timeout for the entire job in minutes"
+        required: false
+        type: number
+        default: 60
+  workflow_dispatch:
+    inputs:
+      timeout-minutes:
+        description: "Timeout for the entire job in minutes"
+        required: false
+        type: number
+        default: 60
+
+jobs:
+  integration-tests:
+    uses: ./.github/workflows/all-tests-common.yml
+    with:
+      platform: dcu
+      run_build: false
+      run_integration_tests: true
+      upload_artifact: false
+      timeout_minutes: ${{ inputs['timeout-minutes'] }}


### PR DESCRIPTION
## Summary

Adds a config-driven Hygon DCU CI pipeline that builds and validates a
self-contained `torch_fl` wheel on DTK hardware.

The DCU backend reuses the CUDA boxing route provided by DTK's hipified PyTorch:
vendor `libtorch_*.so` and HIP libraries are bundled into the wheel, while the
Python runtime uses an isolated Python 3.10 environment with the matching
CPU-only PyTorch package. The resulting test environment does not import the
vendor PyTorch Python package.

Platform-specific behavior stays outside the common workflows in
`.github/configs/dcu.yml` and `.github/scripts/set_env_dcu.sh`.

### What's included

- `.github/configs/dcu.yml`
  - Uses the `hg-8g-cicd-pytorch` runner.
  - Runs in the DTK 26.04 CI image with privileged DCU device access.
  - Defines vendor-boxing, FlagGems, factory-op, and profiler integration tests.
  - Uses a local integration build to avoid transferring the large bundled
    libtorch wheel through Actions artifacts.

- `.github/scripts/set_env_dcu.sh`
  - Discovers `DTK_ROOT` from the environment and common installation paths.
  - Sources the DTK environment before inspecting the vendor PyTorch package.
  - Creates an isolated Python 3.10 virtual environment and installs CPU-only
    PyTorch.
  - Stages the vendor DTK/HIP native libraries through
    `scripts/bundle_dcu_libtorch.sh`.
  - Installs `patchelf` for wheel and bundled-library RPATH rewriting.
  - Pins `numpy<2` for compatibility with the NumPy ABI used by the CPU PyTorch
    wheel.
  - Copies the DTK-provided Triton and FlagGems Python packages into the
    isolated environment.
  - Verifies the CPU PyTorch path, native build output, DTK tooling, and visible
    DCU devices.

- `.github/workflows/build-wheel-dcu.yml`
  - Adds the standalone Hygon DCU wheel-build entrypoint.

- `.github/workflows/integration-test-dcu.yml`
  - Adds the standalone Hygon DCU integration-test entrypoint.

- `.github/workflows/ci.yml`
  - Temporarily enables CI runs from the active `dev-hygon` development branch.

## Testing

Static validation completed locally:

- DCU integration manifest: 5 configured tests validated.
- DCU config and workflow YAML parse successfully.
- `set_env_dcu.sh` passes `bash -n`.
- `git diff --check` passes.
- The branch is based directly on the latest `upstream/main`.

Configured on-device coverage:

- Device and isolated CPU-PyTorch environment checks.
- Representative vendor boxing operator tests.
- Representative FlagGems runtime-path tests.
- General factory-operation tests.
- Profiler parity tests.

## Notes / follow-ups

- The DCU integration job rebuilds and installs a wheel locally because the
  bundled DTK libtorch wheel is too large for reliable artifact transfer.
- Before merge, align the DCU CPU-PyTorch version with the wheel's declared
  PyTorch dependency, ensure DTK Triton in-tree backend discovery is enabled,
  and remove the temporary `dev-hygon` branch trigger.