### PR TITLE
fix(bpu): unbreak torch.compile on stock transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,13 @@ out = compiled(torch.randn(1, 3, 224, 224))
   **82.1 tok/s decode on Qwen3-0.6B against the vendor `llm` demo's 84.8–87.7**
   on the same artifact. Run `benchmarks/bpu_qwen3_bench.py`. This drives a
   prebuilt vendor `.hbm`, not a `torch.compile` graph.
+- **Stock transformers compile too, correctly but not yet quickly.** A
+  HuggingFace `Qwen3ForCausalLM` under `torch.compile(backend="bpu")` runs from
+  its traced graph at **cosine 0.9910 against eager float**, with its largest
+  partitions offloading whole (30/30 and 22/22 nodes). Coverage is capped by
+  Dynamo's symbolic shapes rather than by missing ops — hbdk4 cannot compile a
+  symbolic dim at all — so tracing at a fixed sequence length is what raises it.
+  See [docs/bpu.md](docs/bpu.md#stock-transformers-under-torchcompile).
 
 ### Build Environment Variables
 

--- a/docs/bpu.md
+++ b/docs/bpu.md
@@ -277,6 +277,21 @@ torch-side view is what you want.
   `torch_fl._C._empty_cache()` before exit frees the same blocks cleanly, which
   is what confirms only the exit ordering is at fault. The kernel reclaims the
   carveout when the fd closes.
+- **The `cuda` alias must not break FX or Dynamo.** `_alias_cuda_to_flagos`
+  rebinds `torch.device` to a Python wrapper so hardcoded-`cuda` code lands on
+  the accelerator that is present. Two torch registries compare against that
+  attribute by *identity*, so the swap silently changed their behaviour:
+  `torch.fx.graph.add_global` special-cases `obj != torch.device` to emit a
+  device constant as the bare name `device(type='cpu')`, and with the attribute
+  swapped it fell through to the qualified-name path for custom ops — the name
+  was never added to the generated module's globals and running the graph raised
+  `NameError: name 'device' is not defined`. `torch._dynamo.utils`'s
+  `common_constant_types` is membership-tested with `type(obj) in ...`, so
+  reading `tensor.device` while tracing asserted instead. Between them these
+  took out every model that calls `torch.arange(..., device=...)`, which is how
+  HF builds position ids — i.e. every transformer. Both registries are keyed on
+  objects, so `_keep_device_identity_checks_working` corrects them in place at
+  import. `tests/unit/bpu/test_device_alias.py` covers it.
 
 ## Measured performance
 
@@ -408,8 +423,54 @@ clean answer. Tracing the vendor took about twenty minutes and settled it.
 `tests/unit/bpu/test_kv_window.py` pins the geometry to values transcribed from
 that trace, so a regression fails loudly instead of producing plausible prose.
 
-This path drives a prebuilt vendor artifact, not a `torch.compile` graph. The
-compile side is not there yet — see the limitations below.
+This path drives a prebuilt vendor artifact, not a `torch.compile` graph. For
+what the compile path does on a stock transformer, see below.
+
+### Stock transformers under `torch.compile`
+
+A HuggingFace `Qwen3ForCausalLM` (2 layers, d=64) under
+`torch.compile(backend="bpu")` runs on the board, compiled from the traced graph
+rather than from a vendor artifact: **cosine 0.9910 against eager float**, with
+the largest partitions offloading whole — 30/30 and 22/22 compute nodes, one
+partition each. It is correct, not yet fast: each Dynamo region becomes its own
+`.hbm` submission rather than one graph over a device-resident cache, so the
+82 tok/s above still belongs to `infer.py` alone.
+
+Three things had to be fixed to get here, and the order they were found in is
+the useful part.
+
+**The `cuda` alias was breaking FX codegen.** This looked exactly like a torch
+2.10 bug and was not; see the entry under *Runtime notes*. Until it was fixed,
+every HF model failed at `NameError: name 'device' is not defined` before any
+BPU code ran.
+
+**`pow`, `rsqrt`, `sqrt` and `neg` were missing from the supported set.** Those
+four ops *are* RMSNorm, and without them a norm block split in two at 86%
+coverage. `convert(advice=True)` shows hbdk4 lowering the lot to b30vpu with
+zero CPU fallbacks, so the whitelist was wrong, not the hardware. `slice` joined
+for the same reason on the attention side — it is how attention takes its causal
+window.
+
+**What actually caps coverage is Dynamo's symbolic shapes, not any missing op.**
+This is worth measuring rather than assuming: the obvious suspect,
+`aten._scaled_dot_product_flash_attention_for_cpu`, is a fused tuple-returning
+node that keeps attention proper on the CPU — but forcing the math SDPA backend
+decomposes it and moves whole-model coverage only 56% → 60%. Of the nodes
+rejected on a 1-layer Qwen3, 21 are whitelisted ops carrying a symbolic dim
+(`slice` x10, `view` x4, `unsqueeze` x3, `cat` x2, `mul` x2) and 5 are
+int64/bool, against 8 that are genuinely unsupported (`embedding`, `arange`,
+`scalar_tensor`, `lift_fresh_copy`). hbdk4 bakes memspace offsets and SRAM
+tiling into the artifact, so a symbolic dim cannot be compiled at all and
+`partition.py` rejects it deliberately. Tracing at a fixed sequence length is
+what removes them.
+
+One partition also falls back on an `expand` feeding a 5-D broadcast, which
+fails hbdk4 shape inference (`'hbir.tile' op ... axis 0 is inferred to be 1, but
+got 0`) — the constant-folding gap noted in the limitations. The model still
+runs.
+
+Compile time dominates: **~350 s for a 2-layer model**, because every partition
+goes through hbdk4 under box64. Cached after the first run.
 
 ### Smaller graphs
 
@@ -460,14 +521,14 @@ signature, march and Q/DQ pass version, so this is a first-run cost only.
   on the BPU's VPU rather than its MAC array. `convert(advice=True)` is how to
   check what a given graph actually lowers to.
 - **LLM inference runs a prebuilt vendor artifact, not a compiled graph.**
-  `infer.py` is the runtime half only. Driving a `torch.compile`d transformer
-  the same way needs, in rough order: `aten.slice.Tensor` in `partition.py`'s
-  supported set (without it a transformer block fragments; with it decode and
-  prefill are each a single partition at 100% node coverage), an ONNX
-  constant-folding pass after export (torch's `aten.expand` emits a
-  `Shape->Equal->Where->Expand` chain hbdk4 cannot shape-infer through), and
+  `infer.py` is the runtime half only, and it is what the 82 tok/s above
+  measures. A `torch.compile`d transformer is a separate path that works but is
+  not yet fast — see *Stock transformers under `torch.compile`*. Closing the gap
+  needs an ONNX constant-folding pass after export (torch's `aten.expand` emits
+  a `Shape->Equal->Where->Expand` chain hbdk4 cannot shape-infer through) and
   mixed-precision Q/DQ — the vendor artifact uses si16 for the K cache, si8 for
   V, and f16 for the mask and logits, where `qdq.py` is si8-only. With folding
   alone, `convert(advice=True)` already puts 54 of 66 ops on the BPU; the 12
   fallbacks all report `"fallback to float, op is not completely quantized"`,
   which is the Q/DQ gap rather than a hardware limit.
+

--- a/tests/unit/bpu/test_device_alias.py
+++ b/tests/unit/bpu/test_device_alias.py
@@ -1,0 +1,113 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The `cuda` -> flagos device alias must not break FX or Dynamo.
+
+`_alias_cuda_to_flagos` rebinds `torch.device` to a Python wrapper class so that
+`torch.device("cuda")` lands on the accelerator that is actually present. Two
+torch registries compare against that attribute by *identity* rather than
+structurally, so the swap silently changed their behaviour:
+
+  * `torch.fx.graph.add_global` special-cases `obj != torch.device` to emit a
+    device constant as the bare name `device(type='cpu')`. Once the attribute
+    was a different object the branch fell through to the qualified-name path
+    for custom ops, the name was never added to the generated module's globals,
+    and running the graph raised `NameError: name 'device' is not defined`.
+  * `torch._dynamo.utils.common_constant_types` is membership-tested with
+    `type(obj) in ...`, so reading `tensor.device` during tracing asserted with
+    "Cannot construct `ConstantVariable` for value of type `torch.device`".
+
+Neither surfaces without an accelerator alias in place, and together they took
+out every model that calls `torch.arange(..., device=...)` -- which is how HF
+builds position ids, i.e. every transformer.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+torch_fl = pytest.importorskip("torch_fl")
+
+
+def _aliased() -> bool:
+    """Whether this build actually installed the alias."""
+    return torch.device is not torch._C.device
+
+
+requires_alias = pytest.mark.skipif(
+    not _aliased(), reason="build has real CUDA, so the alias is a no-op"
+)
+
+
+def test_device_constructor_still_returns_a_real_device():
+    d = torch.device("cpu")
+    assert type(d) is torch._C.device
+    assert isinstance(d, torch.device)
+    assert d.type == "cpu"
+
+
+@requires_alias
+def test_repr_round_trips_through_the_shim():
+    """FX codegen emits `repr(device)` verbatim and resolves it as a call."""
+    for d in (torch.device("cpu"), torch.device("cpu", 0)):
+        back = eval(repr(d), {"device": torch.device})  # noqa: S307
+        assert back == d
+        assert type(back) is torch._C.device
+
+
+def test_fx_custom_builtin_matches_the_live_attribute():
+    """`add_global`'s carve-out compares against `torch.device` by identity."""
+    from torch.fx.graph import _custom_builtins
+
+    assert _custom_builtins["device"].obj is torch.device
+
+
+def test_dynamo_treats_a_device_as_a_constant():
+    from torch._dynamo.utils import common_constant_types, is_safe_constant
+
+    assert torch._C.device in common_constant_types
+    assert is_safe_constant(torch.device("cpu"))
+
+
+def test_graph_with_a_device_constant_executes():
+    """The regression: this raised NameError once the alias was installed."""
+    from torch.fx.experimental.proxy_tensor import make_fx
+
+    def f(x):
+        return x + torch.arange(4, device=x.device)
+
+    gm = make_fx(f, tracing_mode="fake")(torch.randn(4))
+    assert "device(type=" in gm.code, "expected a bare device constant in codegen"
+    assert "device" in gm.forward.__globals__
+
+    x = torch.randn(4)
+    torch.testing.assert_close(gm(x), f(x))
+
+
+def test_reading_tensor_device_while_tracing_does_not_assert():
+    """The Dynamo half: `.device` is wrapped as a ConstantVariable."""
+    seen = []
+
+    def backend(gm, example_inputs):
+        seen.append(gm)
+        return gm.forward
+
+    @torch.compile(backend=backend, fullgraph=True)
+    def f(x):
+        return x + torch.arange(x.shape[0], device=x.device)
+
+    x = torch.randn(4)
+    torch.testing.assert_close(f(x), x + torch.arange(4))
+    assert seen, "backend never ran"

--- a/tests/unit/bpu/test_partition.py
+++ b/tests/unit/bpu/test_partition.py
@@ -168,3 +168,58 @@ def test_backend_falls_back_without_hbdk(caplog, monkeypatch):
 
     torch.testing.assert_close(got, expected)
     assert "no hbdk4 compiler reachable" in caplog.text
+
+
+# -- transformer coverage ------------------------------------------------------
+
+
+class RMSNormBlock(torch.nn.Module):
+    """RMSNorm + gated MLP: the shape of every layer in a recent LLM."""
+
+    def __init__(self, d=64):
+        super().__init__()
+        self.w = torch.nn.Parameter(torch.ones(d))
+        self.fc1 = torch.nn.Linear(d, 2 * d)
+        self.fc2 = torch.nn.Linear(2 * d, d)
+
+    def forward(self, x):
+        v = x.pow(2).mean(-1, keepdim=True)
+        y = x * torch.rsqrt(v + 1e-6) * self.w
+        return x + self.fc2(torch.nn.functional.silu(self.fc1(y)))
+
+
+def test_rmsnorm_block_is_one_partition():
+    """`pow` and `rsqrt` are what a norm is made of.
+
+    Without them on the whitelist the graph splits at every norm: 86% of the
+    nodes offloaded across two partitions, each paying its own boundary copy,
+    for an op hbdk4 lowers entirely to b30vpu (checked with
+    `convert(advice=True)`: 6 ops, zero CPU fallbacks).
+    """
+    from torch_fl.accelerator.bpu.decompose import decompose
+
+    gm, _ = _aot_graph(RMSNormBlock().eval(), torch.randn(1, 8, 64))
+    decompose(gm)  # as the backend does, before partitioning
+    parts = partition_graph(gm, min_nodes=2)
+
+    assert len(parts) == 1, summarize(gm, parts)
+    targets = {n.target for n in parts[0].nodes}
+    assert torch.ops.aten.pow.Tensor_Scalar in targets
+    assert torch.ops.aten.rsqrt.default in targets
+
+    compute = [n for n in gm.graph.nodes if n.op == "call_function"]
+    assert len(parts[0].nodes) == len(compute), "every compute node should offload"
+
+
+def test_slice_does_not_split_a_partition():
+    """Attention takes its causal window with `slice`, once per layer."""
+
+    class Sliced(torch.nn.Module):
+        def forward(self, x):
+            return torch.relu(x[:, :4] * 2) + 1
+
+    gm, _ = _aot_graph(Sliced(), torch.randn(2, 8))
+    parts = partition_graph(gm, min_nodes=1)
+
+    assert len(parts) == 1, summarize(gm, parts)
+    assert torch.ops.aten.slice.Tensor in {n.target for n in parts[0].nodes}

--- a/torch_fl/__init__.py
+++ b/torch_fl/__init__.py
@@ -759,6 +759,49 @@ if (
     torch.cuda.init()
 
 
+def _keep_device_identity_checks_working(real_device, shim):
+    """Repair the two torch registries that compare against ``torch.device``.
+
+    Rebinding ``torch.device`` to a Python class (above) is invisible to almost
+    everything -- ``isinstance`` still works, and every consumer that only
+    *calls* it gets a genuine device back. Two places compare the attribute by
+    identity instead, and both silently change behaviour:
+
+    ``torch.fx.graph.add_global`` carves out ``obj != torch.device`` so that a
+    device constant is emitted as the bare name ``device(type='cpu')`` and
+    resolved through the ``device`` custom builtin. With the attribute swapped,
+    the real device class no longer equals it, so the branch falls through to
+    the qualified-name HACK path meant for custom ops -- the name is never added
+    to the module's globals, and the generated forward dies with
+    ``NameError: name 'device' is not defined`` the moment it runs. It is
+    ``torch.arange(..., device=x.device)`` that emits such a constant, which is
+    how every HF model builds its position ids, so this took out essentially
+    every transformer under ``torch.compile``.
+
+    ``torch._dynamo.utils.common_constant_types`` holds the types Dynamo may
+    wrap as a ``ConstantVariable``, and it is tested with ``type(obj) in ...``.
+    Reading ``tensor.device`` while tracing then asserts with "Cannot construct
+    ``ConstantVariable`` for value of type ``torch.device``".
+
+    Both registries are keyed on objects rather than rebuilt per call, so they
+    can be corrected in place once, here. Re-running this is harmless.
+    """
+    from torch.fx.graph import _register_custom_builtin
+
+    # Point the builtin at the shim: `add_global` skips the qualified-name path
+    # for anything not defined under `torch`, so the shim reaches the normal
+    # branch and the name lands in the generated module's globals. Calling it
+    # still yields a real device, which is all the generated code needs.
+    _register_custom_builtin("device", "from torch import device", shim)
+
+    # Dynamo compares `type(obj)`, and a constructed device is always the real
+    # C type whatever `torch.device` currently names -- so it is the real class
+    # that has to be in the set.
+    from torch._dynamo.utils import common_constant_types
+
+    common_constant_types.add(real_device)
+
+
 def _alias_cuda_to_flagos():
     """Make ``device="cuda"`` mean the flagos device when there is no real CUDA.
 
@@ -848,6 +891,7 @@ def _alias_cuda_to_flagos():
             return _orig_device(*args, **kwargs)
 
     torch.device = device
+    _keep_device_identity_checks_working(_orig_device, device)
 
     # Tensor.cuda() / Module.cuda() -> the flagos device.
     def _tensor_cuda(self, device=None, non_blocking=False, **kwargs):

--- a/torch_fl/accelerator/bpu/partition.py
+++ b/torch_fl/accelerator/bpu/partition.py
@@ -68,6 +68,15 @@ _SUPPORTED: set[Callable | str] = {
     torch.ops.aten.div.Tensor,
     torch.ops.aten.add_.Tensor,
     torch.ops.aten.mul_.Tensor,
+    # RMSNorm, which every recent LLM uses in place of LayerNorm. hbdk4 lowers
+    # the lot to b30vpu (`pow` -> Pow, `rsqrt` -> Sqrt+Div in ONNX): checked
+    # with convert(advice=True), 6 ops, zero CPU fallbacks. Without these two a
+    # transformer block splits at every norm -- 86% coverage and two partitions
+    # where one will do.
+    torch.ops.aten.pow.Tensor_Scalar,
+    torch.ops.aten.rsqrt.default,
+    torch.ops.aten.sqrt.default,
+    torch.ops.aten.neg.default,
     # shape
     torch.ops.aten.view.default,
     torch.ops.aten.reshape.default,
@@ -78,6 +87,10 @@ _SUPPORTED: set[Callable | str] = {
     torch.ops.aten.contiguous.default,
     torch.ops.aten.squeeze.dim,
     torch.ops.aten.unsqueeze.default,
+    # `slice` is how attention takes its causal window and how any model that
+    # indexes a cache reads it. Without it a transformer fragments at every
+    # slice; with it decode and prefill are each a single partition.
+    torch.ops.aten.slice.Tensor,
     # `expand` is what AOTAutograd inserts ahead of a batched matmul to
     # broadcast the operands; ONNX Expand covers it exactly. `_unsafe_view`
     # and `t` are rewritten to `view`/`transpose` by decompose.py rather than


### PR DESCRIPTION
A HuggingFace `Qwen3ForCausalLM` under `torch.compile(backend="bpu")` now runs on the board from its **traced graph** rather than a prebuilt vendor artifact: **cosine 0.9910 against eager float**, with the largest partitions offloading whole — 30/30 and 22/22 compute nodes, one partition each.

## The blocker was ours, not torch's

`_alias_cuda_to_flagos` rebinds `torch.device` to a Python shim so hardcoded-`cuda` code reaches the accelerator. Two torch registries compare that attribute by **identity**:

- `torch.fx.graph.add_global` carves out `obj != torch.device` to emit a device constant as the bare name `device(type='cpu')`. Once swapped, it fell through to the qualified-name path meant for custom ops — the name never entered the generated module's globals, and the graph died with `NameError: name 'device' is not defined`.
- `torch._dynamo.utils.common_constant_types` is membership-tested with `type(obj) in ...`, so reading `tensor.device` while tracing asserted instead.

Between them these took out every model calling `torch.arange(..., device=...)` — which is how HF builds position ids, i.e. every transformer. `_keep_device_identity_checks_working` corrects both in place at import; these are the only two such comparisons in `_dynamo/` and `fx/`.

Worth flagging for reviewers: this reads exactly like a torch 2.10 FX codegen bug and is not one. The `make_fx` repro passes in a bare interpreter and only fails after `import torch_fl` — bisecting on the *import* is what located it.

## Whitelist: `pow`, `rsqrt`, `sqrt`, `neg`, `slice`

Those four ops *are* RMSNorm, and without them a norm block split in two at 86% coverage. `convert(advice=True)` shows hbdk4 lowering the lot to b30vpu with **zero CPU fallbacks**, so the whitelist was wrong, not the hardware. `slice` joins for the same reason on the attention side. Measured: rmsnorm-block 86% / 2 partitions → **100% / 1 partition**.

## What actually caps coverage — measured, not assumed

The obvious suspect is the fused `aten._scaled_dot_product_flash_attention_for_cpu` node. Forcing the math SDPA backend decomposes it and moves whole-model coverage only **56% → 60%**.

The real cap is Dynamo's symbolic shapes. Of the nodes rejected on a 1-layer Qwen3: **21** are whitelisted ops carrying a symbolic dim (`slice` ×10, `view` ×4, `unsqueeze` ×3, `cat` ×2, `mul` ×2), **5** are int64/bool, and only **8** are genuinely unsupported ops. hbdk4 bakes memspace offsets and SRAM tiling into the artifact, so a symbolic dim cannot compile at all — `partition.py` rejects it deliberately. Documented rather than worked around; tracing at a fixed sequence length is what raises it.

## Scope

Additive only — **zero deletions** in both code files (`+44/-0` in `torch_fl/__init__.py`, `+13/-0` in `partition.py`). The `torch.device` fix lives in shared code but is inert on any build with real CUDA, where the alias early-returns.

## Verification

- 104 passed, 1 skipped (`tests/unit/bpu/`); `ruff check` and `ruff format --check` both clean.
- New tests confirmed as genuine regressions by reverting each fix: **4 of 6** device-alias tests fail without it; both new partition tests fail without the whitelist entries.
- End-to-end on RDK hardware under box64, 1-layer and 2-layer Qwen3.

Known cost: compile time is ~350 s for a 2-layer model, since every partition goes through hbdk4 under box64. Cached after the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)