### PR TITLE
docs: track CLAUDE.md, and require English for GitHub-facing text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ __pycache__/
 *.swo
 *~
 .cache/
-CLAUDE.md
+
 # Testing/Coverage
 .pytest_cache/
 .coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Project conventions for Claude Code
+
+## Language
+
+**All GitHub-facing text must be written in English** — PR titles, PR descriptions,
+commit messages, issue text, and code review comments. This repository's code,
+comments, and existing history are all English, and PRs are read by contributors
+who do not read Chinese.
+
+Chat replies to the user in this session stay in whatever language the user is
+using (usually Chinese). The rule is about what gets published to GitHub, not
+about how we talk here.
+
+If a PR description has already been opened in the wrong language, fix it with
+`gh api -X PATCH repos/{owner}/{repo}/pulls/{n} -f body=@file` rather than
+leaving it and noting the problem.


### PR DESCRIPTION
Adds a `CLAUDE.md` recording one convention, and stops ignoring the file so the convention is actually shared.

**All GitHub-facing text must be in English** — PR titles and bodies, commit messages, issue text, review comments. The code, comments and commit history in this repository are all English, and PRs are read by contributors who do not read Chinese. #78 was opened with a Chinese description (since corrected), which is what prompted this.

The rule is scoped to what gets published. Conversation with a contributor stays in whatever language they are using.

`CLAUDE.md` was listed in `.gitignore` next to `.idea/` and `.vscode/`, i.e. treated as personal editor state. A shared convention only works if the file is shared, so the entry is removed and the file is tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
