### PR TITLE
docs: redesign README and migrate platform guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,188 @@
+# Contributing to torch_fl
+
+Thank you for your interest in contributing to torch_fl. This guide outlines how to contribute operators, runtime integrations, compiler support, and documentation.
+
+## Ways to Contribute
+
+- **Operators**: Add missing operators or optimize existing implementations for specific backends.
+- **Runtime and platform integration**: Port torch_fl to new accelerators or improve existing backend support.
+- **Compiler integration**: Extend torch.compile support, improve Triton codegen, or add new compilation backends.
+- **Distributed and profiler work**: Enhance collective communication backends (NCCL, FlagCX, HCCL) or profiling integration (CUPTI, vendor profilers).
+- **Tests**: Add operator correctness tests, model integration tests, or performance benchmarks.
+- **Documentation**: Improve setup guides, troubleshooting docs, or vendor-specific integration notes.
+
+## Before You Start
+
+### Check Support Boundaries
+
+torch_fl targets PyTorch `PrivateUse1` extension points and upstream-compatible operator schemas. Contributions should work within these boundaries:
+
+- Operators must match PyTorch's public API (schema, semantics, tensor layout conventions).
+- Platform integrations should use vendor SDKs and official hardware specs, not reverse-engineered APIs.
+- Avoid claiming inherited platform support (e.g., "this works on all CUDA-compatible devices") without evidence.
+
+### Discuss Architectural Changes
+
+For broad changes that affect multiple backends or core dispatch logic, open an issue first to discuss:
+
+- New backend dispatch modes or routing strategies
+- Changes to the build system affecting all platforms
+- Breaking changes to environment variables or configuration files
+- New dependencies or external libraries
+
+Bug fixes, individual operator additions, and documentation improvements do not need upfront discussion.
+
+## Development Workflow
+
+### 1. Branch
+
+Work on a feature branch rather than directly on `main`:
+
+```bash
+git checkout -b feature/my-contribution
+```
+
+### 2. Make Scoped Changes
+
+Keep commits focused. A single PR should address one feature, bug, or documentation improvement. If your work involves multiple independent changes, submit separate PRs.
+
+### 3. Regenerate Bindings When Needed
+
+If you modify operator schemas, add new operators, or change backend registration:
+
+```bash
+python scripts/codegen_ops.py
+```
+
+For platform-specific kernels, run the appropriate codegen script (see [Testing Guide](docs/development/testing.md#code-generation)).
+
+### 4. Run Focused Tests
+
+Before pushing, run tests relevant to your changes:
+
+```bash
+# Unit tests (always run these)
+pytest tests/unit/ -v
+
+# Operator tests (if you modified operator implementations)
+pytest tests/integration/ops/test_<operator>.py -v
+
+# Platform-specific tests (if you changed backend routing)
+pytest tests/integration/ops/ -m <platform> -v
+
+# Model tests (if you changed runtime behavior)
+pytest tests/integration/test_inference.py --model <model-path> -v
+```
+
+### 5. Run Lint and Diff Checks
+
+CI requires passing lint checks. Run these commands locally before pushing:
+
+```bash
+ruff check .
+ruff format --check .
+git diff --check
+```
+
+Fix issues with:
+
+```bash
+ruff format .
+ruff check --fix .
+```
+
+Install the pinned ruff version CI uses:
+
+```bash
+pip install ruff==0.15.12
+```
+
+## Adding an Accelerator Backend
+
+New platform integrations require several components. Use existing backends (CUDA, MetaX, Ascend) as reference implementations.
+
+### Required Components
+
+1. **Runtime compatibility layer**: Device registration, stream/event abstractions, and memory management hooks.
+2. **Operator routing**: Either CUDA boxing kernels (reuse NVIDIA implementations) or native vendor kernels (ACL, mudnn, topsaten, etc.).
+3. **Backend configuration**: A `backends_<platform>.conf` file mapping operators to backend dispatch targets.
+4. **Platform detection**: Add hardware detection logic to `torch_fl/__init__.py` and `tests/integration/ops/conftest.py`.
+5. **Build integration**: Extend `CMakeLists.txt` to find the vendor SDK and compile platform-specific kernels.
+6. **Documentation**: Setup guide, environment variables, and known limitations.
+
+### Documentation Requirements
+
+Platform integrations must include:
+
+- **Compatibility matrix**: Supported hardware models, SDK versions, and PyTorch versions (see [Compatibility](docs/compatibility.md)).
+- **Setup guide**: Installation steps, environment configuration, and validation commands (see [vendor guides](docs/vendors/)).
+- **Environment variables**: Document platform-specific variables in the vendor guide, not the main environment reference.
+- **Testing results**: Evidence that the runtime and operator tests pass on the target hardware.
+
+### Explicit Runtime-only Scope
+
+If the integration provides device/stream/memory abstractions but no operator implementations (CPU fallback for all compute), state this limitation clearly in the PR description and platform documentation.
+
+## Pull Requests
+
+### Title and Description (English Required)
+
+**All PR titles and descriptions must be written in English.** This repository's code, comments, and history are in English, and PRs are reviewed by contributors who do not read other languages.
+
+If you drafted text in another language during development, translate it before opening the PR. A PR opened in the wrong language must be updated before review.
+
+### Include
+
+- **Exact commands**: Show the build commands, test invocations, and their output (success or failure).
+- **Hardware and SDK**: Specify the accelerator model, SDK version, PyTorch version, and torch_fl build configuration.
+- **Validation evidence**: Paste test results, operator correctness checks, or benchmark numbers.
+- **Known limitations**: Document unsupported operators, performance gaps, or environment constraints.
+
+### Exclude
+
+- **Credentials**: No API keys, tokens, registry passwords, or SSH keys.
+- **Machine-local paths**: No `/nfs/`, `/home/<user>/`, `/root/`, or organization-specific hostnames (e.g., private registries, internal CI servers).
+- **Unrelated changes**: No reformatting unrelated files, dependency bumps outside the scope, or "drive-by" cleanups.
+
+### Example PR Description
+
+```
+## Summary
+
+Add operator correctness tests for `torch.nn.functional.gelu` on the MetaX backend.
+
+## Changes
+
+- `tests/integration/ops/test_gelu.py`: Test GELU forward and backward against PyTorch reference
+- Mark as `@pytest.mark.metax` for MetaX-specific routing assertions
+
+## Validation
+
+Hardware: MetaX C550  
+SDK: MACA 2.8.0  
+PyTorch: 2.6.0  
+torch_fl build: `ACCELERATOR=metax METAX_KERNEL=ON`
+
+Commands:
+```bash
+pytest tests/integration/ops/test_gelu.py -v
+```
+
+Results:
+```
+test_gelu_forward PASSED
+test_gelu_backward PASSED
+```
+
+## Known Limitations
+
+None.
+```
+
+### Review and Iteration
+
+Reviewers may request changes to code style, test coverage, or documentation clarity. Address feedback by pushing new commits to the same branch (no force-push unless requested).
+
+## License
+
+By contributing to torch_fl, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE). All new files must include the Apache 2.0 license header (see existing files for the template).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ New platform integrations require several components. Use existing backends (CUD
 
 Platform integrations must include:
 
-- **Compatibility matrix**: Supported hardware models, SDK versions, and PyTorch versions (see [Compatibility](docs/compatibility.md)).
+- **Compatibility matrix**: Supported hardware models, SDK versions, and PyTorch versions (see [Compatibility](docs/reference/compatibility.md)).
 - **Setup guide**: Installation steps, environment configuration, and validation commands (see [vendor guides](docs/vendors/)).
 - **Environment variables**: Document platform-specific variables in the vendor guide, not the main environment reference.
 - **Testing results**: Evidence that the runtime and operator tests pass on the target hardware.

--- a/README.md
+++ b/README.md
@@ -1,1070 +1,193 @@
-# torch_fl
+# torch-fl
 
-A custom PyTorch device plugin based on the PrivateUse1 extension mechanism, registering [FlagGems](https://github.com/FlagOpen/FlagGems) high-performance Triton operators as the `flagos` device backend for unified multi-chip support.
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.8%2B-blue.svg)](https://www.python.org/downloads/)
+[![PyTorch](https://img.shields.io/badge/PyTorch-2.10.x-orange.svg)](https://pytorch.org/)
 
-## Features
+[Documentation](docs/) · [Installation](docs/getting-started/installation.md) · [Quick Start](docs/getting-started/quickstart.md) · [Compatibility](docs/reference/compatibility.md)
 
-- Automatically registers FlagGems Triton operators as dispatch implementations for the `flagos` device
-- Configurable backend routing: select FlagGems or native vendor backend (CUDA/MetaX/Ascend/MUSA) at per-operator granularity
-- Currently supports CUDA, MetaX, Ascend, TsingMicro, DCU, Enflame GCU, and Moore Threads MUSA hardware platforms
-- Complete device management API (stream, event, RNG, AMP)
-## Requirements
+A PyTorch device plugin for the FlagOS software stack. torch-fl exposes a single `flagos` device that routes operators among reusable native kernels, portable compiler kernels, vendor-native implementations, and explicit CPU fallback.
 
-| Dependency | Version |
-|------------|---------|
-| Python | 3.12 |
-| PyTorch | 2.11.0 |
-| CUDA | 12.8 |
-| FlagGems | 5.0.2 |
+## Overview
 
-> CUDA 12.2 has known numerical precision issues (NaN). Please use version 12.9 or higher.
+Accelerator vendors provide different runtimes, compiler stacks, and PyTorch integration strategies. torch-fl offers a PyTorch-native device interface that isolates these differences behind a unified runtime and operator-routing layer.
 
-## Installation
+Users program against standard PyTorch APIs and the `flagos` device. The plugin selects kernel implementations per operator based on platform capabilities and configuration, without exposing vendor differences as distinct device names or requiring workload changes when moving between accelerators.
 
-### Prerequisites
+## Design Philosophy
 
-- Hardware Runtime Dependencies:
-    - CUDA toolkit 12.8 (required only on CUDA platform)
-    - MetaX cu-bridge library (required only on MetaX platform; from the [MetaX developer portal](https://developer.metax-tech.com/softnova))
-    - CANN toolkit (required only on Ascend platform)
-- PyTorch 2.11.0
-- FlagGems (version 5.0.2 or higher, requires DFLAGGEMS_BUILD_C_EXTENSIONS enabled). For source installation, refer to: [FlagGems Installation](https://flagos-ai.github.io/FlagGems/getting-started/install/)
-  - Note: FlagGems is optional on Ascend platform
+torch-fl is built on five principles:
 
-### Build from Source (CUDA Platform)
+1. **PyTorch-native interface** — Standard PyTorch APIs work unchanged; users target the `flagos` device rather than vendor-specific extensions.
 
-```bash
-git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+2. **One logical device** — A single device name (`flagos`) abstracts vendor differences. Platform-specific routing happens transparently at the operator level.
 
-ACCELERATOR=cuda FLAGGEMS_DIR=/path/to/FlagGems/build/cpython-312/ \
-  FLAGGEMS_KERNEL=1 FLAGGEMS_PYTHON=1 CUDA_KERNEL=1 \
-  pip install --no-build-isolation -vvv -e .
+3. **Layered operator backends** — Each operation may dispatch to a different implementation. Routing decisions are per-operator, not per-device or per-model.
+
+4. **Reuse before reimplementation** — Established kernels and compiler stacks are integrated where their dispatch and ABI boundaries permit, rather than rewriting functionality that already exists.
+
+5. **Explicit capability boundaries** — Unsupported operations and CPU fallback paths are documented rather than presented as complete native coverage. Status levels distinguish validated support from experimental integrations.
+
+### Execution Paths
+
+torch-fl implements three principal operator execution strategies:
+
+- **Native vendor kernels**: Direct calls into vendor runtime and operator libraries (ACLNN, mudnn, topsaten). The plugin generates bindings to each vendor's C/C++ API.
+
+- **Compatibility boxing**: Zero-copy metadata conversion into an independent PyTorch dispatch key when the vendor stack exposes one that can coexist with PrivateUse1. CUDA boxing reuses NVIDIA kernels via an external `libtorch_cuda.so`.
+
+- **Portable compiler kernels**: FlagGems kernels generated through Triton or a compatible compiler backend. These kernels target multiple accelerator families without per-platform rewrites.
+
+A platform may combine execution paths. These are implementation strategies, not user-selectable product tiers.
+
+## Architecture
+
+```text
+PyTorch API
+    |
+flagos device (PrivateUse1)
+    |
+device runtime + per-operator routing
+    |
+FlagGems/compiler kernels | compatibility boxing | native vendor kernels | CPU fallback
+    |
+accelerator runtime
 ```
 
-### Build from Source (MetaX Platform)
+This diagram is conceptual. Detailed component architecture, dispatch internals, distributed collectives, compilation integration, and profiler design are documented under [docs/architecture/](docs/architecture/).
 
-MetaX ships a **self-contained boxing wheel**: it reuses PyTorch's generated CUDA boxing kernels (host `g++`, no `mxcc`) and bundles the forked libtorch C++ runtime inside the wheel. The target machine then needs only:
+## Capabilities
 
-- The official `torch==2.10.0+cpu` wheel (from PyPI, no CUDA)
-- This `torch_fl` wheel
-- The `/opt/maca` driver runtime (present on any machine with a MetaX card)
+torch-fl provides project-level support for:
 
-No separate `torch+metax` wheel and no manual `LD_LIBRARY_PATH` are required — `import torch_fl` symlinks the stock wheel's `torch/lib` to the bundled forked libtorch, whose RPATH resolves the MetaX runtime under `/opt/maca`.
+- PyTorch eager tensor operations and device management
+- Autograd and model training
+- `torch.compile` integration
+- Distributed collectives and DDP through `ProcessGroupFlagOS`
+- `torch.profiler` integration
+- FlagGems/Triton operator integration
+- Explicit CPU fallback for uncovered operations where PyTorch semantics permit
 
-> **Getting the MetaX MACA SDK and `torch+metax` wheel** (needed only to *build* the wheel, not to run it)
-> Both are distributed through the MetaX developer portal (SoftNova): <https://developer.metax-tech.com/softnova>. Registration/login is required. Download the MACA SDK (driver + cu-bridge) matching your card and driver version, and the `torch+metax` (`maca-pytorch`) wheel built for the same MACA version and your Python version — it is the source of the forked libtorch bundled into the wheel. Install the SDK to `/opt/maca` (or point `METAX_PATH` at the install location).
+Capability availability and validation status vary by platform. A feature existing in the torch-fl codebase does not imply that every platform implements or validates it. See the [Compatibility Matrix](docs/reference/compatibility.md) for per-platform detail.
 
-**Build the wheel** (on a machine with the MetaX SDK and a `torch+metax` wheel available as the libtorch source):
+## Hardware Support
 
-```bash
-git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+| Platform | Execution path | Validated capabilities | Status | Guide |
+|---|---|---|---|---|
+| NVIDIA CUDA | CUDA boxing over external `libtorch_cuda.so` | Eager, autograd, distributed (FlagCX/NCCL), profiler (CUPTI), FlagGems (Python + C++) | **Stable** | [CUDA](docs/vendors/cuda/installation.md) |
+| MetaX | CUDA boxing via cu-bridge, or native MetaX kernels | Eager, autograd | **Stable** | [MetaX](docs/vendors/metax/installation.md) |
+| Ascend | Native ACLNN backend, optional FlagGems via triton-ascend | Eager, autograd, RNG suite | **Beta** | [Ascend](docs/vendors/ascend/installation.md) |
+| PPU | CUDA boxing against PPU's CUDA-13-compatible SDK | Eager, autograd | **Experimental** | [PPU](docs/vendors/ppu/installation.md) |
+| Hygon DCU | CUDA boxing over hipified DTK torch | Eager, autograd, profiler | **Beta** | [DCU](docs/vendors/dcu/installation.md) |
+| Enflame GCU | Native topsaten backend, CPU fallback for unrouted/int64 ops | Eager | **Experimental** | [GCU](docs/vendors/gcu/installation.md) |
+| Moore Threads MUSA | Native mudnn backend, CPU fallback for unrouted ops | Eager | **Experimental** | [MUSA](docs/vendors/musa/installation.md) |
+| D-Robotics BPU | No eager kernels; `torch.compile` graph path via hbdk4 | Graph compilation only | **Runtime only** | [BPU](docs/vendors/bpu/installation.md) |
+| TsingMicro | Runtime build selector exists | Setup not documented | **Runtime only** | — |
 
-# 1. Build the boxing artifacts (METAX_KERNEL is forced OFF in boxing mode)
-ACCELERATOR=metax FLAGOS_METAX_BOXING=1 \
-  FLAGOS_MACA_TORCH_LIB=/path/to/torch+metax/torch/lib \
-  FLAGOS_WHEEL_LOCAL=metax3.8.1 \
-  python setup.py bdist_wheel
+**Status definitions:**
 
-# 2. Bundle the 8 forked libtorch .so into torch_fl/lib_maca/ and rewrite RPATH
-#    (requires patchelf: pip install patchelf)
-FLAGOS_MACA_TORCH_LIB=/path/to/torch+metax/torch/lib \
-  MACA_PATH=/opt/maca \
-  bash scripts/bundle_maca_libtorch.sh
+- **Stable**: Critical paths are continuously tested and the supported version combination is documented.
+- **Beta**: The primary path is validated, but coverage, packaging, or release procedures are not yet stable.
+- **Experimental**: Validation exists for a specific setup, model, or hardware environment; interfaces or build procedures may change.
+- **Runtime only**: Device runtime support exists, but the platform is not a general eager operator backend.
 
-# 3. Repackage so the bundled libtorch is included (reuses the built artifacts)
-python setup.py build_py
-cp build/lib.*/torch_fl/_C.*.so build/lib.*/torch_fl/  # ensure the C ext is staged
-python setup.py bdist_wheel --skip-build --bdist-dir "$(mktemp -d)"
-```
+Detailed capability breakdowns (eager execution, training, compile, distributed, profiler, FlagGems) and on-hardware validation evidence are in the [Compatibility Matrix](docs/reference/compatibility.md).
 
-The result is `dist/torch_fl-0.1.0+metax3.8.1-cp312-cp312-linux_x86_64.whl` (~1.1 GB — it bundles the forked libtorch, so it exceeds the PyPI 100 MB limit and must be distributed via a private index or directly).
+## Compatibility
 
-`FLAGOS_WHEEL_LOCAL` sets the local version segment (e.g. `metax3.8.1` → `0.1.0+metax3.8.1`) to tag the wheel with the target MACA/driver version.
+| Component | Supported range | Notes |
+|---|---|---|
+| Python | 3.8 or later | Platform SDKs and available wheels may impose a narrower range. |
+| PyTorch | 2.10.x (`>=2.10,<2.11`) | Generated ATen bindings are tied to this minor line. |
+| FlagGems | Platform dependent | Installed from PyPI or a vendor-compatible build only where the platform route uses it. |
+| Triton/compiler | Platform dependent | Use the compiler distribution required by the selected accelerator. |
 
-**Install and run** on the target machine (clean env, MetaX card present):
+### ATen Minor-Line Pinning
 
-```bash
-pip install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
-pip install torch_fl-0.1.0+metax3.8.1-cp312-cp312-linux_x86_64.whl
+torch-fl generates native bindings to PyTorch's internal ATen operator registry. These bindings are sensitive to C++ ABI and operator schema changes, so the project pins to a PyTorch minor line. The current pinned line is **2.10.x**.
 
-export FLAGOS_METAX_BOXING=1
-python -c "
-import torch_fl, torch          # torch_fl must be imported first
-x = torch.randn(4, 4, device='flagos:0')
-print((x + x).sum().cpu())
-"
-```
+Using a different PyTorch minor version (e.g., 2.11.x) will result in build or runtime failures. Patch versions within the same minor line (e.g., 2.10.0 to 2.10.1) are compatible.
 
-In boxing mode, `import torch_fl` auto-selects `backends_cuda.conf` (override with `FLAGOS_BACKEND_CONFIG`). If MACA is installed somewhere other than `/opt/maca`, pass `MACA_PATH` at bundle time (step 2) so the RPATH points there.
+Vendor SDK versions, CUDA toolkit versions, and other platform-specific requirements are documented in each platform's installation guide.
 
-**Optional: FlagGems on MetaX.** Like the CUDA wheel, the MetaX boxing wheel compiles the FlagGems Python-path kernels (`flagos_python` backend) by default, so FlagGems is a runtime switch — set `FLAGOS_USE_FLAGGEMS=1` to route ops to FlagGems' Triton kernels where available, or leave it unset for pure CUDA-kernel reuse (boxing). Enabling it needs two extra target-side pip installs (not bundled in the wheel):
+## Quick Start
 
-```bash
-# On the target MetaX machine, in addition to the wheel + torch+cpu above:
-pip install triton-metax flag_gems     # triton-metax emits mcfatbin for MetaX GPUs
-
-export FLAGOS_METAX_BOXING=1
-export FLAGOS_USE_FLAGGEMS=1            # opt into FlagGems; unset = pure boxing
-python -c "import torch_fl, torch; x=torch.randn(1024, device='flagos:0'); print(torch.nn.functional.silu(x).sum().cpu())"
-```
-
-`import torch_fl` then auto-selects `backends_metax_flaggems.conf` and sets `GEMS_VENDOR=metax` + the MetaX `torch.cuda` compat shim automatically. That conf mirrors the CUDA `backends_flaggems.conf` but routes the ops triton-metax cannot run (`mm`/`bmm`/`mean.dim` — FlagGems uses a SPLIT_K kwarg / CUDA-context path triton-metax rejects) back to the `cuda` boxing kernel (maca `libtorch_cuda`), not the mxcc backend (which is off in boxing mode). Without `triton-metax`/`flag_gems` installed, leave `FLAGOS_USE_FLAGGEMS` unset — the pure boxing path has no extra dependencies.
-
-### Build from Source (Ascend Platform)
-
-#### 1. Install FlagGems (FLAGOS Backend)
-
-On Ascend, FlagGems must be installed from our fork (`torch_fl` branch) with `FLAGGEMS_BACKEND=FLAGOS`. This avoids the `libtorch_npu.so` dependency — instead, FlagGems obtains the ACL stream via `torch_fl`'s `GetCurrentStream` C API.
-
-```bash
-# Clone FlagGems (torch_fl branch)
-git clone -b torch_fl https://github.com/Hchnr/FlagGems.git
-cd FlagGems
-
-# Ensure CANN toolkit environment is sourced
-source /usr/local/Ascend/ascend-toolkit/set_env.sh
-
-# Install FlagGems with FLAGOS backend (skip C++ extensions)
-pip install --no-build-isolation -e . \
-  --config-settings=cmake.define.FLAGGEMS_BACKEND=FLAGOS \
-  --config-settings=cmake.define.FLAGGEMS_BUILD_C_EXTENSIONS=OFF
-
-cd ..
-```
-
-> **Why FLAGOS backend?**
-> The default ascend/npu backend links against `libtorch_npu.so`, which doesn't exist in our environment (`torch_fl` is the PrivateUse1 backend, not `torch_npu`).
-> The `FLAGOS` backend resolves device streams via `extern "C" void* GetCurrentStream(int)`, provided by `torch_fl`'s `libstream_api.so`.
-
-#### 2. Install torch_fl
-
-```bash
-git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
-
-source /usr/local/Ascend/ascend-toolkit/set_env.sh
-
-ACCELERATOR=ascend FLAGGEMS_KERNEL=0 FLAGGEMS_PYTHON=1 \
-  CUDA_KERNEL=0 ASCEND_KERNEL=1 \
-  pip install --no-build-isolation -vvv -e .
-```
-
-Notes:
-- `FLAGGEMS_KERNEL=0`: Disable FlagGems C++ kernel wrappers (FLAGOS backend does not compile `liboperators.so`)
-- `FLAGGEMS_PYTHON=1`: Enable FlagGems Python wrappers to route ops to FlagGems Triton kernels
-- `ASCEND_KERNEL=1`: Compile the Ascend C++ operator backend (ACL NN API)
-
-#### 3. Patch triton-ascend
-
-The stock triton-ascend package depends on `torch_npu` / `libtorch_npu.so`. Since `torch_fl` replaces `torch_npu` as the PrivateUse1 backend, we need to patch triton-ascend to use the `flagos` device interface instead:
-
-```bash
-python scripts/patch_triton_ascend.py
-```
-
-The script auto-detects the triton install path and applies the necessary changes. It is idempotent — running it multiple times is safe. After patching, clear any stale kernel cache:
-
-```bash
-rm -rf ~/.triton/cache/
-```
-
-#### 4. Verify Installation
-
-Two runtime gotchas on Ascend:
-
-- **Import order:** `import torch_fl` **before** `import flag_gems` — torch_fl installs the `torch.npu` shim and sets `GEMS_VENDOR=ascend` that FlagGems reads at its own import time.
-- **libstdc++:** FlagGems pulls in `sqlalchemy`→`_sqlite3`, which needs `CXXABI_1.3.15`. If the system `libstdc++.so.6` is older, preload conda's: `export LD_PRELOAD=$CONDA_PREFIX/lib/libstdc++.so.6`.
-
-```bash
-export LD_PRELOAD=$CONDA_PREFIX/lib/libstdc++.so.6   # if system libstdc++ is old
-python -c "
-import torch_fl, flag_gems
-print('device count:', torch_fl.flagos.device_count())
-print('flag_gems:', flag_gems.__version__)
-"
-```
-
-Enable the FlagGems Triton path at runtime. On an Ascend NPU box (detected via
-`/dev/davinci*`) `torch_fl` auto-selects the ascend config — no need to set
-`FLAGOS_BACKEND_CONFIG` by hand:
-
-```bash
-# Pure aclnn C++ backend (default):        no env needed -> backends_ascend.conf
-# FlagGems Triton where triton-ascend runs: FLAGOS_USE_FLAGGEMS=1
-#                                             -> backends_ascend_flagos_py.conf
-FLAGOS_USE_FLAGGEMS=1 FLAGOS_LOG_DISPATCH=1 python -c "
-import torch, torch_fl, flag_gems
-x = torch.randn(64, 64).to('flagos:0')
-print('abs matches CPU:', torch.allclose(torch.abs(x).cpu(), x.cpu().abs()))
-"
-# expect: [flagos dispatch] abs -> flagos_python
-```
-
-> Ops that triton-ascend cannot compile are routed back to the `ascend` aclnn
-> kernel in `backends_ascend_flagos_py.conf` (annotated per op). FlagGems is
-> optional on Ascend — without it, leave `FLAGOS_USE_FLAGGEMS` unset.
-
-#### 5. Run Tests
-
-```bash
-# Inference test
-pytest tests/integration/test_qwen3_infer.py -v -s --model /path/to/Qwen3-0.6B
-
-# Training test
-pytest tests/integration/test_qwen3_train.py -v -s --model /path/to/Qwen3-0.6B
-```
-
-> **Troubleshooting: `libtorch_npu.so: cannot open shared object file`**
->
-> This error means triton-ascend is still trying to load `torch_npu`. Verify that:
-> 1. You ran `python scripts/patch_triton_ascend.py` after installing triton-ascend
-> 2. FlagGems was installed from `https://github.com/Hchnr/FlagGems` branch `torch_fl`
-> 3. It was built with `FLAGGEMS_BACKEND=FLAGOS`
-> 4. The triton kernel cache was cleared (`rm -rf ~/.triton/cache/`)
-
-### Build from Source (PPU Platform)
-
-PPU (`PPU_SDK`) presents itself as a **CUDA-compatible** device, so it reuses the
-CUDA build directly — no dedicated `ACCELERATOR=ppu` branch is needed. The PPU
-`torch` wheel is already a full CUDA-enabled build (`torch.version.cuda == '13.0'`,
-`torch.cuda.is_available() == True`), and `PPU_SDK/CUDA_SDK` is a complete CUDA 13
-toolkit (nvcc, headers, `libcudart.so.13`). This makes PPU the simplest case of the
-boxing route:
-
-- **No stock `+cpu` wheel and no external `libtorch_cuda.so`** are required — the
-  PPU torch wheel ships its own CUDA runtime, loaded normally by `import torch`.
-- PPU registers ops under the independent `CUDA` dispatch key (not `PrivateUse1`),
-  so the generated CUDA boxing kernels (`csrc/aten/generated/cuda_kernels.cc`,
-  PrivateUse1 → CUDA) are reused unchanged.
-
-```bash
-git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
-
-# Pure CUDA-boxing build (no FlagGems). CUDA_HOME points at the PPU CUDA_SDK;
-# FLAGOS_SKIP_CUDA_ASSETS=1 skips bundling an external libtorch_cuda.so AND skips
-# the pinned nvidia-*-cu12 runtime deps (PPU supplies CUDA 13 via PPU_SDK/CUDA_SDK).
-ACCELERATOR=cuda \
-  CUDA_HOME=/usr/local/PPU_SDK/CUDA_SDK \
-  CUDA_KERNEL=ON FLAGGEMS_KERNEL=OFF FLAGGEMS_PYTHON=OFF \
-  FLAGOS_SKIP_CUDA_ASSETS=1 \
-  pip install --no-build-isolation -vvv -e .
-```
-
-At runtime, set `FLAGOS_DISABLE_CUDA_ASSETS=1` so the import-time preload of a
-bundled `libtorch_cuda.so` is a no-op (there is none — PPU torch provides it):
-
-```bash
-FLAGOS_DISABLE_CUDA_ASSETS=1 python -c "import torch_fl, torch; \
-  x = torch.randn(4, 4, device='flagos'); \
-  print((x @ x).cpu())"
-```
-
-**Optional: FlagGems on PPU.** Set `FLAGGEMS_PYTHON=ON` at build time (the
-default) and `FLAGOS_USE_FLAGGEMS=1` at runtime; `import torch_fl` then selects
-`backends_flaggems.conf` and routes the discovered ops to FlagGems' Triton
-kernels. PPU needs no compat shim beyond the generic CUDA one: `libcuda.so` is a
-real driver, so `is_nvidia_cuda_available()` succeeds, `GEMS_VENDOR=nvidia` is
-set, and `triton.language.extra.cuda.libdevice` resolves (it has `pow`).
-
-PPU's Triton comes from the vendor index, not PyPI, and its version string
-(`3.5.0+v0.2.0.ppu2.1.0`) does not satisfy the `triton>=3.5.1` pin — so when
-`PPU_SDK` is set, `setup.py` drops the `flag_gems`/`triton` requirements and you
-install them yourself:
-
-```bash
-pip install triton==3.5.0+v0.2.0.ppu2.1.0   # vendor index; see note below
-pip install flag_gems
-
-FLAGOS_DISABLE_CUDA_ASSETS=1 FLAGOS_USE_FLAGGEMS=1 python -c "import torch_fl, torch; \
-  x = torch.randn(256, 256, device='flagos'); \
-  print(torch.allclose(torch.softmax(x, -1).cpu(), torch.softmax(x.cpu(), -1), atol=1e-3))"
-```
-
-> **Troubleshooting: `Invalid cross-device link` installing PPU Triton**
->
-> The vendor `triton` sdist is a downloader shim that fetches the real wheel and
-> `rename()`s it into pip's cache. If your pip cache and build dir are on
-> different filesystems (e.g. cache on NFS, build in `/tmp`) that rename fails
-> with `[Errno 18]`. Fetch the wheel the shim reports (`Guessing wheel URL: ...`)
-> with `curl` and `pip install` the file directly.
-
-**Optional: FlagCX on PPU.** Distributed training works out of the box on the
-NCCL fallback — `PPU_SDK` ships a vendor-adapted `libnccl.so.2` and the PPU torch
-wheel is built with `USE_NCCL=1`, so `ProcessGroupNCCL` exists natively and
-`ProcessGroupFlagOS` uses it on the zero-copy CUDA view. To use FlagCX
-(heterogeneous unified comm) instead, build it from source:
-
-```bash
-git clone https://github.com/FlagOpen/FlagCX.git && cd FlagCX
-# --depth 1 skips submodules; without third-party/json the build fails on
-# "nlohmann/json.hpp: No such file or directory".
-git submodule update --init --depth 1 third-party/json
-
-make -j16 USE_PPU=1 \
-  DEVICE_HOME=/usr/local/PPU_SDK/CUDA_SDK \
-  CCL_HOME=/usr/local/PPU_SDK/CUDA_SDK
-
-# Build the torch plugin with the *nvidia* adaptor, not the auto-detected `ppu`
-# one. Both produce identical torch-side code (PPU is CUDA-ABI: same
-# CUDAStreamGuard, CUDAEvent, devName="cuda"), but FlagCX only compiles its
-# extended_api creator for the NVIDIA and MetaX adaptors, so `nvidia` gets the
-# richer ProcessGroupFlagCX binding. `ppu` currently also fails to compile —
-# PPU is missing from the plugin's per-adaptor #ifdef chains.
-cd plugin/torch && FLAGCX_ADAPTOR=nvidia FLAGCX_HOME=$(git rev-parse --show-toplevel) \
-  python setup.py install
-```
-
-`import torch_fl` then prefers FlagCX automatically (`_try_build_flagcx` runs
-before the NCCL fallback); no env var is needed beyond putting `libflagcx.so` on
-the loader path:
-
-```bash
-LD_LIBRARY_PATH=/path/to/FlagCX/build/lib:$LD_LIBRARY_PATH \
-  python tests/manual/test_flagos_dist_live.py --world-size 4
-```
-
-**Run tests:**
-
-```bash
-# Pure boxing
-FLAGOS_DISABLE_CUDA_ASSETS=1 pytest tests/unit tests/integration/ops \
-  tests/integration/test_factory_ops.py -q -m "not flaggems and not flaggems_python"
-
-# FlagGems path (first run is slow: Triton compiles/autotunes every kernel)
-FLAGOS_DISABLE_CUDA_ASSETS=1 FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/ops -q
-
-# Distributed (collectives + DDP). Works on NCCL; add LD_LIBRARY_PATH for FlagCX.
-python tests/manual/test_flagos_dist_live.py --world-size 4
-```
-
-### Build from Source (Hygon DCU Platform)
-
-Hygon DCU (DTK) reuses the **CUDA boxing route** with a dedicated
-`ACCELERATOR=dcu` branch. Two properties of the vendor stack make this work:
-
-- The DCU `torch` wheel is a **hipified** build: it registers its HIP kernels
-  under the `CUDA` dispatch key and its tensors report `DeviceType::CUDA`
-  (`torch.version.cuda is None`, `torch.version.hip == '6.3.x'`). So the
-  generated PrivateUse1 → CUDA boxing kernels
-  (`csrc/aten/generated/cuda_kernels.cc`) dispatch into `libtorch_hip.so`
-  unchanged.
-- DTK ships a **CUDA compatibility toolkit** at `$DTK_ROOT/cuda/cuda-*` whose
-  `libcudart.so.12` is a thin shim over `libgalaxyhip.so` — the same runtime
-  `libtorch_hip.so` uses, so there is one driver state, not two. The runtime
-  sources under `csrc/runtime/accelerator/cuda/` therefore compile as-is with
-  plain host `g++`; no `nvcc`, no `hipcc`, no hipify pass.
-
-The build is **pure boxing**: `CUDA_KERNEL`, `FLAGGEMS_KERNEL` and
-`FLAGGEMS_PYTHON` are all forced off (DTK ships its own Triton, so the
-NVIDIA-targeted PyPI `triton` wheel is the wrong artifact and is not pulled in).
-
-```bash
-git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
-
-source /opt/dtk/env.sh          # exports ROCM_PATH; DTK_ROOT also honored
-
-ACCELERATOR=dcu pip install --no-build-isolation -vvv -e .
-```
-
-`DTK_ROOT` resolves from `DTK_ROOT` → `ROCM_PATH` → `/opt/dtk`. Pass it
-explicitly if DTK lives elsewhere.
-
-**Verify:**
-
-```bash
-python -c "
-import torch, torch_fl
-print('device count:', torch.flagos.device_count())
-x = torch.randn(512, 512, device='flagos')
-print('mm matches .cuda():',
-      torch.allclose(torch.mm(x, x).cpu(), torch.mm(x.cpu().cuda(), x.cpu().cuda()).cpu()))
-"
-```
-
-**Run tests** (deselect the FlagGems markers — this is a pure-boxing build):
-
-```bash
-pytest tests/unit tests/integration/test_allocator.py tests/integration/test_factory_ops.py -q
-pytest tests/integration/ops -q -m "not flaggems and not flaggems_python"
-```
-
-Notes:
-
-- **Memory pool.** flagos tensors and the boxed kernels' outputs share one pool.
-  `dcu_memory.h` delegates caching to torch's own allocator through the
-  device-generic registry (`c10::getDeviceAllocator(kCUDA)`) rather than the
-  `c10::cuda::` namespace — the DCU wheel exports `c10::hip::HIPCachingAllocator`
-  and has zero `c10::cuda` symbols, and `cuda_runtime.h` cannot share a
-  translation unit with `hip/hip_runtime.h`. So `memory_allocated()` /
-  `memory_reserved()` / `empty_cache()` report and act on real usage.
-- **`record_stream` is a no-op** on DCU: building a `c10::Stream` from a raw
-  stream handle needs `c10::cuda::getStreamFromExternal`, which this wheel does
-  not export.
-- **`.cuda()` autograd and `torch_fl` cannot share a process.** PyTorch's
-  `register_privateuse1_backend` makes `at::getAccelerator()` return
-  `PrivateUse1`, so the autograd engine finds no stream metadata for a
-  pure-CUDA graph and asserts in `engine.cpp`. This is upstream PrivateUse1
-  behaviour, identical on CUDA/MetaX/Ascend — flagos-device autograd is
-  unaffected. Take `.cuda()` baselines in a separate process.
-- **DTK's exported MIOpen CMake config** bakes in `/usr/lib/x86_64-linux-gnu/librt.so`,
-  which no longer exists on glibc ≥ 2.34 (librt was folded into libc). The
-  `ACCELERATOR=dcu` branch rewrites that dangling absolute path to `-lrt`.
-
-#### Enabling FlagGems on DCU
-
-DTK ships its own Triton (the `hcu` backend) and a FlagGems build whose `hygon`
-vendor declares `device_name="cuda"`, which is exactly what the boxing route
-expects. Both live in the DTK system interpreter, so point your env at them
-rather than installing the PyPI wheels (which target NVIDIA):
-
-```bash
-pip install pyyaml sqlalchemy          # flag_gems imports these
-mkdir -p /path/to/gems_path && cd /path/to/gems_path
-ln -s /usr/local/lib/python3.10/dist-packages/triton .
-ln -s /usr/local/lib/python3.10/dist-packages/flag_gems .
-
-ACCELERATOR=dcu FLAGGEMS_PYTHON=1 pip install --no-build-isolation -e .
-
-export PYTHONPATH=/path/to/gems_path
-export TRITON_BACKENDS_IN_TREE=1       # this install has no dist-info, so
-                                       # entry-point backend discovery finds nothing
-export FLAGOS_USE_FLAGGEMS=1
-pytest tests/integration/ops -q        # no marker deselection needed
-```
-
-`GEMS_VENDOR=hygon` is set automatically on a DCU build, so you no longer need to
-export it. This matters beyond FlagGems: `GEMS_VENDOR` also selects the comm
-profile (see `torch_fl/comm/process_group.py`), and DCU is a CUDA-ABI vendor
-whose `ProcessGroupNCCL` is RCCL underneath. Export it yourself only to override.
-
-A DCU build records `ACCELERATOR=dcu` in `torch_fl/_build_config.py`, so
-`FLAGOS_USE_FLAGGEMS=1` alone selects `backends_dcu_flaggems.conf` — no need to
-re-export `ACCELERATOR` at runtime. That config is `backends_flaggems.conf` with
-the ops `hcu` Triton cannot compile or run routed back to the cuda boxing
-kernel: `silu_backward` (`tl.math.div_rn` has no `create_precise_divf` lowering)
-and `slice_backward` (its output is correct standalone, but feeding that grad to
-MIOpen's `convolution_backward` triggers a hardware VMFault). Override per op
-with `FLAGOS_OP_<name>=flagos_python|cuda`.
-
-#### Multi-card on DCU
-
-Multi-card works with FlagGems on, over FlagCX or the RCCL fallback. Nothing extra
-to configure — the automatic `GEMS_VENDOR=hygon` routes `ProcessGroupFlagOS` to the
-CUDA-ABI profile (zero-copy `_flagos_to_cuda_view` + `ProcessGroupNCCL`, which on
-DTK is RCCL: `dist.is_nccl_available()` is `True` and `torch.cuda.nccl.version()`
-reports `(2, 22, 3)`).
-
-```bash
-export HSA_FORCE_FINE_GRAIN_PCIE=1     # RCCL warns when unset; affects
-                                       # multi-card throughput and stability
-python tests/manual/test_flagos_dist_live.py --world-size 2
-```
-
-Note that factory ops honoring their `device` index is a prerequisite here: every
-rank>0 worker builds its tensors via a factory, and an output allocated on device 0
-while the Triton kernel launches on device N is a cross-device write that faults
-the GPU. See `tests/integration/test_factory_device_index.py`.
-
-### Build from Source (Enflame GCU Platform)
-
-Enflame GCU takes the **native operator route** (like Ascend), not CUDA boxing:
-the TopsRider stack has no CUDA runtime to box against, and the vendor
-`torch-gcu` wheel claims `PrivateUse1` for itself, so it cannot coexist with
-`torch_fl`. Instead the plugin links the vendor libraries directly:
-
-- `libtopsrt.so` (tops runtime) backs the device / memory / stream layer.
-- `libtopsaten.so` (ATen-style operator library) backs the compute ops. Its call
-  shape is a single direct call — no workspace/executor phase like aclnn.
-
-```bash
-# Upstream CPU torch wheel is enough; no vendor torch needed.
-pip install torch==2.10.0 --index-url https://download.pytorch.org/whl/cpu
-
-ACCELERATOR=gcu pip install --no-build-isolation -vvv -e .
-```
-
-`scripts/codegen_gcu.py` generates the kernels. It validates every op against
-the demangled `topsaten::topsatenXxx` symbols actually present in
-`libtopsaten.so` and skips any that are missing, so a codegen run cannot emit a
-call the installed SDK does not have.
-
-**GCU-specific notes:**
-
-- **Ops without a topsaten kernel are not registered on `PrivateUse1`** at all,
-  so they reach the `cpu_fallback` instead of raising. Adding coverage is a
-  matter of extending the `OPS` table in `scripts/codegen_gcu.py`.
-- **topsaten has no int64 kernels**: every op returns `NOT_SUPPORT` for an
-  `I64` operand. Each generated kernel therefore guards on dtype and runs the
-  op on CPU for int64, which keeps indices, masks and counters working. It also
-  rejects rank-0 shapes, so 0-dim tensors are described as 1-element vectors.
-- **tops device pointers are device-scoped** (no unified addressing): a pointer
-  only resolves against the *current* device, so the allocator and every kernel
-  select the device first, and the default stream is per-device.
-- **A build with native kernels installs a `lib/flagos_platform` marker** so
-  `torch_fl` picks `backends_gcu.conf` rather than the default CUDA routing.
-- Build with `-DGCU_KERNEL=OFF` to skip topsaten entirely; the runtime still
-  works and all compute falls back to CPU.
-
-### Build from Source (Moore Threads MUSA Platform)
-
-MUSA takes the **native operator route**, like Ascend and GCU: the MUSA toolkit
-ships no CUDA runtime, so there is no vendor dispatch key to box into, and the
-generated kernels call the vendor kernel library — **mudnn** (`libmudnn.so`) —
-directly.
-
-mudnn links against `musart` only and pulls in **no torch symbols at all**, which
-is the property that matters here: nothing in the backend embeds torch's C++
-object layout. Only the MUSA toolkit is required — no `torch_musa` package and no
-extracted vendor tree.
-
-The supported target is **`torch==2.10.0+cpu`**, which is what is built and tested
-on this platform. Because mudnn carries no torch symbols the backend is not
-*structurally* pinned to that version — it was also run clean against 2.9.1 from
-the same source tree — but only 2.10.0+cpu is verified, so treat other versions as
-untested rather than supported.
-
-The target machine needs only:
-
-- The official `torch==2.10.0+cpu` wheel (from PyPI, no CUDA)
-- This `torch_fl` wheel
-- The MUSA toolkit under `/usr/local/musa` (`musart` + `mudnn`), present on any
-  machine with a Moore Threads card
-
-```bash
-pip install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
-ACCELERATOR=musa pip install --no-build-isolation -vvv -e .
-```
-
-`--no-build-isolation` is not optional here. Without it pip resolves its own torch
-into a build overlay, and the extension links against that instead of the torch
-you installed — the resulting `import torch_fl` fails with
-`undefined symbol: c10::ValueError`.
-
-> An earlier version of this backend called `torch_musa`'s flat `at::musa::*` API
-> from `libmusa_python.so` instead. That library links against torch and so embeds
-> torch's C++ object layout, which pinned the plugin to one exact torch build:
-> `sizeof(c10::MessageLogger)` changed 408 → 400 between 2.9.1 and 2.10, and the
-> vendor `.so` stack-allocates the larger size at 312 call sites, so mixing
-> versions corrupts its stack (`tensor.sum()` segfaults inside `empty_musa`).
-> mudnn has no such coupling.
-
-`scripts/codegen_mudnn.py` generates the kernels, category-driven like
-`codegen_gcu.py`: an `OPS` table maps each aten op onto a mudnn
-`Unary`/`Binary`/`Reduce`/`MatMul`/`BatchMatMul`/`Softmax` mode. Coverage is
-**64 generated ops** plus 2 handwritten convolution kernels; everything outside
-that set reaches the `cpu_fallback`.
-
-Two mudnn properties shape the kernels, both verified against the library rather
-than assumed:
-
-- **mudnn Tensors carry strides on both operands, and honour 0-strides.** So
-  broadcasting is just `expand()` (a view) and non-contiguous inputs are read in
-  place. The GCU templates have to `.contiguous()` in both cases.
-- **int64 works across Unary/Binary/Reduce/MatMul.** topsaten has no int64
-  kernels at all, so the GCU kernels carry an int64 CPU-fallback branch; here only
-  genuinely unmapped dtypes (complex, quantized) fall back.
-
-`sinh`, `cosh` and `asin` have no mudnn mode and are deliberately left
-unregistered, so they reach the `cpu_fallback` and stay correct. `neg`, `trunc`
-and `expm1` have no mode either but compose exactly from one (`MUL` by -1,
-`TRUNCATEDIV` by 1, `EXP` then `SUB` 1) and are verified against CPU.
-
-**Convolution** is handwritten rather than generated
-(`csrc/aten/backends/musa/mudnn_conv.cc`), because `convolution_overrideable` is
-the one op that cannot be left unregistered: ATen's default for it raises rather
-than being boxable to CPU. mudnn's `Convolution` covers 2 spatial dims only, so
-conv1d runs as a 2D conv with a unit `H` dim (exact against CPU) and conv3d takes
-the CPU fallback. Bias is a separate broadcast `Binary::ADD` — `RunFusion` accepts
-a bias only for the plain non-grouped 2D case. The algorithm is chosen by trial
-and cached per shape, since `GetRecommendForwardAlgorithm` can name one the `Run`
-then rejects.
-
-**MUSA-specific notes:**
-
-- **TF32 follows `torch.backends.cuda.matmul.allow_tf32`.** mudnn enables TF32 by
-  default whereas torch defaults matmul TF32 *off*; left at the mudnn default a
-  64×64 float `mm` drifts ~2e-2 from CPU. The handle is refreshed from torch's
-  flag on every op.
-- **Strided copies and dtype casts go through mudnn's `Unary::IDENTITY` /
-  `Unary::CAST`** (`csrc/aten/backends/musa/mudnn_copy.cc`), which handle both in
-  a single device pass. Without that, `copy_`/`clone`/`contiguous` would reach the
-  CUDA `DispatchStub` and fail with "missing kernel for cuda".
-- **A fully broadcast input is materialized before a multi-dim reduction.** mudnn
-  v3300's `Reduce` raises `SIGFPE` — an uncatchable crash, not an error status —
-  when reducing over more than one dim of a tensor that is a broadcast of a single
-  element. Conv bias gradients hit exactly that, since autograd feeds
-  `ones.expand(...)` into the reduction.
-- **flagos keeps its own caching allocator** over raw `musaMalloc`. mudnn
-  allocates nothing on its own beyond op workspaces, which are served from that
-  same allocator via a `MemoryMaintainer`.
-- **Import `torch_fl` before `torch`**, or export
-  `TORCH_DEVICE_BACKEND_AUTOLOAD=0` — but only if the `torch_musa` package happens
-  to be installed alongside. It registers a `torch.backends` entry point, so a
-  bare `import torch` autoloads it and claims the `PrivateUse1` backend name
-  first. `torch_fl` sets that variable itself, which covers the torch_fl-first
-  order; the other order fails with an explicit message. Nothing of `torch_musa`
-  is used either way.
-- **No CUDA boxing kernels or FlagGems are compiled** — the MUSA toolkit exports
-  no cuda symbols. A build installs a `lib/flagos_platform` marker so `torch_fl`
-  picks `backends_musa.conf`.
-- Build with `-DMUSA_KERNEL=OFF` to skip mudnn entirely; the runtime still works
-  and all compute falls back to CPU.
-
-### Build from Source (D-Robotics RDK BPU Platform)
-
-The BPU is the one platform here with **no operator kernels at all**. Its BPU
-executes whole compiled graphs (a `.hbm` produced by hbdk4), not individual ops,
-so there is nothing for a `PrivateUse1` kernel to call. `torch_fl` supplies a
-real device — UCP-backed memory plus the device/stream layer — and a
-`torch.compile` backend; eager ops run on the CPU.
-
-The supported target is **`torch==2.10.0+cpu`** (the cp314 aarch64 wheel on
-PyPI is what the board runs), and `setup.py`'s `TORCH_PIN` enforces
-`torch>=2.10,<2.11` here as on every other platform. That pin is not
-incidental: the checked-in `csrc/aten/generated/*` bindings are generated
-against one ATen surface, so a newer torch fails as a wall of compile errors
-rather than a clean resolver error.
-
-```bash
-# Upstream CPU torch wheel; the Horizon runtime ships in the board image.
-pip install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
-ACCELERATOR=bpu pip install --no-build-isolation -vvv -e .
-```
-
-```python
-import torch, torch_fl
-
-compiled = torch.compile(MyNet().eval(), backend="bpu")
-out = compiled(torch.randn(1, 3, 224, 224))
-```
-
-**BPU-specific notes:**
-
-- **No SDK root to configure.** `libhbucp.so` (UCP allocator) and `libbpu.so`
-  (core/task API) ship at `/usr/hobot/lib` with headers at `/usr/include/hobot`.
-- **hbdk4 compiles on the board, on the stock kernel.** The compiler ships
-  x86_64-only wheels, so it runs under box64 — which needs to be **built from
-  source**: the packaged 0.2.6 aborts on this board's 64 KB pages, while 0.4+
-  handles them at runtime. No VM, no cross-compile host, no kernel rebuild.
-  Run `scripts/setup_bpu_hbdk4.sh` once, then export
-  `FLAGOS_BPU_X86_PYTHON` and `FLAGOS_BPU_X86_EMULATOR`. Without a reachable
-  hbdk4 the backend logs a warning and runs every partition on the CPU, so the
-  install is still usable. Details in [docs/vendors/bpu/integration.md](docs/vendors/bpu/integration.md).
-- **Quantization is a precondition, not an optimization.** hbdk4 lowers float
-  conv to the CPU, so int8 Q/DQ insertion is what puts work on the BPU at all.
-  On by default; `FLAGOS_BPU_QUANTIZE=0` for bit-exact float artifacts.
-- **Convolution is registered explicitly.** `aten::convolution` routes
-  `PrivateUse1` to `convolution_overrideable`, whose only other kernel raises,
-  so the boxed fallback cannot reach a CPU implementation. Two wrappers in
-  `register.cc` call `at::convolution` on CPU tensors instead.
-- Measured on-board (torch 2.10): **ResNet-18 at 224x224 runs 1.356 ms on the
-  BPU vs 26.10 ms eager CPU — 19.2x**, which is 1.26x off D-Robotics' own
-  `resnet18_224x224_nv12.hbm` (1.075 ms) despite taking an 8x larger float32
-  input. Accuracy: cosine 0.990 vs eager, top-1 agreement 5/5. Run
-  `benchmarks/bpu_resnet18_bench.py`. Toy nets are a wash — submission overhead
-  dominates.
-- **LLM inference has its own runtime path.** `hbm_runtime` copies every input
-  per call, which for a decode step means copying the KV cache — 336 MiB per
-  token, 68.4 ms against the vendor's 11.4. `infer.py` binds `hbDNNInferV2`
-  directly with device-resident buffers and a sliding-window cache, reaching
-  **82.1 tok/s decode on Qwen3-0.6B against the vendor `llm` demo's 84.8–87.7**
-  on the same artifact. Run `benchmarks/bpu_qwen3_bench.py`. This drives a
-  prebuilt vendor `.hbm`, not a `torch.compile` graph.
-- **Stock transformers compile too, correctly but not yet quickly.** A
-  HuggingFace `Qwen3ForCausalLM` under `torch.compile(backend="bpu")` runs from
-  its traced graph at **cosine 0.9910 against eager float**, with its largest
-  partitions offloading whole (30/30 and 22/22 nodes). Coverage is capped by
-  Dynamo's symbolic shapes rather than by missing ops — hbdk4 cannot compile a
-  symbolic dim at all — so tracing at a fixed sequence length is what raises it.
-  See [docs/vendors/bpu/integration.md](docs/vendors/bpu/integration.md#stock-transformers-under-torchcompile).
-
-### Build Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `ACCELERATOR` | Hardware platform: `cuda` (default), `metax`, `ascend`, `tsingmicro`, `dcu`, `gcu`, `musa`, or `bpu` |
-| `CUDA_HOME` | CUDA toolkit path |
-| `DTK_ROOT` | Hygon DTK path (falls back to `ROCM_PATH`, then `/opt/dtk`; required for DCU build) |
-| `TOPS_HOME` | Enflame TopsRider SDK path (default `/opt/tops`; required for GCU build) |
-| `METAX_PATH` | MetaX SDK path (default `/opt/maca`; required for MetaX build) |
-| `METAX_ARCH` / `METAX_MXCC` | Optional GPU arch or `mxcc`/`cucc` compiler path |
-| `METAX_KERNEL` | Enable MetaX C++ kernel build (`ON`/`OFF`; auto-enabled when `ACCELERATOR=metax`) |
-| `ASCEND_HOME` | CANN toolkit path (default `/usr/local/Ascend/ascend-toolkit/latest`) |
-| `FLAGGEMS_DIR` | FlagGems C++ library path (enables low-overhead C++ dispatch) |
-| `FLAGGEMS_KERNEL` | Enable FlagGems C++ kernel wrappers (`ON`/`OFF`, default `ON`; set `0` for Ascend) |
-| `FLAGGEMS_PYTHON` | Enable FlagGems Python kernel wrappers (`ON`/`OFF`, default `OFF`; set `1` to enable) |
-| `CUDA_KERNEL` | Enable CUDA kernel build (`ON`/`OFF`, default `ON`; set `0` for Ascend) |
-| `ASCEND_KERNEL` | Enable Ascend kernel build (`ON`/`OFF`, default `OFF`; set `1` for Ascend) |
-| `GCU_KERNEL` | Enable Enflame GCU topsaten kernel build (`ON`/`OFF`, auto-enabled when `ACCELERATOR=gcu`) |
-| `MUSA_HOME` | Moore Threads MUSA toolkit path (default `/usr/local/musa`; required for MUSA build) |
-| `MUSA_KERNEL` | Enable the MUSA mudnn kernel build (`ON`/`OFF`, auto-enabled when `ACCELERATOR=musa`); `OFF` falls back to CPU for all compute |
-| `FLAGOS_BPU_X86_PYTHON` | Path to an x86_64 python with `hbdk4-compiler`, run under box64 (BPU compile path; see [docs/vendors/bpu/integration.md](docs/vendors/bpu/integration.md)) |
-| `FLAGOS_BPU_X86_EMULATOR` | Path to a box64 binary (0.4+); the packaged 0.2.6 cannot run on this board's 64 KB pages |
-| `FLAGOS_BPU_X86_STUBS` | numba/torch import stubs for the emulated interpreter (defaults next to the x86 python) |
-
-### Runtime Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `FLAGOS_METAX_CUDART_SHIM` | Set to `1` to preload libcudart compatibility shim before `import torch` (often needed with generic PyTorch wheels) |
-| `FLAGOS_METAX_COMPAT` | Set to `1` to patch FlagGems `torch.cuda` device queries for MetaX |
-| `GEMS_VENDOR` | FlagGems vendor name; set to `metax` on MetaX |
-| `LD_PRELOAD` | Often set to `/opt/maca/lib/libsymbol_cu.so` for cu-bridge symbol resolution |
-| `FLAGGEMS_SOURCE_DIR` | FlagGems source directory (required when ops route to `flaggems` or `flagos_python`) |
-| `FLAGOS_BACKEND_CONFIG` | Override backend routing config (MetaX: `backends_metax.conf` or `backends_metax_flagos_py.conf`) |
-| `FLAGOS_DISABLE_FLAGGEMS_PY` | Set to `1` to disable FlagGems Python-layer registration (C++ stub-only mode) |
-| `FLAGOS_LOG_DISPATCH` | Set to `1` to print backend selection for each operator dispatch |
-| `FLAGOS_OP_<name>` | Per-operator backend override (replace `.` with `__` in op names) |
-| `TORCH_DEVICE_BACKEND_AUTOLOAD` | Set to `0` to stop a vendor plugin (e.g. `torch_musa`) from claiming `PrivateUse1` during `import torch`; `torch_fl` sets this itself on MUSA builds |
-| `FLAGOS_BPU_MARCH` | BPU micro-architecture (default `nash-p`) |
-| `FLAGOS_BPU_QUANTIZE` | BPU int8 Q/DQ insertion (default `1`; `0` compiles float, which keeps conv on the CPU) |
-| `FLAGOS_BPU_ACT_SCALE` | BPU fallback activation scale for uncalibrated tensors (default `0.05`) |
-| `FLAGOS_BPU_CACHE` | BPU `.hbm` artifact cache (default `~/.cache/torch_fl_bpu`) |
-
-## Usage
-
-### Basic Usage
+Choose your platform in the [Installation Guide](docs/getting-started/installation.md), then try the following:
 
 ```python
 import torch
-import torch_fl  # Import automatically registers FlagGems operators
+import torch_fl
 
-# Create tensors on flagos device
-x = torch.randn(1000, 1000, device="flagos")
-y = torch.randn(1000, 1000, device="flagos")
+# Create a tensor on the flagos device
+x = torch.randn(4, 4, device="flagos:0")
 
-# All operations automatically use FlagGems Triton kernels
-z = x + y
-mm_result = torch.mm(x, y)
-softmax_result = torch.softmax(x, dim=-1)
+# Operations route to platform-appropriate kernels
+y = torch.relu(x @ x)
+
+# Move result back to CPU
+print(y.cpu())
 ```
 
-### Data Transfer Between Devices
+Operator routing (FlagGems, vendor kernels, compatibility boxing, or CPU fallback) is determined by platform detection and runtime configuration. The code above works unchanged across all supported accelerators.
 
-```python
-cpu_tensor = torch.randn(3, 3)
-flagos_tensor = cpu_tensor.to("flagos")
-back_to_cpu = flagos_tensor.cpu()
-```
+For device queries, synchronization, and multi-device usage patterns, see the [Quick Start Guide](docs/getting-started/quickstart.md).
 
-### Device Context Management
+## Documentation
 
-```python
-with torch_fl.flagos.device(0):
-    a = torch.randn(10, 10, device="flagos")
-```
+### Getting Started
 
-### MetaX Platform Import Order
+- [Installation](docs/getting-started/installation.md) — Platform selection and source builds
+- [Quick Start](docs/getting-started/quickstart.md) — Basic usage patterns
 
-On MetaX hardware, you **must** import `torch_fl` before `import torch`:
+### Reference
 
-```python
-import torch_fl  # Must import first
-import torch
-```
+- [Compatibility Matrix](docs/reference/compatibility.md) — Per-platform capability validation and status
+- [Environment Variables](docs/reference/environment-variables.md) — Build and runtime configuration
 
-Reason: PyTorch's bundled CUDA 12.x runtime is ABI-incompatible with MetaX's cu-bridge (CUDA 11.6 compatibility layer). `torch_fl` preloads a shim library to provide the required symbol versions.
+### Architecture
 
-This restriction does not apply to CUDA platforms.
+- [Distributed Collectives](docs/architecture/distributed-flagcx.md) — ProcessGroupFlagOS, FlagCX, and vendor fallbacks
+- [Profiler Integration](docs/architecture/profiler.md) — torch.profiler parity and CUPTI integration
+- [torch.compile Integration](docs/architecture/torch-compile-integration.md) — Inductor GPU device registration
 
-### MetaX Runtime Setup
+### Platform Guides
 
-Before running tests or inference on MetaX, source the SDK paths and hybrid backend config:
+- [CUDA (NVIDIA)](docs/vendors/cuda/installation.md)
+- [MetaX](docs/vendors/metax/installation.md)
+- [Ascend (Huawei)](docs/vendors/ascend/installation.md)
+- [PPU](docs/vendors/ppu/installation.md)
+- [Hygon DCU](docs/vendors/dcu/installation.md)
+- [Enflame GCU](docs/vendors/gcu/installation.md)
+- [Moore Threads MUSA](docs/vendors/musa/installation.md)
+- [D-Robotics BPU](docs/vendors/bpu/installation.md)
 
-```bash
-export METAX_PATH=/opt/maca
-export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:/opt/maca/mxgpu_llvm/bin:$PATH
-export LD_LIBRARY_PATH=/opt/maca/tools/cu-bridge/lib:/opt/maca/lib:/opt/maca/mxgpu_llvm/lib:/opt/mxdriver/lib:$LD_LIBRARY_PATH
-export LD_PRELOAD=/opt/maca/lib/libsymbol_cu.so
+## Contributing
 
-export FLAGOS_METAX_CUDART_SHIM=1
-export FLAGOS_METAX_COMPAT=1
-export GEMS_VENDOR=metax
-export FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_metax_flagos_py.conf
-export FLAGGEMS_SOURCE_DIR=$(python -c "import os,flag_gems;print(os.path.dirname(flag_gems.__file__))")
-```
+Contributions are welcome in these areas:
 
-#### MetaX runtime notes
+- **Operators**: Add missing operators or optimize existing implementations for specific backends.
+- **Runtime and platform integration**: Port torch-fl to new accelerators or improve existing backend support.
+- **Compiler integration**: Extend torch.compile support, improve Triton codegen, or add new compilation backends.
+- **Distributed and profiler work**: Enhance collective communication backends or profiling integration.
+- **Tests**: Add operator correctness tests, model integration tests, or performance benchmarks.
+- **Documentation**: Improve setup guides, troubleshooting docs, or vendor-specific integration notes.
 
-- **Boxing wheel**: The [self-contained boxing wheel](#build-from-source-metax-platform) (`FLAGOS_METAX_BOXING=1`) reuses PyTorch's CUDA boxing kernels and bundles the forked libtorch, running on official `torch+cpu` with no `mxcc`. By default ops route to `cuda` via `backends_cuda.conf` (no Triton, no extra deps). Setting `FLAGOS_USE_FLAGGEMS=1` opts into the FlagGems `flagos_python` path (`backends_metax_flaggems.conf`), which requires target-side `triton-metax` + `flag_gems`; ops triton-metax cannot run fall back to the `cuda` boxing kernel.
-- **`flash_attn`**: Prebuilt MetaX `flash_attn` wheels may ABI-mismatch newer PyTorch versions. Disable or patch before loading Qwen3/transformers if import fails.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, code generation procedures, testing requirements, and PR guidelines.
 
-### C++ Stub-Only Mode
+**All GitHub-facing text must be written in English** — PR titles, PR descriptions, commit messages, issue text, and code review comments. This repository's code, comments, and history are in English, and PRs are reviewed by contributors who do not read other languages.
 
-You can disable the FlagGems Python-layer registration entirely, leaving only the C++ unified wrapper active. This is useful for verifying that all required operators are covered by C++ stubs.
+## Acknowledgements
 
-```bash
-# Required: tell FlagGems C++ native API where to find Triton kernel sources
-export FLAGGEMS_SOURCE_DIR=$(python -c "import os;import flag_gems;print(os.path.dirname(flag_gems.__file__))")
+torch-fl builds on several upstream projects:
 
-python your_script.py
-```
+- **PyTorch** — The PrivateUse1 extension mechanism and ATen operator surface
+- **FlagGems** — Triton-based portable operator kernels
+- **Triton** (via FlagTree and vendor distributions) — GPU kernel compilation infrastructure
+- **FlagCX** — Heterogeneous collective communication library
+- **Vendor runtime and operator libraries** — ACLNN (Ascend), mudnn (MUSA), topsaten (GCU), cu-bridge (MetaX), DTK (DCU), and others
 
-In this mode, all operator dispatch is handled by the C++ dispatch stub (`backends.conf` routing), with no Python-layer `torch.library` registrations from FlagGems.
-
-### Query Status
-
-```python
-torch_fl.flagos.is_available()       # Check if device is available
-torch_fl.flagos.device_count()       # Number of devices
-torch_fl.flagos.current_device()     # Current device index
-torch_fl.flagos.synchronize()        # Synchronize device
-torch_fl.is_flaggems_enabled()       # Check if FlagGems operators are registered
-torch_fl.get_registered_ops()        # List of registered operators
-```
-
-## Backend Configuration
-
-You can configure whether to use FlagGems or CUDA backend at per-operator granularity.
-
-### Configuration File
-
-Default path is `torch_fl/configs/backends.conf`, can be overridden via `FLAGOS_BACKEND_CONFIG` environment variable:
-
-```ini
-# Format: op_name = backend
-# backend: "flagos" | "flaggems" | "cuda"
-# Operators not listed default to flagos (FlagGems)
-mm = cuda
-bmm = flagos
-cat = cuda
-```
-
-### Environment Variable Override
-
-Individual operators can be overridden via environment variables (higher priority):
-
-```bash
-# Format: FLAGOS_OP_<op_name>=cuda|flaggems
-# Replace "." in operator names with "__"
-export FLAGOS_OP_mm=cuda
-export FLAGOS_OP_mm__out=cuda
-```
-
-### MetaX backend configs
-
-| File | Purpose |
-|------|---------|
-| `torch_fl/configs/backends_metax.conf` | All listed ops → `metax` C++ kernels. Default when pytest detects MetaX (`/dev/mxcd`) and `FLAGOS_BACKEND_CONFIG` is unset. |
-| `torch_fl/configs/backends_metax_flagos_py.conf` | **Recommended for integration tests.** Hybrid routing: most compute ops → `flagos_python`; keep Triton-incompatible ops (`mm`/`bmm`/`mean.dim`) and factory/allocation ops (`zeros`, `scalar_tensor`, `embedding`, …) on `metax`. |
-
-Example (`backends_metax_flagos_py.conf`):
-
-     # elementwise / inference-path ops
-     abs = flagos_python
-     add.Tensor = flagos_python
-     cos = flagos_python
-     sin = flagos_python
-
-     # Triton-incompatible
-     mm = metax
-     bmm = metax
-     mean.dim = metax
-     # factory/allocation
-     zeros = metax
-     scalar_tensor = metax
-
-### Debug Dispatch
-
-```bash
-export FLAGOS_LOG_DISPATCH=1  # Print backend selection for each operator dispatch
-```
-
-## Testing
-
-Tests in `tests/integration/ops/` are marked with `@pytest.mark` to indicate platform scope:
-
-| Mark | Meaning | When to run |
-|------|---------|-------------|
-| `@pytest.mark.anyplatform` | Correctness tests, run everywhere | Always |
-| `@pytest.mark.cuda` | CUDA/FlagGems dispatch routing tests | CUDA platform only |
-| `@pytest.mark.ascend` | Ascend backend dispatch tests | Ascend platform only |
-
-### CUDA Platform
-
-```bash
-# Operator tests (requires FlagGems source for C++ native API)
-FLAGGEMS_SOURCE_DIR=/path_to_repos/FlagGems/src/flag_gems \
-  pytest tests/integration/ops/ -v -m "anyplatform or cuda"
-
-# Qwen3 inference test
-FLAGGEMS_SOURCE_DIR=/path_to_repos/FlagGems/src/flag_gems \
-  pytest tests/integration/test_qwen3_infer.py -v -s
-
-# Qwen3 training test (single GPU)
-FLAGGEMS_SOURCE_DIR=/path_to_repos/FlagGems/src/flag_gems \
-  pytest tests/integration/test_qwen3_train.py -v -s --steps 10
-
-# Run only CUDA-specific tests
-pytest tests/integration/ops/ -v -m cuda
-
-# Run only FlagGems (Triton) backend tests
-pytest tests/integration/ops/ -v -m flaggems
-
-# Run only FlagGems Python wrapper tests
-pytest tests/integration/ops/ -v -m flaggems_python
-
-# Run platform-agnostic correctness tests
-pytest tests/integration/ops/ -v -m anyplatform
-
-# FlagGems Python wrapper (flagos_python) end-to-end tests
-FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_flagos_py.conf \
-  pytest tests/integration/ops/ -v
-```
-
-### MetaX Platform
-
-```bash
-# Runtime (see "MetaX Runtime Setup" above)
-export METAX_PATH=/opt/maca
-export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:$PATH
-export LD_LIBRARY_PATH=/opt/maca/tools/cu-bridge/lib:/opt/maca/lib:$LD_LIBRARY_PATH
-export LD_PRELOAD=/opt/maca/lib/libsymbol_cu.so
-export FLAGOS_METAX_CUDART_SHIM=1
-export FLAGOS_METAX_COMPAT=1
-export GEMS_VENDOR=metax
-export FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_metax_flagos_py.conf
-export FLAGGEMS_SOURCE_DIR=$(python -c "import os,flag_gems;print(os.path.dirname(flag_gems.__file__))")
-
-# Basic op tests (includes Qwen3 inference-path ops: cos/sin/rsqrt/silu/...)
-pytest tests/integration/test_ops.py -v
-
-# Per-op dispatch tests (hybrid config)
-pytest tests/integration/ops/ -v
-
-# Qwen3 inference
-pytest tests/integration/test_qwen3_infer.py -v -s --model /path/to/Qwen3-0.6B
-
-# Qwen3 training (single device)
-pytest tests/integration/test_qwen3_train.py -v -s --steps 10
-
-# All-metax C++ kernel mode (no flagos_python)
-FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_metax.conf \
-  FLAGOS_DISABLE_FLAGGEMS_PY=1 \
-  pytest tests/integration/test_ops.py -v
-```
-
-If `FLAGOS_BACKEND_CONFIG` is not set, `tests/integration/conftest.py` auto-selects `torch_fl/configs/backends_metax.conf` on MetaX hardware.
-
-### Ascend Platform
-
-```bash
-# Operator tests
-FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_ascend.conf \
-  pytest tests/integration/ops/ -v -m "anyplatform or ascend"
-
-# Qwen3 inference test
-FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_ascend.conf \
-  pytest tests/integration/test_qwen3_infer.py -v -s
-
-# Qwen3 training test (single GPU)
-FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_ascend.conf \
-  pytest tests/integration/test_qwen3_train.py -v -s --steps 10
-```
-
-The `test_qwen3_infer.py` and `test_qwen3_train.py` tests use the same code on all platforms — only the installation method (`ACCELERATOR=ascend pip install -e .`) and runtime environment variables differ.
-
-### Pytest Marks
-
-Operator tests in `tests/integration/ops/` use pytest marks to indicate platform/backend requirements:
-
-| Mark | Description |
-|------|-------------|
-| `@pytest.mark.anyplatform` | Platform-agnostic correctness tests (shape, dtype, broadcast) |
-| `@pytest.mark.cuda` | Requires CUDA backend or CUDA reference comparison |
-| `@pytest.mark.flaggems` | Requires FlagGems (Triton) backend |
-| `@pytest.mark.flaggems_python` | Requires FlagGems Python wrapper (pybind11 path) |
-| `@pytest.mark.ascend` | Requires Ascend NPU backend |
-
-Use `-m <mark>` to run specific test categories. Example: `pytest tests/integration/ops/ -m cuda` runs only CUDA tests.
-
-## Project Structure
-
-```
-PyTorch-Plugin-FL/
-├── include/                  # Public headers
-│   ├── flagos.h              #   Unified runtime API (memory, stream, device)
-│   └── macros.h              #   Common macros
-├── accelerator/              # Hardware abstraction layer
-│   ├── csrc/cuda/            #   CUDA runtime implementation
-│   ├── csrc/metax/            #   MetaX cudart shim (symbol version compatibility)
-│   └── csrc/ascend/           #   Ascend runtime (ACL-based memory, stream, device)
-├── csrc/
-│   ├── aten/                 # ATen operator layer
-│   │   ├── common.{h,cc}     #   Backend config loading, Backend enum
-│   │   ├── dispatcher.h      #   Lightweight op dispatcher (replaces PyTorch DispatchStub)
-│   │   ├── device_boxing.h   #   Zero-copy flagos↔CUDA tensor metadata conversion
-│   │   ├── register.cc       #   PrivateUse1 dispatch key registration
-│   │   ├── {op}.{h,cc}       #   Per-operator stub definitions (add, mm, silu, etc.)
-│   │   ├── factory_ops/      #   Basic operators (empty, copy, contiguous, set, fallback)
-│   │   ├── functional_ops/   #   Compute operators (mm, bmm, cat, embedding, softmax, etc.)
-│   │   └── backends/         #   Backend-specific kernel implementations
-│   │       ├── cuda/         #     CUDA kernels (cuBLAS, modified PyTorch kernels)
-│   │       ├── flagos/       #     FlagGems C++ native API wrappers
-│   │       └── ascend/       #     Ascend kernels (ACL NN API)
-│   └── runtime/              # Device runtime
-│       ├── device_allocator  #   Device memory allocator
-│       ├── host_allocator    #   Pinned memory allocator
-│       ├── guard             #   DeviceGuard implementation
-│       ├── generator         #   RNG generator
-│       ├── hooks             #   Runtime hooks
-│       └── accelerator/      #   Hardware abstraction layer
-│           ├── cuda/         #     CUDA runtime implementation
-│           ├── maca/         #     MACA cudart shim (symbol version compatibility)
-│           └── ascend/       #     Ascend runtime (ACL-based memory, stream, device)
-├── torch_fl/
-│   ├── __init__.py           # Plugin entry point: register device, load FlagGems operators
-│   ├── flagos/               # Python device module (stream, event, RNG, AMP)
-│   ├── accelerator/          # Python accelerator module (MACA shim loader)
-│   ├── backends.conf              # Default backend routing config (CUDA/FlagGems)
-│   ├── backends_metax.conf        # MetaX: all listed ops → metax
-│   ├── backends_metax_flagos_py.conf  # MetaX hybrid: metax + flagos_python
-│   ├── backends_flagos_py.conf    # FlagGems Python wrapper routing
-│   ├── backends_ascend.conf       # Ascend backend routing (all ops → ascend)
-│   ├── distributed.py        # Distributed training support (DDP patch)
-│   ├── integration.py        # FlagGems operator registration logic
-│   ├── csrc/                 # C extension (module.cc, stub.c)
-│   └── lib/                  # Compiled shared libraries (libtorch_fl.so, libflagos.so)
-├── tests/
-│   ├── integration/          # Automated integration tests
-│   │   ├── ops/              #   Per-operator dispatch tests
-│   │   ├── test_qwen3_*.py   #   End-to-end model tests
-│   │   └── conftest.py       #   Pytest configuration
-│   ├── manual/               # Manual test scripts
-│   └── common/               # Test utilities
-├── debug/                    # Development notes and debug scripts
-├── cmake/                    # CMake modules
-├── setup.py                  # CMake build entry point
-└── pyproject.toml
-```
-
-## Architecture Overview
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│  Python: import torch_fl                                     │
-│  ┌────────────────┐  ┌────────────────────────────┐          │
-│  │ torch_fl.flagos│  │ torch_fl.distributed       │          │
-│  │ (device API)   │  │ (DDP/FSDP patch)           │          │
-│  └────────────────┘  └────────────────────────────┘          │
-├──────────────────────────────────────────────────────────────┤
-│  PrivateUse1 Dispatch                                        │
-│  ┌─────────────┐  ┌──────────┐  ┌───────────┐  ┌────────┐    │
-│  │ FlagGems    │  │ CUDA     │  │ Ascend    │  │ CPU    │    │
-│  │ (Triton)    │  │ (native) │  │ (ACL NN)  │  │fallback│    │
-│  └─────────────┘  └──────────┘  └───────────┘  └────────┘    │
-├──────────────────────────────────────────────────────────────┤
-│  C++ Runtime (csrc/)                                         │
-│  ┌──────────┐ ┌────────┐ ┌───────┐ ┌───────────┐             │
-│  │Allocator │ │ Guard  │ │ RNG   │ │ Hooks     │             │
-│  └──────────┘ └────────┘ └───────┘ └───────────┘             │
-├──────────────────────────────────────────────────────────────┤
-│  Hardware Abstraction (accelerator/)                         │
-│  ┌──────────────┐  ┌─────────────────────┐  ┌────────────┐   │
-│  │ CUDA Runtime │  │ MetaX cu-bridge+shim │  │ Ascend ACL │   │
-│  └──────────────┘  └─────────────────────┘  └────────────┘   │
-└──────────────────────────────────────────────────────────────┘
-```
+These acknowledgements do not imply endorsement by the named projects or vendors.
 
 ## License
 
-Apache-2.0
+torch-fl is licensed under the [Apache License 2.0](LICENSE).

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,188 @@
+# Testing Guide
+
+This document describes the test structure, pytest markers, and commands for running torch_fl tests.
+
+## Test Structure
+
+Tests are organized by scope and purpose:
+
+| Directory | Responsibility |
+|-----------|----------------|
+| `tests/unit/` | Fast, isolated unit tests for utilities, routing logic, and device registration |
+| `tests/integration/` | End-to-end tests requiring GPU hardware: model inference, training, distributed |
+| `tests/integration/ops/` | Individual operator correctness tests against PyTorch reference implementations |
+| `tests/manual/` | Manual verification scripts for features that require specific hardware or interactive setup |
+| `tests/perf/` | Performance benchmarks and profiling scripts |
+
+## Pytest Markers
+
+Operator tests (`tests/integration/ops/`) use markers to select backend-specific and platform-specific tests. All markers are registered in `tests/integration/ops/conftest.py`.
+
+### Backend Markers
+
+| Marker | Meaning | When to Use |
+|--------|---------|-------------|
+| `main_ops` | Representative operator in the CI smoke subset | Applied to frequently-used ops (add, matmul, conv, etc.) for fast feedback |
+| `anyplatform` | Runs on any accelerator backend | Device-agnostic tests (operator registration, dispatch routing) |
+| `cuda` | Requires CUDA boxing kernels or NVIDIA hardware | Tests asserting `-> cuda` backend routing |
+| `metax` | Requires MetaX C++ (mxcc) backend | Tests asserting `-> metax` backend routing; skipped when `FLAGOS_METAX_BOXING=1` |
+| `ascend` | Requires Ascend ACL backend | Tests asserting `-> ascend` backend routing |
+| `musa` | Requires Moore Threads MUSA backend | Tests asserting `-> musa` backend routing |
+| `flaggems` | Requires FlagGems runtime path on (`FLAGOS_USE_FLAGGEMS=1`) | Tests asserting `-> flagos_python` or vendor-fallback routing |
+| `flaggems_python` | Requires FlagGems Python wrapper backend | Tests checking Python-layer integration (dispatch overhead, GIL behavior) |
+| `flaggems_cpp` | Requires FlagGems C++ runtime (`FLAGOS_USE_FLAGGEMS_CPP=1` + wheel built with `FLAGGEMS_KERNEL=ON`) | Tests asserting `-> kFlagOs` (C++) dispatch |
+
+### Platform Detection
+
+Test filtering is automatic: `conftest.py` detects the active platform from `ACCELERATOR`, `lib/flagos_platform`, or `FLAGOS_BACKEND_CONFIG` and skips tests marked for unavailable backends.
+
+## Running Tests
+
+### Prerequisites
+
+- **Unit tests**: No hardware dependencies; run on CPU-only environments.
+- **Integration tests**: Require GPU hardware matching the build (CUDA, MetaX, Ascend, DCU, MUSA, or GCU).
+- **Operator tests**: Require the SDK and runtime libraries for the target platform.
+
+### Unit Tests
+
+```bash
+pytest tests/unit/ -v
+```
+
+### Platform-filtered Operator Tests
+
+Run all operator tests for the current platform:
+
+```bash
+pytest tests/integration/ops/ -v
+```
+
+Run only main operators (CI smoke subset):
+
+```bash
+pytest tests/integration/ops/ -m main_ops -v
+```
+
+Run FlagGems-routed operators (requires `FLAGOS_USE_FLAGGEMS=1`):
+
+```bash
+FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/ops/ -m "flaggems and main_ops" -v
+```
+
+Run FlagGems C++ operators (requires `FLAGGEMS_KERNEL=ON` build + `FLAGOS_USE_FLAGGEMS_CPP=1`):
+
+```bash
+FLAGOS_USE_FLAGGEMS_CPP=1 pytest tests/integration/ops/ -m "flaggems_cpp and main_ops" -v
+```
+
+### Model Tests
+
+Model integration tests accept command-line options for model path and hyperparameters.
+
+**Inference test**:
+
+```bash
+pytest tests/integration/test_inference.py --model <model-path> --max-new-tokens 128 -v
+```
+
+**Training test**:
+
+```bash
+pytest tests/integration/test_train.py --model <model-path> --steps 10 --batch-size 2 -v
+```
+
+Replace `<model-path>` with a Hugging Face model identifier (e.g., `Qwen/Qwen3-0.6B`) or a local directory containing model weights.
+
+### Distributed Tests
+
+Distributed tests require multi-GPU hardware and a collective communication backend (NCCL, FlagCX, or HCCL).
+
+```bash
+pytest tests/integration/test_distributed.py -v
+```
+
+### torch.compile Tests
+
+Compile integration tests verify operator compatibility with PyTorch's inductor backend.
+
+```bash
+pytest tests/integration/test_compile.py -v
+```
+
+**Note**: Compile tests require a working torch.compile environment. On some platforms, additional environment setup may be needed (see [torch.compile Integration](../features/compile.md)).
+
+### Profiler Tests
+
+Profiler tests validate CUPTI integration and device timeline capture.
+
+```bash
+pytest tests/integration/test_profiler.py -v
+```
+
+**Hardware requirement**: NVIDIA GPU with CUDA toolkit installed (CUPTI library).
+
+## Code Generation
+
+torch_fl uses code generation to create operator bindings and backend-specific kernels. Generated files live under `csrc/aten/generated/` and should not be edited manually.
+
+### Regenerating Operator Bindings
+
+When PyTorch's operator schema changes or new operators are added, regenerate the CUDA boxing kernels:
+
+```bash
+python scripts/codegen_ops.py
+```
+
+This reads `torch._C._dispatch_tls_local_include()` and `native_functions.yaml` to generate `csrc/aten/generated/RegisterFlagOS.cpp` and related files.
+
+### Platform-specific Codegen
+
+| Script | Purpose | When to Run |
+|--------|---------|-------------|
+| `scripts/codegen_ops.py` | CUDA boxing kernels (kCUDA dispatch) | After PyTorch version bump or schema changes |
+| `scripts/codegen_autograd.py` | Autograd backward operator wrappers | After adding autograd support for new operators |
+| `scripts/codegen_ascend.py` | Ascend ACL kernel wrappers | After updating CANN version or adding Ascend ops |
+| `scripts/codegen_gcu.py` | GCU topsaten kernel wrappers | After updating TopsRider SDK or adding GCU ops |
+| `scripts/codegen_mudnn.py` | MUSA mudnn kernel wrappers | After updating MUSA toolkit or adding MUSA ops |
+
+**Environment variables for codegen**:
+
+- `FLAGOS_CODEGEN_ALL`: Set to `1` to regenerate all operator bindings (slow; usually unnecessary).
+- Platform SDK paths (`ASCEND_HOME`, `TOPS_HOME`, `MUSA_HOME`, etc.): Required by platform-specific codegen scripts.
+
+## Linting
+
+torch_fl enforces code style with ruff. CI runs these exact commands:
+
+```bash
+ruff check .
+ruff format --check .
+git diff --check
+```
+
+**Required ruff version**: `0.15.12` (pinned in CI; install with `pip install ruff==0.15.12`).
+
+Fix formatting issues automatically:
+
+```bash
+ruff format .
+```
+
+Fix linting issues automatically where possible:
+
+```bash
+ruff check --fix .
+```
+
+`git diff --check` detects trailing whitespace and conflicts. Run it before committing to catch issues early.
+
+## CI Test Selection
+
+GitHub Actions CI runs a subset of tests based on pytest marks:
+
+- **Smoke tests**: `-m main_ops` (CUDA boxing kernels only)
+- **FlagGems tests**: `-m "flaggems and main_ops"` (when `FLAGOS_USE_FLAGGEMS=1`)
+- **Platform tests**: Vendor-specific runners filter by platform marker (e.g., `-m "ascend and main_ops"`)
+
+To replicate CI behavior locally, use the same mark expressions shown above.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -110,7 +110,7 @@ Compile integration tests verify operator compatibility with PyTorch's inductor 
 pytest tests/integration/test_compile.py -v
 ```
 
-**Note**: Compile tests require a working torch.compile environment. On some platforms, additional environment setup may be needed (see [torch.compile Integration](../features/compile.md)).
+**Note**: Compile tests require a working torch.compile environment. On some platforms, additional environment setup may be needed (see [torch.compile Integration](../architecture/torch-compile-integration.md)).
 
 ### Profiler Tests
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,50 @@
+# Installation
+
+## Choose a Platform
+
+| Platform | Build selector | Execution path | Installation guide |
+|---|---|---|---|
+| NVIDIA CUDA | `ACCELERATOR=cuda` (default) | CUDA boxing over an external `libtorch_cuda.so` | [CUDA Installation](../vendors/cuda/installation.md) |
+| MetaX | `ACCELERATOR=metax` | CUDA-boxing reuse via `cu-bridge`/mxcc, or native MetaX kernels | [MetaX Installation](../vendors/metax/installation.md) |
+| Ascend | `ACCELERATOR=ascend` | Native ACLNN operator backend, optional FlagGems via triton-ascend | [Ascend Installation](../vendors/ascend/installation.md) |
+| PPU | `ACCELERATOR=cuda` + `PPU_SDK`/`PPU_HOME` detection | Same CUDA-boxing path as NVIDIA CUDA, against the PPU's CUDA-13-compatible SDK | [PPU Installation](../vendors/ppu/installation.md) |
+| Hygon DCU | `ACCELERATOR=dcu` | CUDA boxing over the hipified DTK torch build (HIP kernels under the CUDA dispatch key) | [DCU Installation](../vendors/dcu/installation.md) |
+| Enflame GCU | `ACCELERATOR=gcu` | Native `libtopsaten.so` operator backend, with CPU fallback for unrouted/int64 ops | [GCU Installation](../vendors/gcu/installation.md) |
+| Moore Threads MUSA | `ACCELERATOR=musa` | Native `mudnn` operator backend, with CPU fallback for unrouted ops | [MUSA Installation](../vendors/musa/installation.md) |
+| D-Robotics BPU | `ACCELERATOR=bpu` | No eager kernel sets are built; eager ops run on CPU | [BPU Installation](../vendors/bpu/installation.md) |
+| TsingMicro | `ACCELERATOR=tsingmicro` | Runtime/build selector present; no per-op kernel set documented | The runtime build branch exists, but a current end-to-end installation and validation procedure is not documented. |
+
+## Common Requirements
+
+All platforms require:
+
+- **Python**: 3.8 or later
+- **PyTorch**: 2.10.x (`>=2.10,<2.11`) — generated ATen bindings are tied to this minor line
+- **CMake**: 3.18 or later
+- **C++ build toolchain**: A working C++17 compiler (GCC 7+, Clang 5+, or MSVC 2017+)
+- **Platform SDK/runtime**: The vendor-specific SDK, compiler, and runtime libraries for your accelerator
+
+Platform-specific requirements (CUDA toolkit version, vendor SDK paths, additional dependencies) are documented in each platform's installation guide.
+
+## Source Installation Contract
+
+Each platform installation guide defines:
+
+1. The required `ACCELERATOR` value for that platform
+2. SDK/compiler environment variables (e.g., `CUDA_HOME`, `METAX_PATH`, `ASCEND_TOOLKIT_HOME`)
+3. Any platform-specific build flags or dependencies
+
+The general installation pattern is:
+
+```bash
+ACCELERATOR=<platform> pip install --no-build-isolation -e .
+```
+
+The `--no-build-isolation` flag is required so that generated native bindings compile against the PyTorch installation visible in your current environment. Without it, pip creates an isolated build environment that may not see your platform SDK or the correct PyTorch installation.
+
+## After Installation
+
+- **First steps**: See the [Quick Start Guide](quickstart.md) for platform-independent usage examples.
+- **Platform support**: Review the [Compatibility Matrix](../reference/compatibility.md) to understand what capabilities are validated for your platform.
+- **Configuration**: Environment variables controlling runtime behavior are documented in the [Environment Variables Reference](../reference/environment-variables.md).
+- **Testing**: Run the test suite following the [Testing Guide](../development/testing.md) to verify your installation.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -106,5 +106,5 @@ The routing is transparent to your code. No changes are needed when switching be
 
 - Explore the [Compatibility Matrix](../reference/compatibility.md) to understand which features are validated for your platform
 - Review platform-specific notes in your [installation guide](installation.md)
-- Learn about distributed training in the [Distributed Guide](../guides/distributed.md)
-- Profile your workload with the [Profiler Guide](../guides/profiling.md)
+- Learn about distributed training in the [Distributed Guide](../architecture/distributed-flagcx.md)
+- Profile your workload with the [Profiler Guide](../architecture/profiler.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,110 @@
+# Quick Start Guide
+
+This guide shows platform-independent usage patterns for `torch_fl`. After installing for your platform, these examples work the same way across all supported accelerators.
+
+## Basic Usage
+
+```python
+import torch
+import torch_fl
+
+x = torch.randn(4, 4, device="flagos:0")
+y = torch.relu(x @ x)
+print(y.cpu())
+```
+
+This creates tensors on the first `flagos` device, performs a matrix multiplication and ReLU activation, and moves the result back to CPU for printing.
+
+## Moving Tensors Between Devices
+
+Move tensors to the accelerator with `.to()`:
+
+```python
+import torch
+import torch_fl
+
+x = torch.randn(4, 4)  # CPU tensor
+x_flagos = x.to("flagos")  # Move to flagos device 0
+x_flagos_1 = x.to("flagos:1")  # Move to flagos device 1
+```
+
+Move tensors back to CPU:
+
+```python
+y = torch.randn(4, 4, device="flagos")
+y_cpu = y.cpu()  # Move back to CPU
+```
+
+## Selecting a Device
+
+Use `torch.flagos.device()` to set the current device context:
+
+```python
+import torch
+import torch_fl
+
+with torch.flagos.device(0):
+    x = torch.randn(4, 4, device="flagos")  # Created on device 0
+
+with torch.flagos.device(1):
+    y = torch.randn(4, 4, device="flagos")  # Created on device 1
+```
+
+## Synchronization
+
+Wait for all operations on the current device to complete:
+
+```python
+import torch
+import torch_fl
+
+x = torch.randn(1000, 1000, device="flagos")
+y = x @ x  # Asynchronous operation
+torch.flagos.synchronize()  # Wait for completion
+```
+
+## Device Queries
+
+Check device availability and count:
+
+```python
+import torch
+import torch_fl
+
+# Check if any flagos devices are available
+if torch.flagos.is_available():
+    print(f"Found {torch.flagos.device_count()} device(s)")
+    print(f"Current device: {torch.flagos.current_device()}")
+else:
+    print("No flagos devices available")
+```
+
+Query device properties:
+
+```python
+import torch
+import torch_fl
+
+if torch.flagos.is_available():
+    props = torch.flagos.get_device_properties(0)
+    print(f"Device name: {props.name}")
+    print(f"Total memory: {props.total_memory / 1024**3:.2f} GB")
+```
+
+## Operator Routing
+
+Operations on `flagos` tensors are routed to different kernel implementations depending on platform and configuration:
+
+- **Portable compiler kernels**: FlagGems Triton kernels that work across platforms (when enabled)
+- **Native vendor kernels**: Platform-specific optimized implementations (e.g., ACLNN for Ascend, mudnn for MUSA)
+- **Compatibility boxing**: Generated wrapper kernels that delegate to an external vendor backend (e.g., CUDA boxing)
+- **CPU fallback**: Operations without a device kernel fall back to CPU (documented per-platform; not all platforms use this)
+
+The routing is transparent to your code. No changes are needed when switching between platforms or kernel sources.
+
+## Next Steps
+
+- Explore the [Compatibility Matrix](../reference/compatibility.md) to understand which features are validated for your platform
+- Review platform-specific notes in your [installation guide](installation.md)
+- Learn about distributed training in the [Distributed Guide](../guides/distributed.md)
+- Profile your workload with the [Profiler Guide](../guides/profiling.md)

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -1,0 +1,152 @@
+# Compatibility and Platform Support
+
+## Status Definitions
+
+| Status | Meaning |
+|---|---|
+| Stable | Critical paths are continuously tested and the supported version combination is documented. |
+| Beta | The primary path is validated, but coverage, packaging, or release procedures are not yet stable. |
+| Experimental | Validation exists for a specific setup, model, or hardware environment; interfaces or build procedures may change. |
+| Runtime only | Device runtime support exists, but the platform is not a general eager operator backend. |
+
+## Project Compatibility
+
+| Component | Supported range | Notes |
+|---|---|---|
+| Python | 3.8 or later | From package metadata. Platform SDKs and available wheels may impose a narrower range. |
+| PyTorch | 2.10.x (`>=2.10,<2.11`) | Generated ATen bindings are tied to this minor line. |
+| FlagGems | Platform dependent | Installed from PyPI or a vendor-compatible build only where the platform route uses it. |
+| Triton/compiler | Platform dependent | Use the compiler distribution required by the selected accelerator. |
+
+## Platform Matrix
+
+| Platform | Build selector | Execution path | Eager and autograd | `torch.compile` | Distributed | Profiler | FlagGems | Status |
+|---|---|---|---|---|---|---|---|---|
+| NVIDIA CUDA | `ACCELERATOR=cuda` (default) | CUDA boxing over an external `libtorch_cuda.so` | Stable | Beta (first-class inductor GPU device) | Beta (FlagCX + NCCL fallback, DDP live-verified) | Stable (CUPTI parity) | Beta (Python + C++ dispatch paths) | Stable |
+| MetaX | `ACCELERATOR=metax` | CUDA-boxing reuse via `cu-bridge`/mxcc, or native MetaX kernels | Stable | Not validated | Experimental (NCCL-shaped `mccl` fallback; not CI-covered) | Not validated on this vendor's tracer | Beta (Python + C++ dispatch paths) | Stable |
+| Ascend | `ACCELERATOR=ascend` | Native ACLNN operator backend, optional FlagGems via triton-ascend | Stable (CI-covered ops, RNG suite) | Not validated | Experimental (HCCL fallback; architectural routing only, no collective-level CI) | Runtime only (device/runtime events not emitted; profiler parity suite excluded from CI) | Beta (optional, Python dispatch only) | Beta |
+| PPU | `ACCELERATOR=cuda` + `PPU_SDK`/`PPU_HOME` detection | Same CUDA-boxing path as NVIDIA CUDA, against the PPU's CUDA-13-compatible SDK | Experimental | Not validated | Experimental (NCCL fallback via vendor-adapted `libnccl.so.2`; not CI-covered) | Not validated on this vendor's tracer | Experimental (vendor-index Triton required) | Experimental |
+| Hygon DCU | `ACCELERATOR=dcu` | CUDA boxing over the hipified DTK torch build (HIP kernels under the CUDA dispatch key) | Beta | Not validated | Not validated on this vendor's collectives (routing table only) | Beta (parity suite runs in CI) | Beta (Python + C++ dispatch paths) | Beta |
+| Enflame GCU | `ACCELERATOR=gcu` | Native `libtopsaten.so` operator backend, with CPU fallback for unrouted/int64 ops | Experimental | Not validated | Not validated | Not validated | Experimental (Python dispatch, requires vendor Triton) | Experimental |
+| Moore Threads MUSA | `ACCELERATOR=musa` | Native `mudnn` operator backend, with CPU fallback for unrouted ops | Experimental | Not validated | Not validated | Not validated | Experimental (Python dispatch, requires vendor Triton) | Experimental |
+| D-Robotics BPU | `ACCELERATOR=bpu` | No eager kernel sets are built; eager ops run on CPU | Runtime only (CPU fallback for eager) | Experimental (`torch.compile(backend="bpu")` graph path via hbdk4) | Not applicable | Not validated | Not applicable (no per-op kernel build) | Runtime only |
+| TsingMicro | `ACCELERATOR=tsingmicro` | Runtime/build selector present; no per-op kernel set documented | Runtime only | Not validated | Not validated | Not validated | Not applicable | Runtime only |
+
+## Platform Notes
+
+### NVIDIA CUDA
+
+The default and most exercised platform. [`.github/configs/cuda.yml`](../../.github/configs/cuda.yml)
+(lines 69-95) runs vendor-backend and FlagGems-runtime operator suites, general/factory tests,
+the profiler parity suite, and Qwen3-0.6B inference and training against a mounted model.
+Distributed collectives and DDP gradient sync are live-verified on 2x/8x A100 through FlagCX
+with an NCCL fallback (see
+[`docs/architecture/distributed-flagcx.md`](../architecture/distributed-flagcx.md), lines 1-10
+and §6). `torch.compile` registers flagos as a first-class inductor GPU device, validated on
+this platform (see
+[`docs/architecture/torch-compile-integration.md`](../architecture/torch-compile-integration.md),
+lines 84-127). The profiler achieves structural parity with torch-cuda via CUPTI (see
+[`docs/architecture/profiler.md`](../architecture/profiler.md), lines 1-21).
+
+### MetaX
+
+[`.github/configs/metax.yml`](../../.github/configs/metax.yml) (lines 99-125) runs representative
+operator dispatch tests and general factory/autograd tests in CI, and MetaX carries FSDP2 and
+Qwen3 training parity work (see repository history). Distributed support routes through the same
+NCCL-shaped fallback as CUDA (`_VENDOR_PROFILES["metax"]` in
+[`torch_fl/comm/process_group.py`](../../torch_fl/comm/process_group.py), line 93), but that is
+architectural routing, not a CI-verified collective test on this platform. `torch.compile` and
+profiler-tracer parity are not represented in tests or docs for this platform.
+
+### Ascend
+
+[`.github/configs/ascend.yml`](../../.github/configs/ascend.yml) (lines 78-97) runs the
+Ascend-marked operator suite and the full RNG dispatch suite in CI. Model-level (Qwen3)
+validation exists as a point measurement outside CI — training at 0.82x `torch_npu` on real
+Ascend 910 hardware (`tests/perf/e2e_qwen3_train_ascend.py`) — but
+[`.github/configs/ascend.yml`](../../.github/configs/ascend.yml) (line 110) explicitly defers
+Qwen3 inference/training smoke pending a model mount on the CI runner. Profiler parity is
+explicitly out of scope: the Ascend profiler path does not yet emit device-side event
+categories, and `test_profiler_parity.py` is excluded from CI until it does (same file, lines
+112-117). Distributed support recommends the FlagCX path (see
+[`docs/architecture/distributed-flagcx.md`](../architecture/distributed-flagcx.md), lines
+204-208); the native HCCL fallback and the `flagos→npu` zero-copy view are architectural
+routing, not on-hardware-verified collectives (same file, lines 67-75).
+
+### PPU
+
+PPU is not a separate `ACCELERATOR` value. It is `ACCELERATOR=cuda` plus `PPU_SDK`/`PPU_HOME`
+detection (see [`setup.py`](../../setup.py), lines 43-46 and 732-736), reusing the CUDA-boxing
+build against the PPU's CUDA-13-compatible SDK. There is no CI manifest for this platform (no
+`ppu.yml` under `.github/configs/`), so all capabilities here rest on the
+[README](../../README.md)'s build-from-source instructions rather than automated tests.
+FlagGems requires a vendor-index Triton build whose version string does not satisfy the
+project's `triton>=3.5.1` pin (see [`setup.py`](../../setup.py), lines 790-807). Distributed
+support is described as working via the NCCL fallback with a vendor-adapted `libnccl.so.2`, but
+this is not covered by CI.
+
+### Hygon DCU
+
+[`.github/configs/dcu.yml`](../../.github/configs/dcu.yml) (lines 84-99) runs vendor-backend
+and FlagGems-runtime operator suites, general tests, and the profiler parity suite in CI;
+inference and training smoke are explicitly deferred pending a model mount and card-count
+confirmation on the runner (same file, lines 57-61). DCU is a CUDA-boxing build over the
+hipified DTK torch, so it reuses the generated CUDA boxing kernels with no hand-written kernels
+of its own (see [`setup.py`](../../setup.py), lines 376-397). Distributed collectives are not
+exercised by the CI manifest; the NCCL-shaped `_VENDOR_PROFILES["hygon"]` entry in
+[`torch_fl/comm/process_group.py`](../../torch_fl/comm/process_group.py) is routing only.
+
+### Enflame GCU
+
+No CI manifest exists for this platform. GCU takes the native operator route through
+`libtopsaten.so`, with ops lacking a topsaten kernel reaching `cpu_fallback` instead of raising,
+and int64 operands always falling back to CPU because topsaten has no int64 kernels (see
+[`setup.py`](../../setup.py), lines 414-439). FlagGems can reach GCU only through the Python
+dispatch layer with Enflame's `triton_gcu` plugin, and registration is skipped when it or the
+toolchain is missing (same file, lines 420-429). Distributed and profiler support are not
+represented in tests or docs for this platform.
+
+### Moore Threads MUSA
+
+No CI manifest exists for this platform. MUSA takes the native operator route through `mudnn`,
+with a documented CPU fallback for ops the vendor kernel table does not cover (see
+[`setup.py`](../../setup.py), lines 440-457, and
+`tests/integration/ops/test_musa_dispatch.py`, lines 15-24). No CUDA boxing kernels or FlagGems
+C++ kernels are compiled for this platform; FlagGems Python dispatch is optional and needs the
+vendor Triton backend. Distributed and profiler support are not represented in tests or docs for
+this platform.
+
+### D-Robotics BPU
+
+BPU is **Runtime only** for eager execution: every kernel set is disabled at build time for
+`ACCELERATOR=bpu` (see [`setup.py`](../../setup.py), lines 398-413), so eager compute falls
+back to CPU. Acceleration is graph-level, through `torch.compile(backend="bpu")`, which
+partitions a traced graph, quantizes it, and compiles it with hbdk4 into a `.hbm` artifact run
+on the board's native runtime (see [`docs/vendors/bpu/integration.md`](../vendors/bpu/integration.md),
+lines 1-19 and the "Compile pipeline" section). This graph path has measured results on
+ResNet-18 and Qwen3-0.6B against vendor artifacts (same file, lines 296-352), which is why it is
+marked Experimental rather than Runtime only in the `torch.compile` column, while eager
+execution itself has no device kernel path at all. No CI manifest exists for this platform; the
+evidence above is from on-board measurement, not continuous validation.
+
+### TsingMicro
+
+TsingMicro has a build selector (`ACCELERATOR=tsingmicro`) and links against the Kuiper SDK
+(see [`CMakeLists.txt`](../../CMakeLists.txt), lines 196-216), but
+[`setup.py`](../../setup.py) (lines 367-375) disables every kernel set for it, mirroring the
+same "no per-op kernel to call" treatment documented for BPU (see
+[`docs/vendors/bpu/integration.md`](../vendors/bpu/integration.md), lines 37-43). There is no
+recoverable current install or test guide, and no CI manifest, for this platform. It is marked
+**Runtime only**, and setup and operator validation should be treated as not currently
+documented.
+
+## Reading the Matrix
+
+A "Stable" or "Beta" entry in the **Project Compatibility** table describes the project's
+overall Python/PyTorch contract, not platform-wide validation. Each cell in the **Platform
+Matrix** reflects only the evidence cited in that platform's notes above: a capability marked
+"Not validated" may still work, but no test, CI manifest, or measurement in this repository
+currently backs that claim. Distributed and profiler entries in particular distinguish
+architectural routing (a table entry, a code path that exists) from on-hardware verification
+(a CI job or a documented, reproducible measurement) — treat the latter as the bar for anything
+described as validated.

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -65,10 +65,11 @@ profiler-tracer parity are not represented in tests or docs for this platform.
 ### Ascend
 
 [`.github/configs/ascend.yml`](../../.github/configs/ascend.yml) (lines 78-97) runs the
-Ascend-marked operator suite and the full RNG dispatch suite in CI; FlagGems tests are not
-included in the CI test selection. Model-level (Qwen3) validation exists as a point measurement
-outside CI — training at 0.82x `torch_npu` on real Ascend 910 hardware
-(`tests/perf/e2e_qwen3_train_ascend.py`) — but
+Ascend-marked operator suite and the full RNG dispatch suite in CI. FlagGems-marked tests in
+`test_rng_dispatch.py` are selected via `-m "main_ops"` (lines 90-94) but the FlagGems runtime
+path is not enabled in CI, so those tests run against the native ACLNN backend. Model-level
+(Qwen3) validation exists as a point measurement outside CI — training at 0.82x `torch_npu` on
+real Ascend 910 hardware (`tests/perf/e2e_qwen3_train_ascend.py`) — but
 [`.github/configs/ascend.yml`](../../.github/configs/ascend.yml) (line 110) explicitly defers
 Qwen3 inference/training smoke pending a model mount on the CI runner. Profiler parity is
 explicitly out of scope: the Ascend profiler path does not yet emit device-side event
@@ -101,7 +102,7 @@ of its own (see [`setup.py`](../../setup.py), lines 376-397). FlagGems C++ dispa
 for DCU: [`CMakeLists.txt`](../../CMakeLists.txt) line 81 and [`setup.py`](../../setup.py) lines
 376-393 force `FLAGGEMS_KERNEL=OFF` with the comment "FLAGGEMS_KERNEL needs liboperators.so,
 which is not built for DTK," and [`.github/configs/dcu.yml`](../../.github/configs/dcu.yml) line
-90 excludes C++ tests with `-m "not flaggems_cpp"`. Distributed collectives (all_reduce,
+87 excludes C++ tests with `-m "not flaggems_cpp"`. Distributed collectives (all_reduce,
 broadcast, all_gather, all_gather_into_tensor, reduce_scatter_tensor) and DDP are measured
 working on 2 cards via RCCL (see
 [`torch_fl/comm/process_group.py`](../../torch_fl/comm/process_group.py), lines 103-107), but

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -22,11 +22,11 @@
 
 | Platform | Build selector | Execution path | Eager and autograd | `torch.compile` | Distributed | Profiler | FlagGems | Status |
 |---|---|---|---|---|---|---|---|---|
-| NVIDIA CUDA | `ACCELERATOR=cuda` (default) | CUDA boxing over an external `libtorch_cuda.so` | Stable | Beta (first-class inductor GPU device) | Beta (FlagCX + NCCL fallback, DDP live-verified) | Stable (CUPTI parity) | Beta (Python + C++ dispatch paths) | Stable |
-| MetaX | `ACCELERATOR=metax` | CUDA-boxing reuse via `cu-bridge`/mxcc, or native MetaX kernels | Stable | Not validated | Experimental (NCCL-shaped `mccl` fallback; not CI-covered) | Not validated on this vendor's tracer | Beta (Python + C++ dispatch paths) | Stable |
-| Ascend | `ACCELERATOR=ascend` | Native ACLNN operator backend, optional FlagGems via triton-ascend | Stable (CI-covered ops, RNG suite) | Not validated | Experimental (HCCL fallback; architectural routing only, no collective-level CI) | Runtime only (device/runtime events not emitted; profiler parity suite excluded from CI) | Beta (optional, Python dispatch only) | Beta |
+| NVIDIA CUDA | `ACCELERATOR=cuda` (default) | CUDA boxing over an external `libtorch_cuda.so` | Stable | Experimental (inductor GPU device registered; no CI test step) | Beta (FlagCX + NCCL fallback, DDP live-verified) | Stable (CUPTI parity) | Beta (Python + C++ dispatch paths) | Stable |
+| MetaX | `ACCELERATOR=metax` | CUDA-boxing reuse via `cu-bridge`/mxcc, or native MetaX kernels | Stable | Not validated | Experimental (NCCL-shaped `mccl` fallback; not CI-covered) | Not validated on this vendor's tracer | Experimental (Python dispatch; not CI-tested on MetaX) | Stable |
+| Ascend | `ACCELERATOR=ascend` | Native ACLNN operator backend, optional FlagGems via triton-ascend | Stable (CI-covered ops, RNG suite) | Not validated | Experimental (HCCL fallback; architectural routing only, no collective-level CI) | Runtime only (device/runtime events not emitted; profiler parity suite excluded from CI) | Experimental (Python dispatch; not CI-tested on Ascend) | Beta |
 | PPU | `ACCELERATOR=cuda` + `PPU_SDK`/`PPU_HOME` detection | Same CUDA-boxing path as NVIDIA CUDA, against the PPU's CUDA-13-compatible SDK | Experimental | Not validated | Experimental (NCCL fallback via vendor-adapted `libnccl.so.2`; not CI-covered) | Not validated on this vendor's tracer | Experimental (vendor-index Triton required) | Experimental |
-| Hygon DCU | `ACCELERATOR=dcu` | CUDA boxing over the hipified DTK torch build (HIP kernels under the CUDA dispatch key) | Beta | Not validated | Not validated on this vendor's collectives (routing table only) | Beta (parity suite runs in CI) | Beta (Python + C++ dispatch paths) | Beta |
+| Hygon DCU | `ACCELERATOR=dcu` | CUDA boxing over the hipified DTK torch build (HIP kernels under the CUDA dispatch key) | Beta | Not validated | Experimental (RCCL via DTK; all_reduce/DDP measured on 2 cards, not in CI) | Beta (parity suite runs in CI) | Beta (Python dispatch only) | Beta |
 | Enflame GCU | `ACCELERATOR=gcu` | Native `libtopsaten.so` operator backend, with CPU fallback for unrouted/int64 ops | Experimental | Not validated | Not validated | Not validated | Experimental (Python dispatch, requires vendor Triton) | Experimental |
 | Moore Threads MUSA | `ACCELERATOR=musa` | Native `mudnn` operator backend, with CPU fallback for unrouted ops | Experimental | Not validated | Not validated | Not validated | Experimental (Python dispatch, requires vendor Triton) | Experimental |
 | D-Robotics BPU | `ACCELERATOR=bpu` | No eager kernel sets are built; eager ops run on CPU | Runtime only (CPU fallback for eager) | Experimental (`torch.compile(backend="bpu")` graph path via hbdk4) | Not applicable | Not validated | Not applicable (no per-op kernel build) | Runtime only |
@@ -42,18 +42,22 @@ the profiler parity suite, and Qwen3-0.6B inference and training against a mount
 Distributed collectives and DDP gradient sync are live-verified on 2x/8x A100 through FlagCX
 with an NCCL fallback (see
 [`docs/architecture/distributed-flagcx.md`](../architecture/distributed-flagcx.md), lines 1-10
-and §6). `torch.compile` registers flagos as a first-class inductor GPU device, validated on
-this platform (see
-[`docs/architecture/torch-compile-integration.md`](../architecture/torch-compile-integration.md),
-lines 84-127). The profiler achieves structural parity with torch-cuda via CUPTI (see
+and §6). `torch.compile` registers flagos as a first-class inductor GPU device with integration
+documented in
+[`docs/architecture/torch-compile-integration.md`](../architecture/torch-compile-integration.md)
+(lines 84-127), but [`.github/configs/cuda.yml`](../../.github/configs/cuda.yml) has no
+`torch.compile` test step, so this path is not exercised in CI. The profiler achieves structural
+parity with torch-cuda via CUPTI (see
 [`docs/architecture/profiler.md`](../architecture/profiler.md), lines 1-21).
 
 ### MetaX
 
 [`.github/configs/metax.yml`](../../.github/configs/metax.yml) (lines 99-125) runs representative
-operator dispatch tests and general factory/autograd tests in CI, and MetaX carries FSDP2 and
-Qwen3 training parity work (see repository history). Distributed support routes through the same
-NCCL-shaped fallback as CUDA (`_VENDOR_PROFILES["metax"]` in
+operator dispatch tests and general factory/autograd tests in CI, but its test command explicitly
+excludes all FlagGems tests (`-m "not flaggems and not flaggems_python and not flaggems_cpp"` at
+line 118), so FlagGems on MetaX has no CI validation. MetaX carries FSDP2 and Qwen3 training
+parity work (see repository history). Distributed support routes through the same NCCL-shaped
+fallback as CUDA (`_VENDOR_PROFILES["metax"]` in
 [`torch_fl/comm/process_group.py`](../../torch_fl/comm/process_group.py), line 93), but that is
 architectural routing, not a CI-verified collective test on this platform. `torch.compile` and
 profiler-tracer parity are not represented in tests or docs for this platform.
@@ -61,9 +65,10 @@ profiler-tracer parity are not represented in tests or docs for this platform.
 ### Ascend
 
 [`.github/configs/ascend.yml`](../../.github/configs/ascend.yml) (lines 78-97) runs the
-Ascend-marked operator suite and the full RNG dispatch suite in CI. Model-level (Qwen3)
-validation exists as a point measurement outside CI — training at 0.82x `torch_npu` on real
-Ascend 910 hardware (`tests/perf/e2e_qwen3_train_ascend.py`) — but
+Ascend-marked operator suite and the full RNG dispatch suite in CI; FlagGems tests are not
+included in the CI test selection. Model-level (Qwen3) validation exists as a point measurement
+outside CI — training at 0.82x `torch_npu` on real Ascend 910 hardware
+(`tests/perf/e2e_qwen3_train_ascend.py`) — but
 [`.github/configs/ascend.yml`](../../.github/configs/ascend.yml) (line 110) explicitly defers
 Qwen3 inference/training smoke pending a model mount on the CI runner. Profiler parity is
 explicitly out of scope: the Ascend profiler path does not yet emit device-side event
@@ -92,9 +97,15 @@ and FlagGems-runtime operator suites, general tests, and the profiler parity sui
 inference and training smoke are explicitly deferred pending a model mount and card-count
 confirmation on the runner (same file, lines 57-61). DCU is a CUDA-boxing build over the
 hipified DTK torch, so it reuses the generated CUDA boxing kernels with no hand-written kernels
-of its own (see [`setup.py`](../../setup.py), lines 376-397). Distributed collectives are not
-exercised by the CI manifest; the NCCL-shaped `_VENDOR_PROFILES["hygon"]` entry in
-[`torch_fl/comm/process_group.py`](../../torch_fl/comm/process_group.py) is routing only.
+of its own (see [`setup.py`](../../setup.py), lines 376-397). FlagGems C++ dispatch is not built
+for DCU: [`CMakeLists.txt`](../../CMakeLists.txt) line 81 and [`setup.py`](../../setup.py) lines
+376-393 force `FLAGGEMS_KERNEL=OFF` with the comment "FLAGGEMS_KERNEL needs liboperators.so,
+which is not built for DTK," and [`.github/configs/dcu.yml`](../../.github/configs/dcu.yml) line
+90 excludes C++ tests with `-m "not flaggems_cpp"`. Distributed collectives (all_reduce,
+broadcast, all_gather, all_gather_into_tensor, reduce_scatter_tensor) and DDP are measured
+working on 2 cards via RCCL (see
+[`torch_fl/comm/process_group.py`](../../torch_fl/comm/process_group.py), lines 103-107), but
+this measurement is not in CI.
 
 ### Enflame GCU
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,95 @@
+# Environment Variables
+
+This document lists configuration variables that control torch_fl's build, operator routing, and runtime behavior. Platform-specific setup variables are documented in vendor guides.
+
+## Build Selection
+
+These variables control which backends and kernels are compiled into the wheel.
+
+| Variable | Scope | Default | Purpose |
+|----------|-------|---------|---------|
+| `ACCELERATOR` | Build | `cuda` | Hardware platform: `cuda`, `metax`, `ascend`, `tsingmicro`, `dcu`, `gcu`, `musa`, or `bpu` |
+| `FLAGOS_BUILD_JOBS` | Build | System CPU count | Parallel jobs for CMake build |
+| `CUDA_KERNEL` | Build | `ON` | Enable CUDA boxing kernels; set `OFF` for pure vendor builds (Ascend/MUSA/GCU) |
+| `ASCEND_KERNEL` | Build | `OFF` | Enable Ascend ACL kernels; set `ON` for Ascend builds |
+| `GCU_KERNEL` | Build | Auto (enabled when `ACCELERATOR=gcu`) | Enable Enflame GCU topsaten kernels |
+| `MUSA_KERNEL` | Build | Auto (enabled when `ACCELERATOR=musa`) | Enable Moore Threads MUSA mudnn kernels |
+| `METAX_KERNEL` | Build | Auto (enabled when `ACCELERATOR=metax`) | Enable MetaX C++ kernel build |
+| `FLAGGEMS_KERNEL` | Build | `ON` | Enable FlagGems C++ kernel wrappers (liboperators.so); set `OFF` for pure vendor builds |
+| `FLAGGEMS_PYTHON` | Build | `OFF` | Enable FlagGems Python wrapper backend registration |
+| `FLAGOS_METAX_BOXING` | Build | `OFF` | Enable MetaX boxing mode (reuse CUDA boxing kernels + optional FlagGems, no mxcc backend) |
+
+## SDK and Compiler Discovery
+
+These variables locate platform SDKs and toolchains. CMake searches common install paths when they are absent.
+
+| Variable | Scope | Default | Purpose |
+|----------|-------|---------|---------|
+| `CUDA_HOME` | Build & runtime | Auto-detected (system CUDA or conda prefix) | CUDA toolkit path for headers and libraries |
+| `ASCEND_HOME` | Build | `/usr/local/Ascend/ascend-toolkit/latest` | CANN toolkit path for Ascend NPU builds |
+| `MUSA_HOME` | Build | `/usr/local/musa` | Moore Threads MUSA toolkit path |
+| `TOPS_HOME` | Build | `/opt/tops` | Enflame TopsRider SDK path for GCU builds |
+| `METAX_PATH` | Build | `/opt/maca` or `$METAX_HOME` or `$MACA_PATH` or `$MACA_HOME` (first found) | MetaX SDK path |
+| `METAX_ARCH` | Build | No global default | MetaX GPU architecture string (e.g., `mp_21`) |
+| `METAX_MXCC` | Build | No global default | Path to mxcc/cucc compiler override |
+| `DTK_ROOT` | Build | `$ROCM_PATH` or `/opt/dtk` | Hygon DTK path for DCU builds |
+| `PPU_SDK` / `PPU_HOME` | Build | No global default | PPU SDK path for Tsingmicro builds |
+| `CONDA_PREFIX` | Build & runtime | Auto-detected | Conda environment prefix (fallback for CUDA discovery) |
+
+## Operator Routing
+
+These variables control which backend implementation (CUDA boxing, vendor C++, FlagGems C++, or FlagGems Python) each operator dispatches to at runtime.
+
+| Variable | Scope | Default | Purpose |
+|----------|-------|---------|---------|
+| `FLAGOS_BACKEND_CONFIG` | Runtime | Auto-selected by `torch_fl.__init__` based on hardware and switches below | Absolute path to a `backends_*.conf` file; overrides all auto-detection |
+| `FLAGOS_USE_FLAGGEMS` | Runtime | `0` (off) | Enable FlagGems Triton operators via the Python backend (`flagos_python`); selects `backends_flaggems.conf` or platform-specific variant |
+| `FLAGOS_USE_FLAGGEMS_CPP` | Runtime | `0` (off) | Enable FlagGems C++ operators (kFlagOs dispatch, no GIL); selects `backends_flaggems_cpp.conf`; requires wheel built with `FLAGGEMS_KERNEL=ON` |
+| `FLAGOS_OP_<name>` | Runtime | No default | Per-operator backend override (e.g., `FLAGOS_OP_add__Tensor=cuda`); replace `.` with `__` in op names |
+| `FLAGOS_LOG_DISPATCH` | Runtime | `0` (off) | Print backend selection to stderr for each operator dispatch |
+| `FLAGOS_DISABLE_FLAGGEMS_PY` | Runtime | `0` (off) | Disable FlagGems Python-layer registration (C++ stub-only mode) |
+| `FLAGGEMS_SOURCE_DIR` | Runtime | Required when FlagGems is active | Absolute path to FlagGems source directory (Python Triton kernels); must match the version liboperators.so was built against |
+| `GEMS_VENDOR` | Runtime | Auto-detected from hardware or build metadata | FlagGems vendor target: `cuda` (default), `metax`, `ascend`, `musa`, `cambricon`; controls distributed backend and device-specific Triton compilation |
+
+**Note on auto-detection**: `FLAGOS_BACKEND_CONFIG` is normally set by `torch_fl.__init__._select_backend_config()`, which detects the hardware platform (via `/dev/davinci*`, `/dev/mxcd`, or build-time `ACCELERATOR`) and applies the `FLAGOS_USE_FLAGGEMS` / `FLAGOS_USE_FLAGGEMS_CPP` / `FLAGOS_METAX_BOXING` switches to pick the correct config. Users should override `FLAGOS_BACKEND_CONFIG` only for testing or debugging.
+
+## Runtime and Packaging
+
+These variables control asset loading, bundled libtorch behavior, and import-time compatibility shims.
+
+| Variable | Scope | Default | Purpose |
+|----------|-------|---------|---------|
+| `FLAGOS_DISABLE_CUDA_ASSETS` | Runtime | `0` (off) | Skip preloading bundled `libtorch_cuda.so` and CUDA libraries (for builds that use system libtorch) |
+| `FLAGOS_DISABLE_CUDA_SHIM` | Runtime | `0` (off) | Skip registering the `torch.cuda` compatibility shim for generic GPU operations |
+| `FLAGOS_ALIAS_CUDA` | Runtime | `0` (off) | Alias `cuda` device string to `flagos` for drop-in compatibility |
+| `FLAGOS_METAX_CUDART_SHIM` | Runtime | `0` (off) | Preload libcudart version-tag shim before `import torch` (MetaX-specific; required for generic PyTorch wheels) |
+| `FLAGOS_METAX_COMPAT` | Runtime | `0` (off) | Patch FlagGems `torch.cuda` device queries for MetaX compatibility |
+| `FLAGOS_DCU_HIP_VERSION` | Runtime | No default | Override HIP version detection for DCU runtime |
+| `FLAGOS_SKIP_CUDA_ASSETS` | Build | `0` (off) | Skip bundling external `libtorch_cuda.so` into the wheel (for in-tree builds) |
+| `FLAGOS_WHEEL_LOCAL` | Build | `0` (off) | Build a wheel with machine-local paths (non-portable; for dev testing only) |
+| `TORCH_DEVICE_BACKEND_AUTOLOAD` | Runtime | Set by torch_fl on MUSA builds | Stop vendor plugins (e.g., `torch_musa`) from claiming `PrivateUse1` during `import torch` |
+
+## Compiler and Feature Backends
+
+These variables control torch.compile integration and specialized compilation paths.
+
+| Variable | Scope | Default | Purpose |
+|----------|-------|---------|---------|
+| `FLAGOS_COMPILE_FALLBACK_EAGER` | Runtime | `0` (off) | Fall back to eager mode when torch.compile encounters unsupported operations |
+| `FLAGOS_USE_FLAGTREE` | Runtime | `0` (off) | Enable FlagTree compiler backend integration |
+
+For BPU-specific compilation variables, see [BPU Integration Guide](../vendors/bpu/integration.md).
+
+## Platform-specific Variables
+
+Detailed setup and runtime variables for each accelerator backend are documented in platform guides:
+
+- [CUDA (NVIDIA)](../vendors/cuda/setup.md)
+- [MetaX](../vendors/metax/setup.md)
+- [Ascend (Huawei)](../vendors/ascend/setup.md)
+- [DCU (Hygon)](../vendors/dcu/setup.md)
+- [GCU (Enflame)](../vendors/gcu/setup.md)
+- [MUSA (Moore Threads)](../vendors/musa/setup.md)
+- [BPU (Horizon Robotics)](../vendors/bpu/integration.md)
+
+Platform guides document SDK paths, driver requirements, version compatibility, and any additional environment setup (e.g., `LD_PRELOAD`, `LD_LIBRARY_PATH`).

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -84,12 +84,12 @@ For BPU-specific compilation variables, see [BPU Integration Guide](../vendors/b
 
 Detailed setup and runtime variables for each accelerator backend are documented in platform guides:
 
-- [CUDA (NVIDIA)](../vendors/cuda/setup.md)
-- [MetaX](../vendors/metax/setup.md)
-- [Ascend (Huawei)](../vendors/ascend/setup.md)
-- [DCU (Hygon)](../vendors/dcu/setup.md)
-- [GCU (Enflame)](../vendors/gcu/setup.md)
-- [MUSA (Moore Threads)](../vendors/musa/setup.md)
+- [CUDA (NVIDIA)](../vendors/cuda/installation.md)
+- [MetaX](../vendors/metax/installation.md)
+- [Ascend (Huawei)](../vendors/ascend/installation.md)
+- [DCU (Hygon)](../vendors/dcu/installation.md)
+- [GCU (Enflame)](../vendors/gcu/installation.md)
+- [MUSA (Moore Threads)](../vendors/musa/installation.md)
 - [BPU (Horizon Robotics)](../vendors/bpu/integration.md)
 
 Platform guides document SDK paths, driver requirements, version compatibility, and any additional environment setup (e.g., `LD_PRELOAD`, `LD_LIBRARY_PATH`).

--- a/docs/superpowers/plans/2026-08-11-readme-redesign.md
+++ b/docs/superpowers/plans/2026-08-11-readme-redesign.md
@@ -1,0 +1,953 @@
+# README Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the root README with a concise, evidence-based project landing page and move accurate platform installation, compatibility, runtime configuration, testing, and troubleshooting material into stable English documentation entry points.
+
+**Architecture:** Treat package metadata, build branches, runtime routing, CI manifests, tests, and measured design documents as the source of truth. Build the detailed documentation destinations first, then rewrite `README.md` as a curated summary that links to those destinations; unsupported or weakly validated claims are downgraded or omitted instead of inferred from other FlagOS projects.
+
+**Tech Stack:** GitHub-flavored Markdown, Python 3, shell validation with `rg`, repository metadata in `pyproject.toml` and `setup.py`, CMake build configuration, pytest/CI manifests, and Git.
+
+## Global Constraints
+
+- All GitHub-facing text and every file under `docs/` must be written in English; `README_zh.md` is the only localized top-level exception and is out of scope for this change.
+- The root README is a project landing page, not an exhaustive build, runtime, testing, or troubleshooting manual; target approximately 250-350 lines unless accuracy requires otherwise.
+- The user-facing device is always `flagos`; execution paths are implementation strategies, not user-selectable product tiers.
+- Hardware support claims must come from this repository's current build/runtime integration, tests, CI, or measured documentation, not from support claimed by FlagGems, FlagTree, or another FlagOS component.
+- Support statuses use only **Stable**, **Beta**, **Experimental**, and **Runtime only**, with uncertain claims assigned the less mature status.
+- Project-wide compatibility is Python 3.8 or later and PyTorch 2.10.x (`torch>=2.10,<2.11`); platform-specific SDK/compiler combinations belong in the detailed compatibility reference.
+- Generated ATen bindings are pinned to a PyTorch minor line; do not reproduce the stale global Python 3.12, PyTorch 2.11.0, CUDA 12.8, and FlagGems 5.0.2 table.
+- Preserve and link existing architecture/vendor analyses rather than duplicating them; do not reorganize `docs/superpowers/`.
+- Create no empty or speculative platform guide. When setup information is insufficient, omit the guide link and state the limitation in the compatibility matrix.
+- Do not change runtime or operator behavior, add a platform, rewrite `README_zh.md`, or broaden this work into source-tree reorganization.
+- Do not commit machine-local absolute paths, credentials, private proxy details, private registry names, mounted model paths, or host-specific CI paths.
+- The final implementation diff must be documentation-only unless a documentation check itself is demonstrably broken and needs a narrowly scoped fix.
+
+---
+
+## File Map
+
+**Create:**
+
+- `docs/getting-started/installation.md` — platform selector, common prerequisites, source-install contract, and links to verified platform guides.
+- `docs/getting-started/quickstart.md` — platform-independent first tensor, device management, transfers, and status-query examples.
+- `docs/reference/compatibility.md` — source-backed platform execution-path, capability, maturity, version, and limitation matrix.
+- `docs/reference/environment-variables.md` — shared build/runtime routing variables, defaults, scope, and links to platform-specific variables.
+- `docs/development/testing.md` — contributor test layout, pytest marks, platform test commands, code generation, and lint guidance.
+- `docs/vendors/cuda/installation.md` — NVIDIA CUDA build/install/runtime guide and CUDA-specific validation.
+- `docs/vendors/metax/installation.md` — MetaX self-contained boxing-wheel workflow, optional FlagGems route, import/runtime rules, and validation.
+- `docs/vendors/ascend/installation.md` — CANN/ACLNN installation, optional FlagGems/triton-ascend route, validation, and links to existing Ascend analyses.
+- `docs/vendors/ppu/installation.md` — PPU CUDA-compatible build, vendor Triton/FlagGems option, NCCL/FlagCX notes, and validation.
+- `docs/vendors/dcu/installation.md` — DTK boxing build, optional Hygon FlagGems route, RCCL/FlagCX notes, and validation.
+- `docs/vendors/gcu/installation.md` — TopsRider/topsaten native-kernel build, fallback boundaries, and source-backed validation guidance.
+- `docs/vendors/musa/installation.md` — MUSA/mudnn native-kernel build, import-order rule, fallback boundaries, and validation guidance.
+- `docs/vendors/bpu/installation.md` — BPU runtime and `torch.compile` entry point linked to the existing detailed integration guide.
+- `CONTRIBUTING.md` — concise contribution workflow for runtime, operator, compiler, docs, and backend changes.
+
+**Modify:**
+
+- `README.md` — replace the current manual with the approved landing-page information architecture.
+- Existing docs only when a newly created entry point reveals a broken relative link or requires a small reciprocal navigation link; do not rewrite their substantive content.
+
+**Do not create:**
+
+- `docs/vendors/tsingmicro/installation.md` — current source proves a Kuiper runtime build branch exists, but the repository has no complete, current installation/test procedure to migrate.
+- Any placeholder guide for a platform listed only by another FlagOS project.
+
+---
+
+### Task 1: Record the Evidence-backed Support Contract
+
+**Files:**
+- Create: `docs/reference/compatibility.md`
+- Inspect: `pyproject.toml`
+- Inspect: `setup.py`
+- Inspect: `CMakeLists.txt`
+- Inspect: `.github/configs/{cuda,metax,ascend,dcu}.yml`
+- Inspect: `torch_fl/comm/process_group.py`
+- Inspect: `tests/integration/`
+- Inspect: `tests/unit/bpu/`
+- Inspect: `docs/architecture/`
+- Inspect: `docs/vendors/`
+
+**Interfaces:**
+- Consumes: Package/runtime/CI/test evidence already present in the repository.
+- Produces: Canonical support statuses, capability labels, version rules, and limitations that every guide and the root README must summarize without strengthening.
+
+- [ ] **Step 1: Capture the authoritative metadata and platform inventory**
+
+Run:
+
+```bash
+rg -n 'requires-python|torch>=2\.10,<2\.11|TORCH_PIN|ACCELERATOR.*cuda|ACCELERATOR STREQUAL' \
+  pyproject.toml setup.py CMakeLists.txt
+rg -n 'display_name:|integration_tests:|Run .*tests|Profiler parity|Qwen3' \
+  .github/configs/*.yml
+rg -n '^    "(nvidia|metax|thead|hygon|ascend|musa|cambricon)"' \
+  torch_fl/comm/process_group.py
+```
+
+Expected: the first command proves Python `>=3.8`, PyTorch `>=2.10,<2.11`, and the eight explicit `ACCELERATOR` values; the second identifies continuous validation for CUDA, MetaX, Ascend, and DCU; the third identifies distributed routing boundaries.
+
+- [ ] **Step 2: Create the compatibility reference with explicit semantics**
+
+Write `docs/reference/compatibility.md` with these sections and contracts:
+
+```markdown
+# Compatibility and Platform Support
+
+## Status Definitions
+
+| Status | Meaning |
+|---|---|
+| Stable | Critical paths are continuously tested and the supported version combination is documented. |
+| Beta | The primary path is validated, but coverage, packaging, or release procedures are not yet stable. |
+| Experimental | Validation exists for a specific setup, model, or hardware environment; interfaces or build procedures may change. |
+| Runtime only | Device runtime support exists, but the platform is not a general eager operator backend. |
+
+## Project Compatibility
+
+| Component | Supported range | Notes |
+|---|---|---|
+| Python | 3.8 or later | From package metadata. Platform SDKs and available wheels may impose a narrower range. |
+| PyTorch | 2.10.x (`>=2.10,<2.11`) | Generated ATen bindings are tied to this minor line. |
+| FlagGems | Platform dependent | Installed from PyPI or a vendor-compatible build only where the platform route uses it. |
+| Triton/compiler | Platform dependent | Use the compiler distribution required by the selected accelerator. |
+
+## Platform Matrix
+
+| Platform | Build selector | Execution path | Eager and autograd | `torch.compile` | Distributed | Profiler | FlagGems | Status |
+|---|---|---|---|---|---|---|---|---|
+```
+
+Populate all platforms integrated by this repository: NVIDIA CUDA, MetaX, Ascend, PPU, Hygon DCU, Enflame GCU, Moore Threads MUSA, D-Robotics BPU, and TsingMicro. Use the following conservative evidence rules:
+
+- CUDA, MetaX, Ascend, and DCU may cite continuous CI, but individual capabilities must reflect each CI manifest. In particular, do not claim Ascend profiler parity or model-level CI while `.github/configs/ascend.yml` explicitly defers them.
+- PPU is `ACCELERATOR=cuda` with `PPU_SDK` detection, not a separate build selector.
+- GCU and MUSA use native vendor kernels with documented CPU fallback outside generated coverage; mark capabilities not represented in tests/docs as unvalidated.
+- BPU is **Runtime only** for eager execution: the device runtime is native, eager compute falls back to CPU, and acceleration is graph-level through its BPU compile backend or dedicated prebuilt-HBM runtime.
+- TsingMicro has a runtime integration/build selector but no recoverable current install/test guide; mark it **Runtime only** and state that setup and operator validation are not currently documented.
+- For distributed support, distinguish validated paths from architectural routing. A `_VENDOR_PROFILES` row is not proof that collectives were tested on that platform.
+- For profiler support, distinguish project capability from vendor tracer validation.
+
+After the matrix, add `## Platform Notes` with one concise subsection per platform. Each subsection must cite repository-relative evidence links and state material limitations. Add `## Reading the Matrix` clarifying that project-wide capability does not imply platform-wide validation.
+
+- [ ] **Step 3: Verify every matrix claim against its evidence**
+
+Run:
+
+```bash
+rg -n 'Stable|Beta|Experimental|Runtime only' docs/reference/compatibility.md
+rg -n 'CUDA|MetaX|Ascend|PPU|DCU|GCU|MUSA|BPU|TsingMicro' \
+  docs/reference/compatibility.md
+rg -n '2\.11|Python 3\.12|CUDA 12\.8.*all|FlagGems 5\.0\.2.*all' \
+  docs/reference/compatibility.md
+```
+
+Expected: all nine platform names and only the four approved status labels appear; the stale global version claims produce no matches.
+
+- [ ] **Step 4: Check links in the compatibility reference**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import re
+
+path = Path('docs/reference/compatibility.md')
+for target in re.findall(r'\[[^]]+\]\(([^)]+)\)', path.read_text()):
+    if '://' in target or target.startswith('#'):
+        continue
+    resolved = (path.parent / target.split('#', 1)[0]).resolve()
+    assert resolved.exists(), f'{path}: broken link: {target}'
+print('compatibility links: OK')
+PY
+```
+
+Expected: `compatibility links: OK`.
+
+- [ ] **Step 5: Commit the support contract**
+
+```bash
+git add docs/reference/compatibility.md
+git commit -m "docs: define platform compatibility matrix"
+```
+
+---
+
+### Task 2: Create Shared Installation and Quick-start Entry Points
+
+**Files:**
+- Create: `docs/getting-started/installation.md`
+- Create: `docs/getting-started/quickstart.md`
+- Reference: `docs/reference/compatibility.md`
+- Reference: `pyproject.toml`
+- Reference: `setup.py`
+
+**Interfaces:**
+- Consumes: The platform names, status contract, and project compatibility range from Task 1.
+- Produces: Stable README destinations for installation selection and platform-independent first use.
+
+- [ ] **Step 1: Create the installation selector**
+
+Write `docs/getting-started/installation.md` with:
+
+1. `# Installation`
+2. `## Choose a Platform`, containing a table with `Platform | Build selector | Execution path | Installation guide`.
+3. Links for CUDA, MetaX, Ascend, PPU, DCU, GCU, MUSA, and BPU; these links may temporarily point to files created by Tasks 4-6 and will be validated after those tasks.
+4. A TsingMicro row with no guide link and the explicit text: “The runtime build branch exists, but a current end-to-end installation and validation procedure is not documented.”
+5. `## Common Requirements`, stating Python 3.8+, PyTorch 2.10.x, CMake 3.18+, a C++ build toolchain, and a platform SDK/runtime.
+6. `## Source Installation Contract`, explaining that platform guides define the required `ACCELERATOR` and SDK/compiler variables, and that `--no-build-isolation` is used so generated native bindings compile against the selected PyTorch installation.
+7. `## After Installation`, linking to `quickstart.md`, the compatibility matrix, environment-variable reference, and testing guide.
+
+Do not include full vendor command sequences here.
+
+- [ ] **Step 2: Create the platform-independent quick start**
+
+Write `docs/getting-started/quickstart.md` with:
+
+```python
+import torch
+import torch_fl
+
+x = torch.randn(4, 4, device="flagos:0")
+y = torch.relu(x @ x)
+print(y.cpu())
+```
+
+Then add short sections for:
+
+- moving tensors with `.to("flagos")` and `.cpu()`,
+- selecting a device with `torch.flagos.device(0)`,
+- synchronizing with `torch.flagos.synchronize()`,
+- querying `is_available()`, `device_count()`, and `current_device()`,
+- a routing note that an operation may use a portable compiler kernel, compatibility boxing, a native vendor kernel, or documented CPU fallback depending on platform and configuration.
+
+Do not say every operation uses FlagGems. Do not include vendor SDK paths or build commands.
+
+- [ ] **Step 3: Verify shared docs contain no platform manual leakage**
+
+Run:
+
+```bash
+rg -n 'ACCELERATOR=.*pip install|/opt/|/usr/local/|LD_LIBRARY_PATH|LD_PRELOAD|pytest ' \
+  docs/getting-started/*.md
+```
+
+Expected: no matches except a generic mention of `ACCELERATOR` without a command or machine path; edit any leaking detail out.
+
+- [ ] **Step 4: Verify language and Markdown shape**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import re
+
+for path in Path('docs/getting-started').glob('*.md'):
+    text = path.read_text()
+    assert text.startswith('# '), path
+    assert not any(0x3400 <= ord(char) <= 0x9FFF for char in text), path
+print('getting-started docs: OK')
+PY
+```
+
+Expected: `getting-started docs: OK`.
+
+- [ ] **Step 5: Commit shared onboarding docs**
+
+```bash
+git add docs/getting-started/installation.md docs/getting-started/quickstart.md
+git commit -m "docs: add shared installation and quickstart guides"
+```
+
+---
+
+### Task 3: Extract Environment and Contributor References
+
+**Files:**
+- Create: `docs/reference/environment-variables.md`
+- Create: `docs/development/testing.md`
+- Create: `CONTRIBUTING.md`
+- Reference: `setup.py`
+- Reference: `CMakeLists.txt`
+- Reference: `torch_fl/__init__.py`
+- Reference: `torch_fl/compile/README.md`
+- Reference: `torch_fl/comm/process_group.py`
+- Reference: `tests/integration/conftest.py`
+- Reference: `tests/integration/ops/conftest.py`
+- Reference: `.github/workflows/lint.yml`
+- Reference: `scripts/codegen_*.py`
+
+**Interfaces:**
+- Consumes: Current build/runtime variable definitions and actual test/lint/codegen commands.
+- Produces: Stable operational and contribution links for all platform guides and the root README.
+
+- [ ] **Step 1: Inventory variables from source, not only the old README**
+
+Run:
+
+```bash
+rg -o 'os\.environ(?:\.get)?\("[A-Z0-9_]+"|os\.getenv\("[A-Z0-9_]+' \
+  setup.py torch_fl scripts .github/scripts | sort -u
+rg -n '\$ENV\{[A-Z0-9_]+\}|CACHE (STRING|BOOL|PATH)' CMakeLists.txt csrc/CMakeLists.txt
+```
+
+Expected: source-defined build and runtime variables are listed. Compare them with `README.md:680-721`; do not migrate old descriptions that source contradicts.
+
+- [ ] **Step 2: Create the environment-variable reference**
+
+Write `docs/reference/environment-variables.md` with these sections:
+
+- `## Build Selection`: `ACCELERATOR`, `FLAGOS_BUILD_JOBS`, and the kernel switches.
+- `## SDK and Compiler Discovery`: shared variables with platform and default/precedence where source defines one.
+- `## Operator Routing`: `FLAGOS_USE_FLAGGEMS`, `FLAGOS_BACKEND_CONFIG`, `FLAGOS_OP_<name>`, `FLAGOS_LOG_DISPATCH`, `FLAGGEMS_SOURCE_DIR`, and `GEMS_VENDOR`; explain that auto-detection/build metadata normally sets the vendor and users should override only deliberately.
+- `## Runtime and Packaging`: asset/bundle switches and import/runtime compatibility controls.
+- `## Compiler and Feature Backends`: compile and BPU-specific variables, linking to the relevant detailed guides.
+- `## Platform-specific Variables`: links to vendor guides rather than duplicating long setup blocks.
+
+For each variable, use `Variable | Scope | Default or auto-detection | Purpose`. If source does not define a stable default, write “No global default” instead of guessing.
+
+- [ ] **Step 3: Create the development and testing guide**
+
+Write `docs/development/testing.md` with:
+
+- test directory responsibilities: `tests/unit/`, `tests/integration/`, `tests/integration/ops/`, `tests/manual/`, and `tests/perf/`;
+- pytest marks read from `tests/integration/ops/conftest.py`, including `main_ops`, `anyplatform`, `cuda`, `ascend`, `flaggems`, `flaggems_python`, and `flaggems_cpp` only if currently registered;
+- generic commands for unit tests and platform-filtered operator tests;
+- model-test commands that use `<model-path>` rather than a local filesystem path;
+- profiler and compile test entry points;
+- code generation commands mapped to their source files, with a warning not to hand-edit `csrc/aten/generated/`;
+- exact lint commands from CI:
+
+```bash
+ruff check .
+ruff format --check .
+git diff --check
+```
+
+State hardware and SDK prerequisites next to commands that need them; do not imply they run in a CPU-only environment.
+
+- [ ] **Step 4: Create a concise contribution guide**
+
+Write `CONTRIBUTING.md` with:
+
+- `## Ways to Contribute`: operators, runtime/platform integration, compiler integration, distributed/profiler work, tests, and documentation;
+- `## Before You Start`: check support boundaries, avoid claiming inherited platform support, and discuss broad architectural changes first;
+- `## Development Workflow`: branch, make scoped changes, regenerate bindings when needed, run focused tests, run lint/diff checks;
+- `## Adding an Accelerator Backend`: link to compatibility, installation, environment, testing, and relevant architecture docs; require a runtime path, operator route or explicit runtime-only scope, platform guide, and validation evidence;
+- `## Pull Requests`: English title/body, exact commands/results, hardware/SDK combination, limitations, no credentials or machine-local paths;
+- `## License`: contributions are under Apache-2.0.
+
+Keep it concise; detailed commands remain in `docs/development/testing.md`.
+
+- [ ] **Step 5: Verify variable and test documentation against source**
+
+Run:
+
+```bash
+rg -n 'FLAGOS_USE_FLAGGEMS|FLAGOS_BACKEND_CONFIG|FLAGOS_OP_<name>|GEMS_VENDOR' \
+  docs/reference/environment-variables.md
+rg -n 'main_ops|anyplatform|flaggems_python|flaggems_cpp|ruff check|ruff format' \
+  docs/development/testing.md
+rg -n '/nfs/|/home/[^<]|/root/|harbor\.|MODEL_PATH: /' \
+  docs/reference/environment-variables.md docs/development/testing.md CONTRIBUTING.md
+```
+
+Expected: required routing/test terms are present; the local/private path scan has no matches.
+
+- [ ] **Step 6: Commit reference and contribution docs**
+
+```bash
+git add docs/reference/environment-variables.md docs/development/testing.md CONTRIBUTING.md
+git commit -m "docs: add configuration and contribution references"
+```
+
+---
+
+### Task 4: Migrate CUDA-compatible Platform Guides
+
+**Files:**
+- Create: `docs/vendors/cuda/installation.md`
+- Create: `docs/vendors/metax/installation.md`
+- Create: `docs/vendors/ppu/installation.md`
+- Create: `docs/vendors/dcu/installation.md`
+- Reference: `README.md:34-112`
+- Reference: `README.md:224-465`
+- Reference: `.github/configs/{cuda,metax,dcu}.yml`
+- Reference: `.github/scripts/set_env_{cuda,metax,dcu}.sh`
+- Reference: `scripts/with_cuda_libtorch.sh`
+- Reference: `scripts/bundle_maca_libtorch.sh`
+- Reference: `scripts/bundle_ppu_libtorch.sh`
+- Reference: `scripts/bundle_dcu_libtorch.sh`
+- Reference: `docs/vendors/cuda/external-libtorch-cuda.md`
+
+**Interfaces:**
+- Consumes: Shared compatibility/configuration/testing docs and current boxing build scripts.
+- Produces: Detailed installation destinations for the compatibility-key boxing family.
+
+- [ ] **Step 1: Write the NVIDIA CUDA guide**
+
+Create `docs/vendors/cuda/installation.md` with:
+
+- supported route: CPU PyTorch plus bundled/external CUDA libtorch compatibility-key boxing, with optional FlagGems compiler kernels;
+- prerequisites and exact source installation flow verified against `.github/scripts/set_env_cuda.sh` and `setup.py`;
+- a basic verification command using `device="flagos:0"`;
+- operator, FlagGems, Qwen3, compile, distributed, and profiler validation commands only where current tests/CI support them;
+- troubleshooting limited to verified import/asset and version-pin failures;
+- `## Further Reading` linking to `external-libtorch-cuda.md`, compile, distributed, profiler, environment, and testing docs.
+
+Use placeholders such as `<path-to-FlagGems>` and `<model-path>` rather than machine-local examples.
+
+- [ ] **Step 2: Write the MetaX guide**
+
+Create `docs/vendors/metax/installation.md` by editing, not blindly copying, `README.md:44-112` and `README.md:756-789`. Include:
+
+- build-host versus target-host requirements;
+- self-contained boxing wheel steps using repository scripts;
+- import-order and MACA runtime rules;
+- pure boxing versus optional `triton-metax`/FlagGems routing;
+- representative operator/factory validation matching `.github/configs/metax.yml`;
+- clearly label model training/inference and distributed claims as manual/experimental unless backed by current CI;
+- replace `/opt/maca` only where it is the documented SDK default; replace user/repository/model paths with angle-bracket placeholders.
+
+- [ ] **Step 3: Write the PPU guide**
+
+Create `docs/vendors/ppu/installation.md` from the verified PPU material in `README.md:224-337`. Preserve these distinctions:
+
+- `PPU_SDK` triggers a CUDA-compatible route; the build selector remains `ACCELERATOR=cuda`;
+- vendor PyTorch supplies the CUDA dispatch-key implementation, so bundled CUDA assets are disabled;
+- vendor Triton versioning may require manual dependency installation;
+- NCCL is the default distributed route and FlagCX is optional;
+- status remains Experimental because validation is setup-specific and no PPU CI manifest exists.
+
+Remove temporary troubleshooting detail that cannot be reproduced from repository scripts. Link to shared distributed/testing references rather than repeating complete manuals.
+
+- [ ] **Step 4: Write the DCU guide**
+
+Create `docs/vendors/dcu/installation.md` from `README.md:339-465`, `setup.py`, the DCU bundle script, and `.github/configs/dcu.yml`. Include:
+
+- DTK/hipified-PyTorch compatibility-key boxing architecture;
+- `ACCELERATOR=dcu` installation and `DTK_ROOT`/`ROCM_PATH` precedence;
+- optional DTK-provided Triton/FlagGems route;
+- RCCL exposed through the NCCL API and optional FlagCX;
+- CI-backed operator, factory, FlagGems, and profiler commands;
+- current limits such as `record_stream` only if still true in source;
+- no fixed machine path except documented vendor defaults.
+
+- [ ] **Step 5: Verify all compatibility-boxing guides share the right boundaries**
+
+Run:
+
+```bash
+for f in docs/vendors/{cuda,metax,ppu,dcu}/installation.md; do
+  printf '%s: ' "$f"
+  rg -q '^## (Prerequisites|Requirements)' "$f" && \
+  rg -q '^## (Install|Build)' "$f" && \
+  rg -q '^## Verif' "$f" && echo OK
+done
+rg -n '/nfs/|/home/[^<]|/root/|harbor\.|/models/' \
+  docs/vendors/{cuda,metax,ppu,dcu}/installation.md
+```
+
+Expected: four `OK` lines; no local/private path matches.
+
+- [ ] **Step 6: Check vendor-guide links**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import re
+
+for path in Path('docs/vendors').glob('*/installation.md'):
+    for target in re.findall(r'\[[^]]+\]\(([^)]+)\)', path.read_text()):
+        if '://' in target or target.startswith('#'):
+            continue
+        resolved = (path.parent / target.split('#', 1)[0]).resolve()
+        assert resolved.exists(), f'{path}: broken link: {target}'
+print('boxing guide links: OK')
+PY
+```
+
+Expected: `boxing guide links: OK`.
+
+- [ ] **Step 7: Commit compatibility-boxing guides**
+
+```bash
+git add docs/vendors/cuda/installation.md docs/vendors/metax/installation.md \
+  docs/vendors/ppu/installation.md docs/vendors/dcu/installation.md
+git commit -m "docs: migrate compatibility platform installation guides"
+```
+
+---
+
+### Task 5: Migrate Native-kernel Platform Guides
+
+**Files:**
+- Create: `docs/vendors/ascend/installation.md`
+- Create: `docs/vendors/gcu/installation.md`
+- Create: `docs/vendors/musa/installation.md`
+- Reference: `README.md:113-223`
+- Reference: `README.md:467-611`
+- Reference: `.github/configs/ascend.yml`
+- Reference: `.github/scripts/set_env_ascend.sh`
+- Reference: `scripts/codegen_ascend.py`
+- Reference: `scripts/codegen_gcu.py`
+- Reference: `scripts/codegen_mudnn.py`
+- Reference: `docs/vendors/ascend/{aclnn-codegen,external-libtorch-npu,npu-plan}.md`
+
+**Interfaces:**
+- Consumes: Shared compatibility/configuration/testing docs and native runtime/operator codegen sources.
+- Produces: Detailed installation destinations for platforms that call vendor runtime/operator libraries directly.
+
+- [ ] **Step 1: Write the Ascend guide**
+
+Create `docs/vendors/ascend/installation.md` with:
+
+- CPU PyTorch plus CANN prerequisites;
+- `ACCELERATOR=ascend`/ACLNN native-kernel build as the default path;
+- optional FlagGems plus triton-ascend path, including why torch_npu cannot be loaded as a compatibility-key fallback;
+- import order, patch script, verification, operator/factory/RNG test commands matching current CI;
+- explicit limitations: no model mount in current CI, no device-side profiler parity yet, and distributed capability depends on a viable FlagCX/HCCL integration rather than being implied globally;
+- links to all three existing Ascend analyses.
+
+Do not carry stale private fork URLs forward unless the source/install tooling still requires and documents them; prefer current upstream project links.
+
+- [ ] **Step 2: Write the GCU guide**
+
+Create `docs/vendors/gcu/installation.md` with:
+
+- CPU PyTorch plus TopsRider/topsaten prerequisites;
+- `ACCELERATOR=gcu` source installation;
+- native `topsrt` runtime and generated topsaten operator path;
+- explicit CPU fallback for missing kernels and int64 limitations;
+- optional FlagGems/Triton-GCU only as an experimental route if current source still enables it;
+- verification based on generic factory/operator smoke tests, clearly labelled as manual because there is no GCU CI config;
+- codegen contributor link to `scripts/codegen_gcu.py` and shared testing docs.
+
+- [ ] **Step 3: Write the MUSA guide**
+
+Create `docs/vendors/musa/installation.md` with:
+
+- CPU PyTorch plus MUSA toolkit/mudnn prerequisites;
+- `ACCELERATOR=musa` source installation and required no-build-isolation behavior;
+- native musart runtime and generated mudnn operators;
+- `torch_fl`-before-`torch` rule when torch_musa is installed and the `TORCH_DEVICE_BACKEND_AUTOLOAD` interaction;
+- generated-op and convolution/fallback boundaries;
+- manual validation using `tests/integration/ops/test_musa_dispatch.py` plus focused common operator tests;
+- distributed support described as FlagCX-only architecture unless live evidence proves more;
+- no claim of continuous validation because no MUSA CI config exists.
+
+- [ ] **Step 4: Compare all native guides against build forcing rules**
+
+Run:
+
+```bash
+rg -n 'ACCELERATOR == "(ascend|gcu|musa)"|-(DASCEND_KERNEL|DGCU_KERNEL|DMUSA_KERNEL)' setup.py
+rg -n 'ACCELERATOR=(ascend|gcu|musa)|ACLNN|topsaten|mudnn|CPU fallback' \
+  docs/vendors/{ascend,gcu,musa}/installation.md
+```
+
+Expected: every guide's selected native kernel route agrees with `setup.py`; no guide describes CUDA boxing for these platforms.
+
+- [ ] **Step 5: Verify no unsupported profiler/distributed claims slipped in**
+
+Run:
+
+```bash
+rg -n 'full profiler parity|continuously tested|Stable|NCCL fallback' \
+  docs/vendors/{ascend,gcu,musa}/installation.md
+```
+
+Expected: no matches unless immediately negated as an explicit limitation; revise ambiguous claims.
+
+- [ ] **Step 6: Commit native-kernel guides**
+
+```bash
+git add docs/vendors/ascend/installation.md docs/vendors/gcu/installation.md \
+  docs/vendors/musa/installation.md
+git commit -m "docs: migrate native platform installation guides"
+```
+
+---
+
+### Task 6: Create the BPU Runtime-only Entry Point
+
+**Files:**
+- Create: `docs/vendors/bpu/installation.md`
+- Preserve: `docs/vendors/bpu/integration.md`
+- Reference: `README.md:612-678`
+- Reference: `setup.py:398-413`
+- Reference: `torch_fl/accelerator/bpu/`
+- Reference: `tests/unit/bpu/`
+- Reference: `benchmarks/README.md`
+
+**Interfaces:**
+- Consumes: The **Runtime only** definition and BPU capability boundary from Task 1.
+- Produces: A concise BPU installation entry point without duplicating its extensive architecture and benchmark analysis.
+
+- [ ] **Step 1: Write the BPU entry guide**
+
+Create `docs/vendors/bpu/installation.md` with:
+
+- supported target and runtime prerequisites;
+- `ACCELERATOR=bpu` installation command;
+- explicit behavior boundary: native device memory/runtime, CPU fallback for eager operators, graph acceleration through `torch.compile(backend="bpu")`, and a separate prebuilt-HBM LLM runtime;
+- hbdk4/box64 setup via `scripts/setup_bpu_hbdk4.sh` only where compilation is needed;
+- short verification for import/device runtime and links to focused unit tests;
+- links to `integration.md` for partitioning, quantization, cache, zero-copy, fixed-shape limits, benchmark results, and LLM runtime details;
+- no duplicated performance numbers in the installation guide unless they are necessary to explain validation status.
+
+- [ ] **Step 2: Verify the guide does not imply eager acceleration**
+
+Run:
+
+```bash
+rg -n 'eager|CPU fallback|torch\.compile|Runtime only|\.hbm' \
+  docs/vendors/bpu/installation.md
+```
+
+Expected: all five concepts are present and explicitly distinguish the execution modes.
+
+- [ ] **Step 3: Verify the existing detailed guide remains the canonical analysis**
+
+Run:
+
+```bash
+rg -n 'integration\.md' docs/vendors/bpu/installation.md
+rg -n '1\.356 ms|82\.1 tok/s|19\.2x' docs/vendors/bpu/installation.md
+```
+
+Expected: the first command finds the link; the second produces no output, avoiding duplication of measured detail.
+
+- [ ] **Step 4: Commit the BPU entry point**
+
+```bash
+git add docs/vendors/bpu/installation.md
+git commit -m "docs: add BPU runtime installation entry point"
+```
+
+---
+
+### Task 7: Rewrite the Root README as the Project Landing Page
+
+**Files:**
+- Modify: `README.md`
+- Reference: `docs/superpowers/specs/2026-08-11-readme-redesign-design.md`
+- Reference: all documentation created in Tasks 1-6
+- Reference: `LICENSE`
+
+**Interfaces:**
+- Consumes: Canonical compatibility/status claims and complete documentation destinations.
+- Produces: The public project landing page; it must summarize, never strengthen, detailed documentation.
+
+- [ ] **Step 1: Replace the root README using the approved section order**
+
+Rewrite `README.md` with exactly this top-level information architecture:
+
+```markdown
+# torch-fl
+
+[useful badges and documentation links only]
+
+[one-paragraph project positioning]
+
+## Overview
+## Design Philosophy
+## Architecture
+## Capabilities
+## Hardware Support
+## Compatibility
+## Quick Start
+## Documentation
+## Contributing
+## Acknowledgements
+## License
+```
+
+Header rules:
+
+- Use the display name `torch-fl`; code/package imports remain `torch_fl`.
+- Describe it as the PyTorch device plugin for the FlagOS software stack.
+- State that one `flagos` device routes operators among reusable native kernels, portable compiler kernels, vendor-native implementations, and explicit CPU fallback.
+- Include only verifiable badges, such as license and supported Python/PyTorch metadata. Do not add coverage, download, release, or build-status badges without a stable public target.
+- Omit the stale `README_zh.md` link unless labelled “Chinese (translation may lag behind this README)”; prefer omission to implying synchronization.
+
+- [ ] **Step 2: Explain the design without overclaiming**
+
+In `## Design Philosophy`, cover these five principles:
+
+1. PyTorch-native interface.
+2. One logical device.
+3. Layered per-operator backends.
+4. Reuse before reimplementation.
+5. Explicit capability boundaries.
+
+Define these three implementation paths:
+
+- native vendor kernels;
+- compatibility-key boxing;
+- portable compiler kernels.
+
+Clarify that a platform may combine paths and users do not choose product tiers.
+
+- [ ] **Step 3: Add the compact conceptual architecture diagram**
+
+Use a plain text diagram, not a detailed component inventory:
+
+```text
+PyTorch API
+    |
+flagos device (PrivateUse1)
+    |
+device runtime + per-operator routing
+    |
+FlagGems/compiler kernels | compatibility boxing | native vendor kernels | CPU fallback
+    |
+accelerator runtime
+```
+
+Link architecture detail to `docs/architecture/` documents instead of reproducing dispatch, distributed, compile, or profiler internals.
+
+- [ ] **Step 4: Summarize capabilities and platform support conservatively**
+
+The capabilities section must list project-level support for:
+
+- eager tensor operations and device management;
+- autograd and training;
+- `torch.compile`;
+- distributed collectives and DDP through `ProcessGroupFlagOS`;
+- `torch.profiler` integration;
+- FlagGems/Triton integration;
+- explicit CPU fallback.
+
+Immediately state that availability and validation vary by platform.
+
+Create the compact support table:
+
+```markdown
+| Platform | Execution path | Validated capabilities | Status | Guide |
+|---|---|---|---|---|
+```
+
+Copy status and capability wording from `docs/reference/compatibility.md`. Use no guide link for TsingMicro. Keep BPU labelled **Runtime only** and avoid presenting its eager CPU fallback as accelerator operator coverage.
+
+- [ ] **Step 5: Add compatibility, quick start, docs, contribution, acknowledgements, and license**
+
+- Compatibility: state Python 3.8+ and PyTorch 2.10.x, explain generated ATen minor-line pinning, and link the detailed matrix.
+- Quick Start: direct readers to the installation selector, then show only a short `flagos:0` example whose comment does not prescribe the backend route.
+- Documentation: curate links to installation, quickstart, compatibility, architecture, environment variables, testing, and contribution docs.
+- Contributing: summarize accepted contribution areas and link `CONTRIBUTING.md`.
+- Acknowledgements: name PyTorch, FlagGems, FlagTree/Triton where applicable, FlagCX, and vendor runtime/operator libraries without implying endorsement.
+- License: link `LICENSE` and state Apache-2.0.
+
+- [ ] **Step 6: Enforce README scope and size**
+
+Run:
+
+```bash
+wc -l README.md
+rg -n '^### Build|ACCELERATOR=.*pip install|LD_LIBRARY_PATH|LD_PRELOAD|pytest |/opt/|/usr/local/' README.md
+rg -n 'Python 3\.12|PyTorch 2\.11\.0|CUDA 12\.8|All operations automatically use FlagGems' README.md
+rg -n 'include/|debug/' README.md
+```
+
+Expected: approximately 250-350 lines; no platform build/runtime/test commands, stale global claims, or removed root paths. A platform name in the support table is fine; procedural details are not.
+
+- [ ] **Step 7: Check README links**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import re
+
+path = Path('README.md')
+for target in re.findall(r'\[[^]]+\]\(([^)]+)\)', path.read_text()):
+    if '://' in target or target.startswith('#'):
+        continue
+    resolved = (path.parent / target.split('#', 1)[0]).resolve()
+    assert resolved.exists(), f'{path}: broken link: {target}'
+print('README links: OK')
+PY
+```
+
+Expected: `README links: OK`.
+
+- [ ] **Step 8: Commit the root README rewrite**
+
+```bash
+git add README.md
+git commit -m "docs: redesign project README"
+```
+
+---
+
+### Task 8: Validate Navigation, Language, Claims, and Diff Scope
+
+**Files:**
+- Modify: only documentation files with defects found by these checks
+- Validate: `README.md`
+- Validate: `CONTRIBUTING.md`
+- Validate: `docs/getting-started/`
+- Validate: `docs/reference/`
+- Validate: `docs/development/`
+- Validate: `docs/vendors/*/installation.md`
+
+**Interfaces:**
+- Consumes: The complete documentation implementation.
+- Produces: A review-ready documentation-only diff satisfying every spec acceptance criterion.
+
+- [ ] **Step 1: Validate every relative Markdown link in changed public docs**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import re
+
+paths = [Path('README.md'), Path('CONTRIBUTING.md')]
+paths += list(Path('docs/getting-started').glob('*.md'))
+paths += list(Path('docs/reference').glob('*.md'))
+paths += list(Path('docs/development').glob('*.md'))
+paths += list(Path('docs/vendors').glob('*/installation.md'))
+
+broken = []
+for path in paths:
+    text = path.read_text()
+    for target in re.findall(r'\[[^]]+\]\(([^)]+)\)', text):
+        if '://' in target or target.startswith('#') or target.startswith('mailto:'):
+            continue
+        file_target = target.split('#', 1)[0]
+        if file_target and not (path.parent / file_target).resolve().exists():
+            broken.append(f'{path}: {target}')
+assert not broken, 'Broken links:\n' + '\n'.join(broken)
+print(f'checked {len(paths)} Markdown files: all local links resolve')
+PY
+```
+
+Expected: all local links resolve.
+
+- [ ] **Step 2: Validate English-only publication policy**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import re
+
+paths = [Path('README.md'), Path('CONTRIBUTING.md')]
+paths += list(Path('docs').rglob('*.md'))
+bad = [str(p) for p in paths if any(0x3400 <= ord(char) <= 0x9FFF for char in p.read_text())]
+assert not bad, 'CJK found in English docs:\n' + '\n'.join(bad)
+print('English-language scan: OK')
+PY
+```
+
+Expected: `English-language scan: OK`. Historical `docs/superpowers/` files are included because the project policy covers all `docs/`; do not weaken the scan.
+
+- [ ] **Step 3: Scan for secrets, private infrastructure, and machine-local paths**
+
+Run:
+
+```bash
+rg -n '/nfs/|/home/[A-Za-z0-9_-]+/|/root/|harbor\.|https?://[^ ]+:[^ @]+@|proxy(_url)?=' \
+  README.md CONTRIBUTING.md docs --glob '*.md'
+```
+
+Expected: no matches. Documented vendor defaults such as `/opt/dtk`, `/opt/maca`, `/opt/tops`, `/usr/local/musa`, and `/usr/local/Ascend` are allowed only inside the relevant vendor guide and must not contain a user or private-host component.
+
+- [ ] **Step 4: Cross-check package compatibility and platform names**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+
+readme = Path('README.md').read_text()
+compat = Path('docs/reference/compatibility.md').read_text()
+assert 'Python 3.8' in readme and 'Python 3.8' in compat
+assert '2.10' in readme and '>=2.10,<2.11' in compat
+for platform in ['CUDA', 'MetaX', 'Ascend', 'PPU', 'DCU', 'GCU', 'MUSA', 'BPU', 'TsingMicro']:
+    assert platform in readme, f'README missing {platform}'
+    assert platform in compat, f'compatibility matrix missing {platform}'
+assert 'Runtime only' in compat
+print('compatibility summaries agree: OK')
+PY
+```
+
+Expected: `compatibility summaries agree: OK`.
+
+- [ ] **Step 5: Recheck root README boundary and stale paths**
+
+Run:
+
+```bash
+rg -n '^### Build from Source|ACCELERATOR=.*pip install|source /|export (LD_|PATH=)|pytest ' README.md
+rg -n '├── include/|├── debug/|path_to_repos|/path/to/' README.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 6: Run repository formatting checks**
+
+Run:
+
+```bash
+git diff --check
+ruff check .
+ruff format --check .
+```
+
+Expected: all commands exit 0. Markdown-only changes should not alter Ruff results; if Ruff fails on a pre-existing source issue, capture the exact failure and do not edit unrelated source merely to make this documentation change green.
+
+- [ ] **Step 7: Confirm the final diff is documentation-only**
+
+Run:
+
+```bash
+git diff --name-only flagos/main...HEAD
+```
+
+Expected: only `README.md`, `CONTRIBUTING.md`, and files under `docs/` are listed, including the approved spec and this plan. No source, test, build, generated, or workflow file appears.
+
+- [ ] **Step 8: Review the final support-language diff**
+
+Run:
+
+```bash
+git diff --stat flagos/main...HEAD
+git diff --word-diff=plain flagos/main...HEAD -- README.md docs/reference/compatibility.md
+```
+
+Expected: the reviewer can trace every compact README claim to equal or more conservative wording in the compatibility reference. Correct any mismatch before committing.
+
+- [ ] **Step 9: Commit validation fixes if needed**
+
+If validation required documentation edits:
+
+```bash
+git add README.md CONTRIBUTING.md docs
+git commit -m "docs: fix README navigation and validation issues"
+```
+
+If every check passed without edits, do not create an empty commit.
+
+- [ ] **Step 10: Record final verification for handoff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline flagos/main..HEAD
+```
+
+Expected: clean working tree and a reviewable sequence of documentation commits: design spec, compatibility contract, shared onboarding/reference docs, platform guides, README rewrite, and optional validation fixes.

--- a/docs/superpowers/specs/2026-08-11-readme-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-11-readme-redesign-design.md
@@ -45,7 +45,7 @@ The English `README.md` will use the following section order:
 
 ```text
 # torch-fl
-  Badges · Documentation · 中文
+  Badges · Documentation · Chinese README
 
 Project positioning
 

--- a/docs/superpowers/specs/2026-08-11-readme-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-11-readme-redesign-design.md
@@ -1,0 +1,296 @@
+# README redesign — design document
+
+Date: 2026-08-11
+Status: Approved for implementation planning
+
+## 1. Goal
+
+Replace the current root `README.md` with a concise project landing page that explains what torch-fl is, why it exists, how it supports multiple accelerator families, what capabilities and versions are validated, and where users should go next.
+
+The root README must not remain an exhaustive build manual. Platform-specific installation, runtime configuration, testing, and troubleshooting belong under `docs/` and must be linked from the README.
+
+## 2. Audience and success criteria
+
+The README serves three audiences, in this order:
+
+1. PyTorch users deciding whether torch-fl supports their accelerator and workload.
+2. Framework and platform engineers evaluating torch-fl's architecture and capability boundaries.
+3. Contributors adding operators, runtime features, or a new accelerator backend.
+
+A reader should be able to answer the following within the first few sections:
+
+- What is torch-fl?
+- Why is it different from a vendor-specific PyTorch fork or a conventional PrivateUse1 plugin?
+- Which accelerator platforms are supported, through which execution path, and at what maturity level?
+- Which PyTorch and Python versions are supported?
+- Does the project cover eager execution, autograd, compilation, distributed execution, and profiling?
+- Where are the installation and contribution instructions?
+
+The target size for the root README is approximately 250-350 lines. This is a guideline rather than a hard limit; clarity and accurate support claims take priority.
+
+## 3. Reference projects and adopted conventions
+
+The information architecture combines conventions from several established projects:
+
+- vLLM and SGLang keep their root READMEs focused on positioning, capabilities, a short getting-started path, and links to detailed documentation.
+- PyTorch explains the design philosophy before directing readers to installation, resources, releases, and contribution material.
+- FlagCX and FlagScale use explicit support tables to make multi-backend scope discoverable.
+- FlagGems uses a compact About → Features → Getting Started → Contribution structure that is consistent with the wider FlagOS ecosystem.
+
+The design deliberately does not copy PyTorch's long source-build section or FlagTree's platform installation details into the root README.
+
+## 4. Root README information architecture
+
+The English `README.md` will use the following section order:
+
+```text
+# torch-fl
+  Badges · Documentation · 中文
+
+Project positioning
+
+## Overview
+
+## Design Philosophy
+
+## Architecture
+
+## Capabilities
+
+## Hardware Support
+
+## Compatibility
+
+## Quick Start
+
+## Documentation
+
+## Contributing
+
+## Acknowledgements
+
+## License
+```
+
+### 4.1 Header and positioning
+
+The header will identify the project as `torch-fl` and describe it as the PyTorch device plugin for the FlagOS software stack. The opening paragraph must state that torch-fl exposes a single `flagos` device while selecting among reusable native kernels, portable compiler kernels, and vendor-native implementations.
+
+The header may include only useful, maintainable links and badges. It must not add decorative or unverified status badges.
+
+### 4.2 Overview
+
+The overview will describe the ecosystem problem: accelerator vendors expose different runtimes, compiler stacks, and PyTorch integration strategies. torch-fl provides a PyTorch-native device surface and isolates these differences behind a common runtime and operator-routing layer.
+
+This section should describe the project rather than make unsupported performance or completeness claims.
+
+### 4.3 Design Philosophy
+
+The section will explain five principles:
+
+1. **PyTorch-native interface** — users program against standard PyTorch APIs and the `flagos` device.
+2. **One logical device** — vendor differences do not create a different user-facing device name for every accelerator.
+3. **Layered operator backends** — routing may select different implementations per operator.
+4. **Reuse before reimplementation** — reuse established kernels and compiler stacks where their dispatch and ABI boundaries permit it.
+5. **Explicit capability boundaries** — unsupported paths and CPU fallbacks are documented instead of being presented as full native coverage.
+
+It will also define the three principal execution paths:
+
+- **Native vendor kernels:** direct calls into vendor runtime and operator libraries, such as ACLNN, mudnn, or topsaten.
+- **Compatibility-key boxing:** zero-copy metadata conversion into an independent PyTorch dispatch key when the vendor stack exposes one that can coexist with PrivateUse1.
+- **Portable compiler kernels:** FlagGems kernels generated through Triton or a compatible compiler backend.
+
+These paths are implementation strategies, not user-selectable product tiers. A platform may use more than one path.
+
+### 4.4 Architecture
+
+The README will include one compact diagram showing this flow:
+
+```text
+PyTorch API
+    ↓
+flagos device (PrivateUse1)
+    ↓
+device runtime + per-operator routing
+    ↓
+FlagGems/compiler kernels | compatibility boxing | native vendor kernels | CPU fallback
+    ↓
+accelerator runtime
+```
+
+The diagram must remain conceptual. Detailed component diagrams, dispatch internals, and profiler/distributed designs belong in `docs/architecture/`.
+
+### 4.5 Capabilities
+
+The README will summarize the project-wide capability surface:
+
+- PyTorch eager tensor operations and device management
+- autograd and model training
+- `torch.compile`
+- distributed collectives and DDP through `ProcessGroupFlagOS`
+- `torch.profiler` integration
+- FlagGems/Triton operator integration
+- explicit CPU fallback for uncovered operations where PyTorch semantics permit it
+
+The section must distinguish project support from platform validation. A capability existing in torch-fl does not imply that every platform implements or validates it. Per-platform capability detail belongs in the compatibility reference.
+
+### 4.6 Hardware Support
+
+The root support table will have five columns:
+
+```text
+Platform | Execution path | Validated capabilities | Status | Guide
+```
+
+The table will list accelerator platforms supported by the current codebase, using names consistent with the build configuration and runtime detection. Chip families must not be added solely because FlagGems or FlagTree supports them; torch-fl itself must have an integration path in the repository.
+
+Support status has these precise meanings:
+
+- **Stable:** critical paths are continuously tested and the supported version combination is documented.
+- **Beta:** the primary path has been validated, but coverage, packaging, or release procedures are not yet stable.
+- **Experimental:** validation exists for a specific setup, model, or hardware environment, and interfaces or build procedures may change.
+- **Runtime only:** the device runtime is integrated, but the platform is not a general eager operator backend.
+
+Status assignments must be derived from code, tests, and documented live validation. Uncertain claims default to the less mature status.
+
+The root table remains compact. A detailed matrix covering eager execution, training, compile, distributed, profiler, and FlagGems support will live in `docs/reference/compatibility.md`.
+
+### 4.7 Compatibility
+
+The README will state the supported Python and PyTorch range from package metadata, currently Python 3.8 or later and PyTorch 2.10.x. It will explain that generated ATen bindings are pinned to a PyTorch minor line and that vendor SDK or compiler versions vary by platform.
+
+It must not preserve the stale global requirements table that claims Python 3.12, PyTorch 2.11.0, CUDA 12.8, and FlagGems 5.0.2 for all platforms. Platform-specific validated combinations belong in the compatibility reference and installation guides.
+
+### 4.8 Quick Start
+
+The root README will provide one short, platform-independent Python example using `device="flagos"`. It will not include platform build commands, SDK paths, environment-variable tables, import-order troubleshooting, or test invocations.
+
+Before the example, the section will direct users to choose their platform in the installation guide. The example must avoid claiming that every operation always uses FlagGems, because routing depends on the platform and configuration.
+
+### 4.9 Documentation
+
+The documentation section will be a curated navigation list, not a dump of every file. It will link to:
+
+- installation and platform selection,
+- compatibility and support matrix,
+- architecture documents,
+- backend configuration or environment-variable reference,
+- development and testing guidance.
+
+Vendor-specific design analyses may be reached through their platform guide rather than all being linked directly from the root README.
+
+### 4.10 Contributing
+
+The section will welcome operator, runtime, compiler, documentation, and accelerator-backend contributions. It will link to a contribution guide if one exists; otherwise implementation must create a concise `CONTRIBUTING.md` or a development guide rather than embedding the complete workflow in the README.
+
+Contribution claims must match the actual lint, code generation, and test commands in the repository.
+
+### 4.11 Acknowledgements and license
+
+Acknowledgements will identify the upstream systems the project materially builds on, including PyTorch, FlagGems, FlagTree/Triton where applicable, and vendor runtime or operator libraries. It must avoid implying endorsement by vendors or projects.
+
+The license section will link to the repository's Apache-2.0 `LICENSE` file.
+
+## 5. Documentation structure and migration
+
+The redesign introduces stable documentation entry points:
+
+```text
+docs/
+├── getting-started/
+│   ├── installation.md
+│   └── quickstart.md
+├── reference/
+│   ├── compatibility.md
+│   └── environment-variables.md
+└── vendors/
+    ├── cuda/
+    │   └── installation.md
+    ├── metax/
+    │   └── installation.md
+    ├── ascend/
+    │   └── installation.md
+    ├── ppu/
+    │   └── installation.md
+    ├── dcu/
+    │   └── installation.md
+    ├── gcu/
+    │   └── installation.md
+    ├── musa/
+    │   └── installation.md
+    ├── bpu/
+    │   └── installation.md
+    └── tsingmicro/
+        └── installation.md
+```
+
+Only platforms supported by the latest code and for which accurate instructions can be recovered from the current README or repository will receive an installation page. Empty placeholder guides are prohibited. If a platform lacks sufficient verified setup information, its support-table guide will point to a scoped existing document or omit the guide link while clearly marking the limitation.
+
+Existing documents will be preserved and linked rather than duplicated:
+
+- `docs/vendors/ascend/aclnn-codegen.md`, `external-libtorch-npu.md`, and `npu-plan.md` remain detailed design and analysis documents linked from the Ascend guide.
+- `docs/vendors/bpu/integration.md` remains the detailed BPU architecture and operating guide; the BPU installation entry will link to it and avoid copying its full content.
+- `docs/vendors/cuda/external-libtorch-cuda.md` remains the external-libtorch design explanation linked from the CUDA guide.
+- `docs/vendors/flaggems/` remains focused on FlagGems routing analyses.
+- `docs/architecture/` remains focused on cross-cutting architecture.
+- `docs/superpowers/` historical design and implementation material is not part of the end-user navigation hierarchy and will not be reorganized in this change.
+
+The migration will extract and edit current README material rather than blindly copying it. Stale paths, obsolete project trees, conflicting version claims, and machine-specific assumptions must be removed.
+
+## 6. Scope boundaries
+
+This redesign includes:
+
+- rewriting the English `README.md`,
+- creating or consolidating English installation and compatibility documentation needed by the new README,
+- moving platform-specific build, runtime, testing, and troubleshooting material out of the root README,
+- adding navigation links among the new entry points and existing architecture/vendor documents,
+- verifying support claims against the current code, tests, package metadata, and existing measured documentation,
+- validating Markdown, local links, language policy, and repository formatting checks.
+
+This redesign does not include:
+
+- changing runtime or operator behavior,
+- adding support for a new accelerator,
+- claiming support inherited only from another FlagOS component,
+- reorganizing `docs/superpowers/`,
+- rewriting `README_zh.md` in the same change.
+
+`README_zh.md` is currently stale and will no longer be presented as an exact mirror until it receives a separate translation update. The English README may retain a clearly labelled link to it only if that does not imply synchronized content; otherwise the link will be omitted until translation is updated.
+
+## 7. Content integrity and error handling
+
+Documentation must fail conservatively:
+
+- If support status cannot be verified, use the less mature category.
+- If a platform guide is incomplete, state the missing validation instead of inventing commands.
+- If metadata and the old README disagree, package/build metadata and current tested code take precedence.
+- If an existing README instruction conflicts with current source behavior, it must not be migrated without verification.
+- Machine-local absolute paths, credentials, and private proxy details must not appear in committed files.
+- Everything under `docs/` and all GitHub-facing text must remain in English.
+
+## 8. Verification
+
+Implementation is complete only after all of the following pass:
+
+1. Every relative Markdown link in `README.md` and the new or changed documentation resolves.
+2. The support and version tables agree with `pyproject.toml`, `setup.py`, build configuration, and platform routing code.
+3. No platform-specific build procedure remains in the root README beyond a link to its guide.
+4. No stale root paths such as the removed `include/` or `debug/` layout remain.
+5. No CJK characters appear under `docs/` or in the English `README.md`.
+6. No machine-local absolute paths or proxy credentials are introduced.
+7. `git diff --check` passes.
+8. Repository Markdown/lint checks pass where available.
+9. The final diff is documentation-only unless a discovered broken documentation check requires a narrowly scoped fix.
+
+## 9. Implementation sequence
+
+The implementation plan should proceed in this order:
+
+1. Inventory and verify platform/version/capability claims from source, tests, and existing documents.
+2. Create the installation, compatibility, and reference entry points.
+3. Migrate and clean platform-specific content from the current README.
+4. Rewrite the root README against the approved information architecture.
+5. Validate all claims and links, then run documentation and repository checks.
+
+This order prevents the root README from linking to incomplete destinations and keeps support claims grounded in the detailed guides.

--- a/docs/vendors/ascend/installation.md
+++ b/docs/vendors/ascend/installation.md
@@ -1,0 +1,206 @@
+# Ascend Installation Guide
+
+Ascend NPU uses native CANN ACLNN operator kernels, not CUDA boxing. The platform supports two operator execution paths: a default pure ACLNN backend and an optional FlagGems route via triton-ascend.
+
+## Prerequisites
+
+- **CPU PyTorch 2.10.x**: `torch==2.10.0` from the upstream CPU index
+- **CANN toolkit**: Ascend 910 with CANN 9.0.0 or compatible version
+- **Python**: 3.8 or later
+- **Operating System**: Linux (aarch64 verified in CI; x86_64 on real hardware)
+- **Device node**: `/dev/davinci_manager` and `/dev/davinci*` devices must be accessible
+
+## Installation
+
+### 1. Install CPU PyTorch
+
+```bash
+pip install torch==2.10.0 --index-url https://download.pytorch.org/whl/cpu
+```
+
+### 2. Source the CANN toolkit environment
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+```
+
+Verify that `ASCEND_HOME` points to a directory containing `lib64/` and `include/`:
+
+```bash
+ls $ASCEND_HOME/lib64/libascendcl.so
+ls $ASCEND_HOME/include/aclnn_base.h
+```
+
+### 3. Build and install torch_fl
+
+The default configuration uses native ACLNN kernels without FlagGems:
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git
+cd PyTorch-Plugin-FL
+
+ACCELERATOR=ascend pip install --no-build-isolation -v -e .
+```
+
+Build flags:
+- `ACCELERATOR=ascend`: selects the Ascend build path and native ACLNN kernel backend
+- `ASCEND_KERNEL=1`: compiled automatically when `ACCELERATOR=ascend` (default ON)
+- `CUDA_KERNEL=0`: automatically disabled for Ascend (no CUDA runtime exists)
+- `--no-build-isolation`: ensures the build uses your installed CPU torch, not pip's overlay
+
+The build runs `scripts/codegen_ascend.py` to generate operator kernels calling ACLNN APIs (`libopapi.so`) directly. Coverage is category-driven: unary, binary, reductions, and matmul families are generated; ops without an ACLNN mapping fall back to CPU.
+
+## Verification
+
+### Import order
+
+**Critical**: always import `torch_fl` before other packages that might register device backends:
+
+```python
+import torch_fl  # Must come first
+import torch
+```
+
+On an Ascend NPU box (detected via `/dev/davinci*`), `torch_fl` auto-selects `backends_ascend.conf` with no environment variable needed.
+
+### Check device availability
+
+```python
+import torch_fl
+import torch
+
+print(f"flagos available: {torch_fl.flagos.is_available()}")
+print(f"flagos devices: {torch_fl.flagos.device_count()}")
+
+x = torch.randn(64, 64, device="flagos:0")
+y = torch.abs(x)
+print(f"abs matches CPU: {torch.allclose(y.cpu(), x.cpu().abs())}")
+```
+
+Expected output:
+```
+flagos available: True
+flagos devices: 1  (or more, depending on your NPU count)
+abs matches CPU: True
+```
+
+## Testing
+
+Run the Ascend operator suite:
+
+```bash
+pytest tests/integration/ops/ -m "ascend" -v -s --tb=short
+```
+
+Run the RNG dispatch suite:
+
+```bash
+pytest tests/integration/ops/test_rng_dispatch.py -m "main_ops" -v -s --tb=short
+```
+
+Run general factory operator tests:
+
+```bash
+pytest tests/integration/test_factory_ops.py -v -s --tb=short
+```
+
+All three test groups are exercised in CI (see `.github/configs/ascend.yml` lines 78-97).
+
+## Optional: FlagGems via triton-ascend
+
+FlagGems provides Triton-compiled kernels as an alternative execution path. This is **optional** and **experimental** on Ascend; the native ACLNN backend is the default and recommended path.
+
+### Why FlagGems requires a fork
+
+The upstream FlagGems package links against `libtorch_npu.so` (from the `torch_npu` vendor package), which occupies the same `PrivateUse1` dispatch key as `torch_fl` and cannot coexist. Our fork replaces that dependency with a `FLAGOS` backend that obtains the ACL stream via `torch_fl`'s `GetCurrentStream` C API.
+
+See [`docs/vendors/ascend/external-libtorch-npu.md`](external-libtorch-npu.md) for the technical analysis proving why `torch_npu` cannot act as a compatibility fallback.
+
+### Install FlagGems (torch_fl branch)
+
+```bash
+git clone -b torch_fl https://github.com/Hchnr/FlagGems.git
+cd FlagGems
+
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+
+pip install --no-build-isolation -e . \
+  --config-settings=cmake.define.FLAGGEMS_BACKEND=FLAGOS \
+  --config-settings=cmake.define.FLAGGEMS_BUILD_C_EXTENSIONS=OFF
+
+cd ..
+```
+
+The `FLAGOS` backend skips the C++ extension build (`liboperators.so`) and provides only the Python dispatch path.
+
+### Rebuild torch_fl with FlagGems Python wrappers
+
+```bash
+ACCELERATOR=ascend FLAGGEMS_KERNEL=0 FLAGGEMS_PYTHON=1 \
+  CUDA_KERNEL=0 ASCEND_KERNEL=1 \
+  pip install --no-build-isolation -v -e .
+```
+
+Build flags:
+- `FLAGGEMS_PYTHON=1`: enables Python-dispatch wrappers for FlagGems Triton kernels
+- `FLAGGEMS_KERNEL=0`: disables C++ kernel wrappers (the FLAGOS backend does not build `liboperators.so`)
+- `ASCEND_KERNEL=1`: keeps the native ACLNN backend for ops FlagGems cannot compile
+
+### Patch triton-ascend
+
+The stock `triton-ascend` package depends on `torch_npu`. Patch it to use the `flagos` device interface instead:
+
+```bash
+python scripts/patch_triton_ascend.py
+```
+
+The script is idempotent. After patching, clear stale kernel cache:
+
+```bash
+rm -rf ~/.triton/cache/
+```
+
+### Runtime libstdc++ compatibility
+
+FlagGems pulls in `sqlalchemy`, which requires `CXXABI_1.3.15`. If your system `libstdc++.so.6` is older, preload conda's:
+
+```bash
+export LD_PRELOAD=$CONDA_PREFIX/lib/libstdc++.so.6
+```
+
+### Enable FlagGems at runtime
+
+```bash
+FLAGOS_USE_FLAGGEMS=1 python -c "
+import torch_fl, flag_gems, torch
+x = torch.randn(64, 64, device='flagos:0')
+print('abs matches CPU:', torch.allclose(torch.abs(x).cpu(), x.cpu().abs()))
+"
+```
+
+With `FLAGOS_USE_FLAGGEMS=1`, the runtime loads `backends_ascend_flagos_py.conf` instead of `backends_ascend.conf`. Ops that triton-ascend cannot compile are routed back to the ACLNN kernel (annotated per-op in the config).
+
+Without `FLAGOS_USE_FLAGGEMS`, all ops use the pure ACLNN backend.
+
+## Limitations
+
+### No model mount in CI
+
+`.github/configs/ascend.yml` (line 110) explicitly defers Qwen3 inference/training smoke tests pending a model mount on the CI runner. Point measurements outside CI show training at 0.82x `torch_npu` performance on real Ascend 910 hardware (`tests/perf/e2e_qwen3_train_ascend.py`).
+
+### No device-side profiler parity yet
+
+The Ascend profiler path does not yet emit device-side event categories (kernel, gpu_memcpy, gpu_memset, runtime, ac2g flows). The flagos trace has only `['Trace', 'cpu_op']` versus the torch-cuda baseline. `test_profiler_parity.py` is excluded from CI until device/runtime events are implemented (`.github/configs/ascend.yml` lines 112-117).
+
+### Distributed support is architectural only
+
+Distributed collectives route through FlagCX (recommended) or an HCCL fallback. The routing architecture is in place (see [`docs/architecture/distributed-flagcx.md`](../../architecture/distributed-flagcx.md) lines 204-208), but collective-level CI tests on Ascend hardware do not yet exist. The HCCL fallback and the `flagos→npu` zero-copy view are routing logic, not on-hardware-verified collectives (same document, lines 67-75).
+
+## Reference Documentation
+
+- [ACLNN operator codegen design](aclnn-codegen.md): category-driven code generation for native kernels
+- [Ascend NPU integration plan](npu-plan.md): operator coverage strategy and acceptance criteria
+- [External libtorch_npu analysis](external-libtorch-npu.md): why `torch_npu` cannot act as a boxing fallback
+- [Compatibility matrix](../../reference/compatibility.md): platform status and capability claims
+- [Testing guide](../../reference/testing.md): running and interpreting test suites
+- [Configuration reference](../../reference/configuration.md): runtime environment variables and backend configs

--- a/docs/vendors/ascend/installation.md
+++ b/docs/vendors/ascend/installation.md
@@ -202,5 +202,5 @@ Distributed collectives route through FlagCX (recommended) or an HCCL fallback. 
 - [Ascend NPU integration plan](npu-plan.md): operator coverage strategy and acceptance criteria
 - [External libtorch_npu analysis](external-libtorch-npu.md): why `torch_npu` cannot act as a boxing fallback
 - [Compatibility matrix](../../reference/compatibility.md): platform status and capability claims
-- [Testing guide](../../reference/testing.md): running and interpreting test suites
-- [Configuration reference](../../reference/configuration.md): runtime environment variables and backend configs
+- [Testing guide](../../development/testing.md): running and interpreting test suites
+- [Environment variables](../../reference/environment-variables.md): runtime environment variables and backend configs

--- a/docs/vendors/bpu/installation.md
+++ b/docs/vendors/bpu/installation.md
@@ -1,0 +1,110 @@
+# BPU (D-Robotics RDK) Installation
+
+The BPU platform provides **runtime acceleration only** — native device memory and streams, graph-level compilation through `torch.compile`, and a separate prebuilt-HBM LLM runtime. Eager operators execute on the CPU via fallback.
+
+## Supported Target
+
+- **Hardware:** D-Robotics RDK board with Horizon BPU (nash-p, nash-e, or nash-m)
+- **PyTorch:** `torch==2.10.0+cpu` (aarch64 cp314 wheel)
+- **Python:** 3.14 aarch64
+- **Runtime:** `libhbucp.so` and `libbpu.so` at `/usr/hobot/lib` (shipped in board image)
+
+The torch version pin is enforced: checked-in ATen bindings target the 2.10 series (`torch>=2.10,<2.11`), and a newer torch fails at build time with signature mismatches.
+
+## Installation
+
+Install the upstream CPU torch wheel, then build torch_fl with the BPU accelerator:
+
+```bash
+pip install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
+ACCELERATOR=bpu pip install --no-build-isolation -e .
+```
+
+No SDK root configuration is needed — the runtime ships at standard system paths.
+
+## Execution Modes
+
+The BPU backend provides three distinct execution paths:
+
+1. **Eager CPU fallback:** Individual operators on flagos tensors execute on the CPU. No per-operator BPU kernels exist because the BPU executes whole compiled graphs, not single ops.
+
+2. **Graph acceleration via `torch.compile`:** Traced graphs compile to `.hbm` artifacts through hbdk4 and execute on the BPU. Quantization (int8 Q/DQ insertion) is applied by default to move convolution and pooling work onto the device.
+
+   ```python
+   import torch, torch_fl
+   
+   model = MyNet().eval()
+   compiled = torch.compile(model, backend="bpu")
+   out = compiled(torch.randn(1, 3, 224, 224))
+   ```
+
+3. **Prebuilt-HBM LLM runtime:** `torch_fl.accelerator.bpu.infer` drives vendor-supplied `.hbm` artifacts with device-resident buffers and a sliding-window KV cache, bypassing `torch.compile` entirely.
+
+## Compiler Setup (Optional)
+
+Graph compilation requires hbdk4, which ships x86_64-only wheels. On-board compilation runs under box64 emulation:
+
+```bash
+scripts/setup_bpu_hbdk4.sh --wheels /path/to/oe/wheels
+export FLAGOS_BPU_X86_PYTHON=~/hbdk4-x86/python/bin/python3.11
+export FLAGOS_BPU_X86_EMULATOR=~/hbdk4-x86/bin/box64
+```
+
+The wheels are in the D-Robotics OE package (`oe-package-*.tgz` on `ftp://oeftp@sdk.d-robotics.cc/`). The script needs `hbdk4_compiler-*cp311*` and `hbdk4_march-*`.
+
+**Without a reachable hbdk4**, the backend logs a warning and executes every partition on the CPU — the install remains usable, just without BPU acceleration.
+
+Verify compiler availability:
+
+```bash
+python -c "from torch_fl.accelerator.bpu.compiler import find_hbdk; print(find_hbdk())"
+# -> x86-emul (if box64 setup succeeded)
+# -> cli (if native x86 python with hbdk4 is on PATH)
+# -> unavailable (hbdk4 not found; graphs will run on CPU)
+```
+
+## Verification
+
+Basic import and device runtime:
+
+```python
+import torch, torch_fl
+
+# Device runtime is present
+assert torch.utils.backend_registration.is_registered_backend("flagos")
+print(torch.cuda.device_count())  # 1 if BPU runtime is available
+
+# Create a flagos tensor and verify it runs (on CPU, eagerly)
+x = torch.randn(3, 3, device="flagos")
+y = x + x
+print(y.device)  # flagos:0
+```
+
+Focused unit tests covering device memory, streams, the `cuda` alias, weight freezing, partitioning, Q/DQ insertion, and the KV cache layout:
+
+```bash
+pytest tests/unit/bpu/ -v
+```
+
+Graph compilation (requires hbdk4 setup):
+
+```bash
+python benchmarks/bpu_resnet18_bench.py  # first run compiles (~25 min), then cached
+```
+
+## Further Documentation
+
+**For architecture details, partitioning strategy, quantization, calibration, zero-copy paths, fixed-shape constraints, benchmark results, and LLM runtime internals**, see [integration.md](integration.md).
+
+That document covers:
+- Why there are no per-op kernels
+- The full compile pipeline (Dynamo → AOTAutograd → ONNX → hbdk4)
+- Why quantization is a precondition rather than an optimization
+- On-board compilation with box64 (why source-built box64 is required, the `libhbtl.so` preload, numba/torch stubs)
+- Calibration for better int8 accuracy
+- Runtime notes (host-mapped device memory, synchronous execution, the cached-block leak at exit, FX/Dynamo identity fixes for the `cuda` alias)
+- Measured performance against D-Robotics' own artifacts
+- Stock transformers under `torch.compile` (correct but not yet fast; coverage capped by symbolic shapes)
+- Known limitations (single device, int8 only, synchronous, prebuilt LLM path separate from torch.compile)
+
+Environment variables, cache layout, and the sliding-window KV cache geometry are all documented there.

--- a/docs/vendors/cuda/installation.md
+++ b/docs/vendors/cuda/installation.md
@@ -1,0 +1,213 @@
+# NVIDIA CUDA Installation Guide
+
+## Overview
+
+The CUDA backend reuses PyTorch's optimized CUDA kernels through compatibility-key boxing, eliminating the need for hand-written kernels. This route installs CPU-only PyTorch via pip and bundles a version-matched external `libtorch_cuda.so` that provides the full CUDA operator set. An optional FlagGems compiler path routes eligible operations to Triton kernels at runtime.
+
+**Status:** Stable. CI validates vendor-backend and FlagGems operator suites, factory ops, profiler parity, and Qwen3-0.6B inference/training on 8-GPU A100 runners.
+
+## Prerequisites
+
+- NVIDIA GPU with compute capability 7.0 or later (tested on RTX 2080 Ti, A100)
+- NVIDIA driver 470.0 or later (tested with 550.163.01)
+- CUDA 12.x toolkit (headers and `nvcc` required for build; runtime dependencies are bundled)
+- Python 3.8 or later
+- PyTorch 2.10.0 (CPU wheel; installed automatically from the build script)
+- `cmake >= 3.18`, `ninja`, `patchelf` (for build)
+
+## Installation
+
+### From Source (Standard Build)
+
+Clone the repository and build with the CUDA accelerator:
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git
+cd PyTorch-Plugin-FL
+
+# Install CPU PyTorch (if not already present)
+pip install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
+
+# Build torch_fl with CUDA boxing kernels and bundled CUDA assets
+ACCELERATOR=cuda \
+  CUDA_KERNEL=1 \
+  pip install --no-build-isolation -vvv -e .
+```
+
+This build:
+- Generates CUDA boxing kernels from PyTorch's ATen schema (`csrc/aten/generated/cuda_kernels.cc`)
+- Bundles `libtorch_cuda.so` and related CUDA dispatcher libraries into `torch_fl/lib/`
+- Compiles FlagGems Python-dispatch integration by default (runtime opt-in)
+- Pins matching `nvidia-*-cu12` runtime dependencies for the bundled CUDA assets
+
+### With FlagGems C++ Dispatch (Optional)
+
+To enable the C++ fast path for FlagGems Triton kernels:
+
+```bash
+ACCELERATOR=cuda \
+  CUDA_KERNEL=1 \
+  FLAGGEMS_KERNEL=1 \
+  FLAGGEMS_DIR=<path-to-FlagGems>/lib/cmake/FlagGems \
+  pip install --no-build-isolation -vvv -e .
+```
+
+`FLAGGEMS_DIR` must point to the FlagGems CMake config directory containing `FlagGemsConfig.cmake` and `liboperators.so`. See [FlagGems integration](../flaggems/) for build details.
+
+### Environment Variables
+
+The following environment variables control runtime behavior:
+
+- `FLAGOS_USE_FLAGGEMS=1`: Route eligible operations to FlagGems Triton kernels (default: CUDA boxing path)
+- `FLAGOS_USE_FLAGGEMS_CPP=1`: Prefer C++ dispatch over Python dispatch when both are available
+- `CUDA_VISIBLE_DEVICES`: Control which GPUs are visible to the process
+
+## Verification
+
+### Basic Device Check
+
+```bash
+python -c "
+import torch_fl
+import torch
+
+print(f'PyTorch version: {torch.__version__}')
+print(f'flagos devices: {torch.flagos.device_count()}')
+print(f'flagos available: {torch.flagos.is_available()}')
+
+# Basic computation
+x = torch.randn(4, 4, device='flagos:0')
+y = (x @ x).sum()
+print(f'Sample result: {y.cpu().item():.4f}')
+"
+```
+
+Expected output shows `flagos devices: N` (where N matches your GPU count) and a floating-point result.
+
+### Operator Validation
+
+Run the main operator test suite against the CUDA boxing backend:
+
+```bash
+pytest tests/integration/ops/ \
+  -m "main_ops and not flaggems_python and not flaggems_cpp" \
+  -v --tb=short
+```
+
+### FlagGems Validation (if enabled)
+
+Test the FlagGems runtime path:
+
+```bash
+FLAGOS_USE_FLAGGEMS=1 \
+  pytest tests/integration/ops/ \
+  -m "flaggems and main_ops" \
+  -v --tb=short
+```
+
+First run is slow — Triton compiles and autotunes every kernel. Subsequent runs reuse the cache.
+
+### Factory Operations
+
+Verify factory operations respect device placement:
+
+```bash
+pytest tests/integration/test_factory_ops.py -v --tb=short
+```
+
+### Distributed (Multi-GPU)
+
+Verify collective communication and DDP gradient sync:
+
+```bash
+# Requires 2+ GPUs and FlagCX installed (optional; falls back to NCCL)
+python tests/manual/test_flagos_dist_live.py --world-size 2
+```
+
+See [Distributed (FlagCX)](../../architecture/distributed-flagcx.md) for FlagCX installation and heterogeneous communication.
+
+### Profiler
+
+Verify profiler parity with torch.cuda:
+
+```bash
+pytest tests/integration/test_profiler_parity.py -v -m main_ops --tb=short
+```
+
+See [Profiler Architecture](../../architecture/profiler.md) for details on CUPTI integration and device event emission.
+
+### Model Inference and Training
+
+Run Qwen3-0.6B inference and training (requires model weights):
+
+```bash
+# Inference
+pytest tests/integration/test_qwen3_infer.py \
+  --model <model-path> -v --tb=short
+
+# Training
+pytest tests/integration/test_qwen3_train.py \
+  --model <model-path> -v --tb=short
+```
+
+### torch.compile (Experimental)
+
+The CUDA backend registers flagos as a first-class inductor GPU device. Basic verification:
+
+```bash
+python -c "
+import torch
+import torch_fl
+
+@torch.compile
+def f(x):
+    return torch.nn.functional.gelu(x) + x
+
+x = torch.randn(256, 256, device='flagos:0')
+y = f(x)
+print(f'Compiled result shape: {y.shape}')
+"
+```
+
+See [torch.compile Integration](../../architecture/torch-compile-integration.md) for implementation details. This path is not exercised in CI.
+
+## Troubleshooting
+
+### Import Error: `Cannot initialize CUDA without ATen_cuda library`
+
+**Cause:** `libtorch_cuda.so` was not preloaded before `import torch`, so PyTorch's CUDAHooks cached the stub implementation.
+
+**Fix:** Ensure `import torch_fl` occurs before any torch import in your script. The torch_fl import hook preloads the bundled CUDA assets.
+
+### Runtime Error: `CUDA error: invalid device ordinal`
+
+**Cause:** `device="flagos:N"` index exceeds available GPU count, or `CUDA_VISIBLE_DEVICES` restricts visibility.
+
+**Fix:** Check `torch.flagos.device_count()` and ensure the device index is in range.
+
+### Symbol Version Mismatch
+
+**Cause:** PyTorch CPU wheel version does not match the bundled `libtorch_cuda.so` version.
+
+**Fix:** The build script pins torch 2.10.0+cpu and bundles matching CUDA assets. If you manually installed a different torch version, rebuild torch_fl or reinstall `torch==2.10.0+cpu`.
+
+### FlagGems Import Error
+
+**Cause:** `flag_gems` package not installed, or `FLAGGEMS_DIR` pointed to an incompatible build.
+
+**Fix:** Install FlagGems from PyPI (`pip install flag_gems`) or build from source matching your CUDA version. See [FlagGems Integration](../flaggems/).
+
+### nvidia-smi Shows GPUs, but `torch.flagos.device_count()` Returns 0
+
+**Cause:** CUDA runtime initialization failed, often due to driver/runtime version skew.
+
+**Fix:** Check `nvidia-smi` output for driver version and ensure CUDA runtime dependencies match. Reinstall `nvidia-*-cu12` packages if needed.
+
+## Further Reading
+
+- [External libtorch_cuda.so: Measured Validation](external-libtorch-cuda.md) — Deep dive into the CPU torch + external CUDA dispatcher architecture
+- [torch.compile Integration](../../architecture/torch-compile-integration.md) — Inductor GPU device registration and compilation workflow
+- [Distributed (FlagCX)](../../architecture/distributed-flagcx.md) — Multi-GPU collectives, DDP, and heterogeneous communication
+- [Profiler Architecture](../../architecture/profiler.md) — CUPTI integration and device event emission
+- [Environment Variables](../../reference/environment-variables.md) — Complete runtime configuration reference
+- [Testing Guide](../../development/testing.md) — Running the full test suite and CI-equivalent validation

--- a/docs/vendors/dcu/installation.md
+++ b/docs/vendors/dcu/installation.md
@@ -1,0 +1,220 @@
+# Hygon DCU Installation Guide
+
+## Overview
+
+Hygon DCU (DTK) reuses the **CUDA boxing route** with a dedicated `ACCELERATOR=dcu` branch. Two properties of the vendor stack enable this:
+
+- The DCU `torch` wheel is a **hipified** build: it registers HIP kernels under the `CUDA` dispatch key and its tensors report `DeviceType::CUDA` (`torch.version.cuda is None`, `torch.version.hip == '6.3.x'`). Generated PrivateUse1 → CUDA boxing kernels dispatch into `libtorch_hip.so` unchanged.
+- DTK ships a **CUDA compatibility toolkit** at `$DTK_ROOT/cuda/cuda-*` whose `libcudart.so.12` is a thin shim over `libgalaxyhip.so` — the same runtime `libtorch_hip.so` uses. Runtime sources compile as-is with plain host `g++`; no `nvcc`, no `hipcc`, no hipify pass.
+
+The build is **pure boxing**: `CUDA_KERNEL`, `FLAGGEMS_KERNEL`, and `FLAGGEMS_PYTHON` are all forced off by default (DTK ships its own Triton, so the NVIDIA-targeted PyPI `triton` wheel is the wrong artifact).
+
+**Status:** Beta. CI validates vendor-backend and FlagGems-runtime operator suites, general tests, and profiler parity on DCU runners. Inference and training smoke tests are deferred pending model mount and card-count confirmation.
+
+## Prerequisites
+
+- Hygon DCU hardware with driver installed
+- DTK (Hygon Deep Learning Toolkit) installed at `/opt/dtk` (or `$DTK_ROOT`/`$ROCM_PATH`)
+- DTK torch wheel (hipified, registers kernels under CUDA dispatch key)
+- Python 3.8 or later matching the DTK torch build
+- `cmake >= 3.18`, `ninja`, `patchelf`
+
+## Installation
+
+### From Source
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git
+cd PyTorch-Plugin-FL
+
+# Source DTK environment (exports ROCM_PATH and other variables)
+source /opt/dtk/env.sh
+
+# Build with ACCELERATOR=dcu (pure boxing, no FlagGems by default)
+ACCELERATOR=dcu pip install --no-build-isolation -vvv -e .
+```
+
+`DTK_ROOT` resolves from `DTK_ROOT` → `ROCM_PATH` → `/opt/dtk`. Pass it explicitly if DTK lives elsewhere.
+
+### Build Notes
+
+- **`ACCELERATOR=dcu` forces boxing mode:** `CUDA_KERNEL=OFF`, `FLAGGEMS_KERNEL=OFF`, `FLAGGEMS_PYTHON=OFF` in `setup.py`. The generated PrivateUse1 → CUDA boxing kernels (`csrc/aten/generated/cuda_kernels.cc`) are the only kernel set compiled.
+- **No `nvcc` or `hipcc` needed:** CUDA runtime sources compile with plain `g++` using DTK's CUDA compatibility toolkit headers.
+- **MIOpen CMake config fix:** DTK's exported MIOpen config bakes in `/usr/lib/x86_64-linux-gnu/librt.so`, which no longer exists on glibc ≥ 2.34 (librt was folded into libc). The `ACCELERATOR=dcu` branch rewrites that dangling path to `-lrt`.
+
+## Verification
+
+### Basic Device Check
+
+```bash
+python -c "
+import torch, torch_fl
+
+print(f'PyTorch version: {torch.__version__}')
+print(f'torch.version.hip: {torch.version.hip}')
+print(f'flagos devices: {torch.flagos.device_count()}')
+
+# Basic computation
+x = torch.randn(512, 512, device='flagos')
+result = torch.mm(x, x)
+print(f'mm output shape: {result.shape}')
+print(f'mm matches .cuda(): {torch.allclose(result.cpu(), torch.mm(x.cpu().cuda(), x.cpu().cuda()).cpu())}')
+"
+```
+
+Expected output shows `torch.version.hip: 6.3.x`, `flagos devices: N`, and `mm matches .cuda(): True`.
+
+### Operator Tests (Vendor Backend)
+
+Run the main operator suite against the DCU boxing backend:
+
+```bash
+pytest tests/unit tests/integration/test_allocator.py \
+  tests/integration/test_factory_ops.py -q
+
+pytest tests/integration/ops/ \
+  -m "main_ops and not flaggems and not flaggems_python" \
+  -v --tb=short
+```
+
+### Profiler Parity
+
+Verify profiler parity with torch.cuda:
+
+```bash
+pytest tests/integration/test_profiler_parity.py \
+  -v -m main_ops --tb=short
+```
+
+See [Profiler Architecture](../../architecture/profiler.md) for details on device event emission for DCU.
+
+## Enabling FlagGems on DCU
+
+DTK ships its own Triton (the `hcu` backend) and a FlagGems build whose `hygon` vendor declares `device_name="cuda"`, which is exactly what the boxing route expects. Both live in the DTK system interpreter, so point your environment at them rather than installing PyPI wheels:
+
+### Step 1: Expose DTK's Triton and FlagGems
+
+```bash
+pip install pyyaml sqlalchemy  # flag_gems imports these
+
+mkdir -p <gems-path> && cd <gems-path>
+ln -s /usr/local/lib/python3.10/dist-packages/triton .
+ln -s /usr/local/lib/python3.10/dist-packages/flag_gems .
+```
+
+Adjust the Python path (`python3.10`) to match your DTK system interpreter.
+
+### Step 2: Build with FlagGems Python Dispatch
+
+```bash
+source /opt/dtk/env.sh
+
+ACCELERATOR=dcu \
+  FLAGGEMS_PYTHON=1 \
+  pip install --no-build-isolation -e .
+```
+
+### Step 3: Runtime Configuration
+
+```bash
+export PYTHONPATH=<gems-path>
+export TRITON_BACKENDS_IN_TREE=1  # DTK install has no dist-info;
+                                  # entry-point backend discovery finds nothing
+export FLAGOS_USE_FLAGGEMS=1
+```
+
+`GEMS_VENDOR=hygon` is set automatically on a DCU build, so you no longer need to export it manually. This matters beyond FlagGems: `GEMS_VENDOR` also selects the comm profile (see `torch_fl/comm/process_group.py`), and DCU is a CUDA-ABI vendor whose `ProcessGroupNCCL` is RCCL underneath.
+
+A DCU build records `ACCELERATOR=dcu` in `torch_fl/_build_config.py`, so `FLAGOS_USE_FLAGGEMS=1` alone selects `backends_dcu_flaggems.conf` — no need to re-export `ACCELERATOR` at runtime.
+
+### FlagGems Configuration
+
+`backends_dcu_flaggems.conf` is `backends_flaggems.conf` with ops `hcu` Triton cannot compile or run routed back to the cuda boxing kernel:
+
+- `silu_backward`: `tl.math.div_rn` has no `create_precise_divf` lowering
+- `slice_backward`: output is correct standalone, but feeding that grad to MIOpen's `convolution_backward` triggers a hardware VMFault
+
+Override per-op routing with `FLAGOS_OP_<name>=flagos_python|cuda`.
+
+### FlagGems Verification
+
+```bash
+export PYTHONPATH=<gems-path>
+export TRITON_BACKENDS_IN_TREE=1
+export FLAGOS_USE_FLAGGEMS=1
+
+pytest tests/integration/ops/ \
+  -m "flaggems and main_ops" \
+  -v --tb=short
+```
+
+No marker deselection needed — the FlagGems path is now enabled.
+
+## Multi-Card on DCU
+
+Multi-card works with FlagGems enabled, over FlagCX or the RCCL fallback. The automatic `GEMS_VENDOR=hygon` routes `ProcessGroupFlagOS` to the CUDA-ABI profile (zero-copy `_flagos_to_cuda_view` + `ProcessGroupNCCL`, which on DTK is RCCL: `dist.is_nccl_available() == True` and `torch.cuda.nccl.version()` reports `(2, 22, 3)`).
+
+```bash
+export HSA_FORCE_FINE_GRAIN_PCIE=1  # RCCL warns when unset; affects
+                                    # multi-card throughput and stability
+
+# Collectives + DDP (FlagGems can be on or off)
+python tests/manual/test_flagos_dist_live.py --world-size 2
+```
+
+**Prerequisite:** Factory ops honoring their `device` index is required. Every rank>0 worker builds tensors via a factory, and an output allocated on device 0 while the Triton kernel launches on device N is a cross-device write that faults the GPU. See `tests/integration/test_factory_device_index.py`.
+
+## Implementation Notes
+
+### Memory Pool
+
+flagos tensors and boxed kernels' outputs share one pool. `dcu_memory.h` delegates caching to torch's own allocator through the device-generic registry (`c10::getDeviceAllocator(kCUDA)`) rather than the `c10::cuda::` namespace — the DCU wheel exports `c10::hip::HIPCachingAllocator` and has zero `c10::cuda` symbols, and `cuda_runtime.h` cannot share a translation unit with `hip/hip_runtime.h`. So `memory_allocated()` / `memory_reserved()` / `empty_cache()` report and act on real usage.
+
+### `.cuda()` Autograd and torch_fl Cannot Share a Process
+
+PyTorch's `register_privateuse1_backend` makes `at::getAccelerator()` return `PrivateUse1`, so the autograd engine finds no stream metadata for a pure-CUDA graph and asserts in `engine.cpp`. This is upstream PrivateUse1 behavior, identical on CUDA/MetaX/Ascend — flagos-device autograd is unaffected. Take `.cuda()` baselines in a separate process.
+
+## Troubleshooting
+
+### Import Error: `cannot open shared object file: libhydmi.so`
+
+**Cause:** Hygon DMI device management library not found; `hyhal` driver stack not on `LD_LIBRARY_PATH`.
+
+**Fix:** Ensure `/usr/local/hyhal/lib` (or `/opt/hyhal/lib` if symlinked) is on `LD_LIBRARY_PATH`. CI setup prepends it after probing the host driver mount.
+
+### Build Error: `MIOpen: librt.so not found`
+
+**Cause:** DTK's MIOpen CMake config references the no-longer-present `/usr/lib/x86_64-linux-gnu/librt.so`.
+
+**Fix:** This is automatically rewritten by the `ACCELERATOR=dcu` branch in `CMakeLists.txt`. If you see this error, verify `ACCELERATOR=dcu` is set and you are using the latest repository code.
+
+### Triton: `No backend registered for 'hcu'`
+
+**Cause:** `TRITON_BACKENDS_IN_TREE=1` not set, so entry-point discovery finds nothing.
+
+**Fix:** Export `TRITON_BACKENDS_IN_TREE=1` and ensure `PYTHONPATH` includes the directory with symlinked `triton` and `flag_gems`.
+
+### FlagGems: `silu_backward` or `slice_backward` crashes
+
+**Cause:** `hcu` Triton backend limitation or MIOpen interaction bug.
+
+**Expected behavior.** `backends_dcu_flaggems.conf` already routes these ops to the cuda boxing kernel. If you see crashes, verify `FLAGOS_USE_FLAGGEMS=1` is set and the config is being selected.
+
+### Multi-card: GPU VMFault or device-side hang
+
+**Cause:** `HSA_FORCE_FINE_GRAIN_PCIE=1` not set, or factory ops not respecting device index.
+
+**Fix:** Export `HSA_FORCE_FINE_GRAIN_PCIE=1` before running multi-card tests. Verify `tests/integration/test_factory_device_index.py` passes.
+
+### `torch.flagos.device_count()` Returns 0
+
+**Cause:** DCU driver not loaded, or `/dev/kfd` and `/dev/dri` device nodes not accessible.
+
+**Fix:** Check vendor-provided driver diagnostics. If running in a container, ensure `--privileged` or device passthrough is configured.
+
+## Further Reading
+
+- [Environment Variables](../../reference/environment-variables.md) — Complete runtime configuration reference
+- [Profiler Architecture](../../architecture/profiler.md) — Device event emission for DCU
+- [Distributed (FlagCX)](../../architecture/distributed-flagcx.md) — Multi-GPU collectives and RCCL fallback
+- [Testing Guide](../../development/testing.md) — Running local validation equivalent to CI

--- a/docs/vendors/gcu/installation.md
+++ b/docs/vendors/gcu/installation.md
@@ -141,4 +141,4 @@ All compute ops will fall back to CPU. This mode is useful for testing the runti
 
 - [Codegen source](../../../scripts/codegen_gcu.py): category-driven kernel generation for `topsaten`
 - [Compatibility matrix](../../reference/compatibility.md): platform status and limitations
-- [Configuration reference](../../reference/configuration.md): runtime environment variables and backend selection
+- [Environment variables](../../reference/environment-variables.md): runtime environment variables and backend selection

--- a/docs/vendors/gcu/installation.md
+++ b/docs/vendors/gcu/installation.md
@@ -1,0 +1,144 @@
+# Enflame GCU Installation Guide
+
+Enflame GCU uses native operator kernels calling `libtopsaten.so`, not CUDA boxing. The TopsRider stack has no CUDA runtime, and the vendor `torch-gcu` wheel claims `PrivateUse1` for itself, so it cannot coexist with `torch_fl`.
+
+## Prerequisites
+
+- **CPU PyTorch 2.10.x**: `torch==2.10.0` from the upstream CPU index
+- **TopsRider SDK**: GCU toolkit with `topsrt` runtime and `topsaten` operator library
+- **Python**: 3.8 or later
+- **Operating System**: Linux
+
+The TopsRider SDK provides:
+- `libtopsrt.so`: device/memory/stream runtime layer
+- `libtopsaten.so`: ATen-style operator library with single-call execution (no workspace/executor phase like ACLNN)
+
+## Installation
+
+### 1. Install CPU PyTorch
+
+```bash
+pip install torch==2.10.0 --index-url https://download.pytorch.org/whl/cpu
+```
+
+### 2. Build and install torch_fl
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git
+cd PyTorch-Plugin-FL
+
+ACCELERATOR=gcu pip install --no-build-isolation -v -e .
+```
+
+Build flags:
+- `ACCELERATOR=gcu`: selects the GCU build path and enables `GCU_KERNEL=ON`
+- `GCU_KERNEL=ON`: compiles generated `topsaten` operator kernels (automatic when `ACCELERATOR=gcu`)
+- `CUDA_KERNEL=OFF`: automatically disabled (no CUDA runtime exists on GCU)
+- `FLAGGEMS_PYTHON=OFF`: automatically disabled (GCU uses its own backend config routing)
+- `--no-build-isolation`: ensures the build uses your installed CPU torch
+
+The build runs `scripts/codegen_gcu.py` to generate kernels. Each op is validated against the demangled `topsaten::topsatenXxx` symbols actually present in `libtopsaten.so`; ops missing from the SDK are skipped with a warning.
+
+### Codegen validation
+
+The generator matches derived `topsaten<Name>` symbols (e.g., `topsatenAdd`, `topsatenSqrt`) against the installed SDK via:
+
+```bash
+nm -DC /path/to/libtopsaten.so | grep 'topsaten::topsaten'
+```
+
+Only ops with verified symbols are generated. Coverage extends as the SDK expands.
+
+## Verification
+
+### Import and device availability
+
+```python
+import torch_fl
+import torch
+
+print(f"flagos available: {torch_fl.flagos.is_available()}")
+print(f"flagos devices: {torch_fl.flagos.device_count()}")
+
+x = torch.randn(64, 64, device="flagos:0")
+y = torch.abs(x)
+print(f"abs matches CPU: {torch.allclose(y.cpu(), x.cpu().abs())}")
+```
+
+### Runtime backend selection
+
+`torch_fl` installs a `lib/flagos_platform` marker so the runtime picks `backends_gcu.conf` automatically. No `FLAGOS_BACKEND_CONFIG` override is needed.
+
+## Testing
+
+Run smoke tests over generated operators and factory functions:
+
+```bash
+# General factory operator tests
+pytest tests/integration/test_factory_ops.py -v -s --tb=short
+
+# Common operator smoke tests (elementwise, reductions, matmul)
+pytest tests/integration/ops/test_common_ops.py -v -s --tb=short
+```
+
+**Note**: GCU has no CI configuration file (`.github/configs/gcu.yml` does not exist), so these tests must be run manually on GCU hardware.
+
+## Platform-specific Behavior
+
+### CPU fallback for missing kernels
+
+Ops without a `topsaten` kernel are **not registered** on `PrivateUse1` at all, so they reach the `cpu_fallback` dispatcher hook instead of raising an error. This keeps models working even when coverage is incomplete. Adding an op is a matter of extending the `OPS` table in `scripts/codegen_gcu.py`.
+
+### int64 limitations
+
+`topsaten` has no int64 kernels: every op returns `NOT_SUPPORT` for an `I64` operand. Each generated kernel guards on dtype and runs the op on CPU for int64 inputs. This keeps indices, masks, and counters working transparently.
+
+### Rank-0 tensor workaround
+
+`topsaten` rejects rank-0 shapes, so 0-dim tensors are described as 1-element vectors to the library.
+
+### Device-scoped pointers
+
+GCU device pointers are device-scoped (no unified addressing): a pointer only resolves against the **current** device. The allocator and every kernel select the device first, and the default stream is per-device.
+
+### Contiguous input requirement
+
+Unlike `mudnn` (MUSA), `topsaten` does not honor strides on non-contiguous inputs. Generated kernels call `.contiguous()` where necessary to materialize a contiguous copy before passing to `topsaten`.
+
+## Optional: FlagGems via Triton-GCU
+
+FlagGems can provide Triton-compiled kernels as an experimental alternative path if the Enflame `triton_gcu` plugin and `/opt/triton_gcu` toolchain are installed. This path is **not built by default** and is **experimental**.
+
+When both the plugin and toolchain are present, `torch_fl/accelerator/gcu/_gcu_compat.py` registers FlagGems operators directly onto `PrivateUse1` via `flag_gems.enable()`. When either is missing, registration is skipped and all ops stay on `topsaten`.
+
+**Note**: Unlike Ascend, FlagGems on GCU does not require a fork or special build flags. The standard FlagGems package can be used if the Triton-GCU toolchain is available. However, this path is not exercised in testing and should be considered experimental.
+
+## Limitations
+
+### No continuous validation
+
+GCU has no CI runner (no `.github/configs/gcu.yml` config exists), so all tests are manual. The platform status is **Experimental** (see [`docs/reference/compatibility.md`](../../reference/compatibility.md) line 30).
+
+### Distributed support not validated
+
+Distributed collectives are not validated on GCU hardware. The `_VENDOR_PROFILES` routing table in `torch_fl/comm/process_group.py` lists GCU as FlagCX-only unless live evidence proves otherwise.
+
+### Profiler and torch.compile not validated
+
+Neither `torch.compile` nor profiler-tracer parity has been validated on GCU.
+
+## Build without native kernels
+
+To build the runtime layer only (device/memory/stream support) with no native operator kernels:
+
+```bash
+ACCELERATOR=gcu GCU_KERNEL=OFF pip install --no-build-isolation -v -e .
+```
+
+All compute ops will fall back to CPU. This mode is useful for testing the runtime layer in isolation.
+
+## Reference Documentation
+
+- [Codegen source](../../../scripts/codegen_gcu.py): category-driven kernel generation for `topsaten`
+- [Compatibility matrix](../../reference/compatibility.md): platform status and limitations
+- [Configuration reference](../../reference/configuration.md): runtime environment variables and backend selection

--- a/docs/vendors/metax/installation.md
+++ b/docs/vendors/metax/installation.md
@@ -1,0 +1,229 @@
+# MetaX Installation Guide
+
+## Overview
+
+MetaX ships a **self-contained boxing wheel**: it reuses PyTorch's CUDA boxing kernels (compiled with host `g++`, no `mxcc`) and bundles the MetaX-forked libtorch C++ runtime inside the wheel. The target machine needs only the stock `torch==2.10.0+cpu` wheel, this `torch_fl` wheel, and the `/opt/maca` driver runtime.
+
+**Status:** Stable. CI validates representative operator dispatch and factory/autograd tests on 8-GPU MetaX runners. FlagGems and model-level validation are not covered in CI.
+
+## Prerequisites
+
+### Build Host (Wheel Builder)
+
+Requires the full MetaX SDK and a `torch+metax` wheel to extract the forked libtorch:
+
+- MetaX MACA SDK (driver + cu-bridge), installed to `/opt/maca` or `$METAX_PATH`
+- `torch+metax` wheel (`maca-pytorch`) from the MetaX developer portal (SoftNova)
+- Python 3.8 or later matching the target deployment environment
+- `patchelf` (`pip install patchelf`)
+
+**Getting the MetaX SDK and torch+metax wheel:**  
+Both are distributed through the MetaX developer portal: <https://developer.metax-tech.com/softnova>. Registration and login are required. Download the MACA SDK matching your card and driver version, and the `torch+metax` wheel built for the same MACA version and your Python version. Install the SDK to `/opt/maca` (or export `METAX_PATH` to the install location).
+
+### Target Host (Deployment)
+
+Requires only:
+
+- Official `torch==2.10.0+cpu` from PyPI (no CUDA)
+- The `torch_fl` wheel built below
+- `/opt/maca` driver runtime (present on any machine with a MetaX card)
+
+No separate `torch+metax` wheel, no manual `LD_LIBRARY_PATH` configuration.
+
+## Installation
+
+### Building the Wheel
+
+#### Step 1: Build the Boxing Artifacts
+
+On a machine with the MetaX SDK and `torch+metax` wheel available:
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git
+cd PyTorch-Plugin-FL
+
+# Build the boxing artifacts (METAX_KERNEL forced OFF in boxing mode)
+ACCELERATOR=metax \
+  FLAGOS_METAX_BOXING=1 \
+  FLAGOS_MACA_TORCH_LIB=<path-to-torch+metax>/torch/lib \
+  FLAGOS_WHEEL_LOCAL=metax3.8.1 \
+  python setup.py bdist_wheel
+```
+
+**Parameters:**
+- `FLAGOS_MACA_TORCH_LIB`: Path to the `torch+metax` wheel's `torch/lib` directory (source of forked libtorch)
+- `FLAGOS_WHEEL_LOCAL`: Local version tag (e.g., `metax3.8.1` → wheel version `0.1.0+metax3.8.1`), identifying the target MACA/driver version
+
+#### Step 2: Bundle the Forked Libtorch
+
+```bash
+FLAGOS_MACA_TORCH_LIB=<path-to-torch+metax>/torch/lib \
+  MACA_PATH=/opt/maca \
+  bash scripts/bundle_maca_libtorch.sh
+```
+
+This script:
+- Copies 8 forked libtorch `.so` files from `torch+metax/torch/lib` into `torch_fl/lib_maca/`
+- Rewrites RPATH with `patchelf` so libraries find each other via `$ORIGIN` and locate the MACA runtime at `/opt/maca/lib`
+
+#### Step 3: Repackage the Wheel
+
+```bash
+python setup.py build_py
+cp build/lib.*/torch_fl/_C.*.so build/lib.*/torch_fl/
+python setup.py bdist_wheel --skip-build --bdist-dir "$(mktemp -d)"
+```
+
+The result is `dist/torch_fl-0.1.0+metax3.8.1-cp312-cp312-linux_x86_64.whl` (~1.1 GB — it bundles the forked libtorch and exceeds PyPI's 100 MB limit; distribute via private index or direct transfer).
+
+### Installation on Target Host
+
+#### Install Dependencies
+
+```bash
+pip install torch==2.10.0+cpu --index-url https://download.pytorch.org/whl/cpu
+pip install torch_fl-0.1.0+metax3.8.1-cp312-cp312-linux_x86_64.whl
+```
+
+#### Runtime Configuration
+
+Set the boxing mode environment variable:
+
+```bash
+export FLAGOS_METAX_BOXING=1
+```
+
+**Import order:** On MetaX, you **must** import `torch_fl` before `import torch`:
+
+```python
+import torch_fl  # Must import first
+import torch
+```
+
+**Reason:** PyTorch's bundled CUDA 12.x runtime is ABI-incompatible with MetaX's cu-bridge (CUDA 11.6 compatibility layer). `torch_fl` preloads a shim library to provide the required symbol versions before torch initializes.
+
+## Verification
+
+### Basic Device Check
+
+```bash
+export FLAGOS_METAX_BOXING=1
+python -c "
+import torch_fl  # Import first
+import torch
+
+print(f'PyTorch version: {torch.__version__}')
+print(f'torch.cuda devices (MetaX): {torch.cuda.device_count()}')
+print(f'flagos devices: {torch.flagos.device_count()}')
+print(f'flagos available: {torch.flagos.is_available()}')
+
+# Basic computation
+x = torch.randn(4, 4, device='flagos:0')
+y = (x + x).sum()
+print(f'Sample result: {y.cpu().item():.4f}')
+"
+```
+
+Expected output shows `torch.cuda devices: N` and `flagos devices: N` (MetaX cards present as `torch.cuda` devices), and a floating-point result.
+
+### Operator Validation
+
+Run representative operator tests:
+
+```bash
+export FLAGOS_METAX_BOXING=1
+pytest \
+  tests/integration/ops/test_abs_dispatch.py \
+  tests/integration/ops/test_add_dispatch.py \
+  tests/integration/ops/test_bmm_dispatch.py \
+  tests/integration/ops/test_mm_dispatch.py \
+  tests/integration/ops/test_softmax_dispatch.py \
+  -m "not flaggems and not flaggems_python and not flaggems_cpp" \
+  -v --tb=short
+```
+
+### Factory and Autograd
+
+```bash
+export FLAGOS_METAX_BOXING=1
+pytest tests/integration/test_factory_ops.py -v --tb=short
+```
+
+## Optional: FlagGems on MetaX
+
+The MetaX boxing wheel compiles FlagGems Python-dispatch kernels by default, so FlagGems is a runtime switch. Enabling it requires two additional target-side dependencies:
+
+```bash
+# On the target MetaX machine, in addition to torch+cpu and torch_fl:
+pip install triton-metax flag_gems
+```
+
+`triton-metax` emits `mcfatbin` for MetaX GPUs; `flag_gems` provides the Triton kernel library.
+
+### Runtime Configuration
+
+```bash
+export FLAGOS_METAX_BOXING=1
+export FLAGOS_USE_FLAGGEMS=1  # Opt into FlagGems; unset = pure boxing
+```
+
+`import torch_fl` then auto-selects `backends_metax_flaggems.conf`, which routes most ops to FlagGems' Triton kernels and falls back to the CUDA boxing kernel for ops `triton-metax` cannot compile (`mm`/`bmm`/`mean.dim` — FlagGems uses a SPLIT_K kwarg or CUDA-context path `triton-metax` rejects).
+
+### FlagGems Verification
+
+```bash
+export FLAGOS_METAX_BOXING=1
+export FLAGOS_USE_FLAGGEMS=1
+python -c "
+import torch_fl, torch
+x = torch.randn(1024, device='flagos:0')
+result = torch.nn.functional.silu(x).sum()
+print(f'FlagGems SILU result: {result.cpu().item():.4f}')
+"
+```
+
+Without `triton-metax`/`flag_gems` installed, leave `FLAGOS_USE_FLAGGEMS` unset — the pure boxing path has no extra dependencies.
+
+## Distributed (Experimental)
+
+Multi-GPU distributed training routes through the NCCL-shaped `mccl` fallback. The routing exists architecturally (see `_VENDOR_PROFILES["metax"]` in `torch_fl/comm/process_group.py`), but collective-level validation is not covered in CI. Manual verification on MetaX hardware is required.
+
+## Model Inference and Training (Manual)
+
+MetaX carries FSDP2 and Qwen3 training parity work in repository history, but these tests are not part of the CI manifest. Model-level validation remains a manual exercise on MetaX hardware.
+
+## Troubleshooting
+
+### Import Error: `undefined symbol` from libtorch
+
+**Cause:** Import order violation — `import torch` occurred before `import torch_fl`, so the cudart shim was not loaded.
+
+**Fix:** Always `import torch_fl` first in your scripts.
+
+### Runtime Error: `device count mismatch`
+
+**Cause:** `torch.cuda.device_count()` and `torch.flagos.device_count()` differ, indicating the MACA runtime or driver is not correctly initialized.
+
+**Fix:** Verify `/opt/maca` is present and accessible. Check `LD_LIBRARY_PATH` does not override MACA runtime paths.
+
+### `FLAGOS_METAX_BOXING=1` not set
+
+**Symptom:** `import torch_fl` fails with configuration errors or missing libraries.
+
+**Fix:** Export `FLAGOS_METAX_BOXING=1` before running Python. This variable gates the MetaX-specific import-time setup.
+
+### Wheel Too Large for PyPI
+
+**Expected behavior.** The bundled forked libtorch causes the wheel to exceed PyPI's 100 MB limit (~1.1 GB). Distribute via a private package index or direct file transfer.
+
+### FlagGems: `triton-metax` not found
+
+**Cause:** `triton-metax` is not available on PyPI; it must come from a vendor-specific index.
+
+**Fix:** Obtain `triton-metax` from the MetaX developer portal or your vendor contact. If unavailable, disable FlagGems (unset `FLAGOS_USE_FLAGGEMS`) and use the pure boxing path.
+
+## Further Reading
+
+- [Environment Variables](../../reference/environment-variables.md) — Complete runtime configuration reference
+- [Testing Guide](../../development/testing.md) — Running local validation equivalent to CI
+- [Distributed (FlagCX)](../../architecture/distributed-flagcx.md) — Multi-GPU communication architecture (NCCL-shaped fallback for MetaX)

--- a/docs/vendors/musa/installation.md
+++ b/docs/vendors/musa/installation.md
@@ -191,4 +191,4 @@ All compute ops will fall back to CPU. This mode is useful for testing the runti
 
 - [Codegen source](../../../scripts/codegen_mudnn.py): category-driven kernel generation for `mudnn`
 - [Compatibility matrix](../../reference/compatibility.md): platform status and limitations
-- [Configuration reference](../../reference/configuration.md): runtime environment variables and backend selection
+- [Environment variables](../../reference/environment-variables.md): runtime environment variables and backend selection

--- a/docs/vendors/musa/installation.md
+++ b/docs/vendors/musa/installation.md
@@ -1,0 +1,194 @@
+# Moore Threads MUSA Installation Guide
+
+Moore Threads MUSA uses native operator kernels calling `libmudnn.so`, not CUDA boxing. The MUSA toolkit ships no CUDA runtime, and there is no vendor dispatch key to box into.
+
+## Prerequisites
+
+- **CPU PyTorch 2.10.x**: `torch==2.10.0` from the upstream CPU index
+- **MUSA toolkit**: Moore Threads SDK with `musart` runtime and `mudnn` operator library under `/usr/local/musa`
+- **Python**: 3.8 or later
+- **Operating System**: Linux
+
+The MUSA toolkit provides:
+- `musart`: runtime layer (device/memory/stream)
+- `mudnn` (`libmudnn.so`): operator library with category-driven API (Unary/Binary/Reduce/MatMul/Softmax/Convolution)
+
+`mudnn` links against `musart` only and pulls in **no torch symbols at all**, making this backend torch-version-agnostic (tested against both 2.9.1 and 2.10.0 from the same source tree, though only 2.10.0 is officially supported).
+
+## Installation
+
+### 1. Install CPU PyTorch
+
+```bash
+pip install torch==2.10.0 --index-url https://download.pytorch.org/whl/cpu
+```
+
+### 2. Build and install torch_fl
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git
+cd PyTorch-Plugin-FL
+
+ACCELERATOR=musa pip install --no-build-isolation -v -e .
+```
+
+Build flags:
+- `ACCELERATOR=musa`: selects the MUSA build path and enables `MUSA_KERNEL=ON`
+- `MUSA_KERNEL=ON`: compiles generated `mudnn` operator kernels (automatic when `ACCELERATOR=musa`)
+- `CUDA_KERNEL=OFF`: automatically disabled (the MUSA toolkit exports no CUDA symbols)
+- `FLAGGEMS_KERNEL=OFF`: automatically disabled
+- `--no-build-isolation`: **required** (without it, pip resolves its own torch into a build overlay, and the extension links against that instead of your installed torch, causing `import torch_fl` to fail with `undefined symbol: c10::ValueError`)
+
+The build runs `scripts/codegen_mudnn.py` to generate kernels. Coverage is **64 generated ops** plus 2 handwritten convolution kernels; everything outside that set reaches the `cpu_fallback`.
+
+### Why no-build-isolation is required
+
+Without `--no-build-isolation`, pip creates a temporary build environment and installs its own copy of torch there. The C++ extension then links against that temporary torch, not the one you installed. When you later `import torch_fl` in your actual environment, the torch C++ object layouts don't match, causing symbol resolution failures.
+
+This constraint is specific to MUSA because `mudnn` has no torch dependency at all. Earlier versions of this backend called `torch_musa`'s flat `at::musa::*` API from `libmusa_python.so`, which links against torch and embeds its C++ object layout—pinning the plugin to one exact torch build (`sizeof(c10::MessageLogger)` changed 408 → 400 between 2.9.1 and 2.10, corrupting the vendor `.so`'s stack). `mudnn` avoids that coupling entirely.
+
+## Verification
+
+### Import order with torch_musa
+
+If the `torch_musa` package is installed alongside `torch_fl` (not recommended, but possible), you must **import `torch_fl` before `torch`**, or export `TORCH_DEVICE_BACKEND_AUTOLOAD=0`:
+
+```bash
+export TORCH_DEVICE_BACKEND_AUTOLOAD=0
+```
+
+`torch_musa` registers a `torch.backends` entry point, so a bare `import torch` autoloads it and claims the `PrivateUse1` backend name first. `torch_fl` sets `TORCH_DEVICE_BACKEND_AUTOLOAD=0` internally when imported first, which covers the torch_fl-first order. The other order fails with an explicit message.
+
+**Recommendation**: do not install `torch_musa` when using `torch_fl`. Nothing from `torch_musa` is used.
+
+### Import and device availability
+
+```python
+import torch_fl  # Must come before torch if torch_musa is present
+import torch
+
+print(f"flagos available: {torch_fl.flagos.is_available()}")
+print(f"flagos devices: {torch_fl.flagos.device_count()}")
+
+x = torch.randn(64, 64, device="flagos:0")
+y = torch.abs(x)
+print(f"abs matches CPU: {torch.allclose(y.cpu(), x.cpu().abs())}")
+```
+
+### Runtime backend selection
+
+`torch_fl` installs a `lib/flagos_platform` marker so the runtime picks `backends_musa.conf` automatically. No environment variable override is needed.
+
+## Testing
+
+Run the MUSA dispatch suite:
+
+```bash
+pytest tests/integration/ops/test_musa_dispatch.py -v
+```
+
+This test file checks that ops route to the `musa` backend, exercises per-op environment overrides, and validates results against CPU references. It replaces the generic per-op tests in `tests/integration/ops/`, which assert `-> cuda` routing that MUSA builds cannot produce (no CUDA boxing kernels are compiled).
+
+Run common operator smoke tests:
+
+```bash
+pytest tests/integration/ops/test_common_ops.py -v -s --tb=short
+```
+
+**Note**: MUSA has no CI configuration file (`.github/configs/musa.yml` does not exist), so all validation is manual.
+
+## Operator Coverage
+
+### Generated operators (64 ops)
+
+Category-driven codegen via `scripts/codegen_mudnn.py` covers:
+
+- **Unary**: abs, sqrt, rsqrt, exp, log, log2, log10, log1p, sin, cos, acos, atan, tanh, sigmoid, silu, relu, gelu, erf, floor, ceil, sign
+- **Binary**: add, mul, sub, div, pow, eq, ne, lt, le, gt, ge, maximum, minimum, logical_and, logical_or, logical_xor
+- **Reductions**: sum, mean, max, min, argmax, argmin (with dim support)
+- **MatMul**: mm, addmm, bmm, baddbmm
+- **Softmax**: softmax, log_softmax
+- **Composed from single mode**: neg (MUL by -1), trunc (TRUNCATEDIV by 1), expm1 (EXP then SUB 1)
+
+### Handwritten operators (2 ops)
+
+**Convolution** (`csrc/aten/backends/musa/mudnn_conv.cc`):
+- `convolution_overrideable` cannot be left unregistered (ATen's default raises rather than being boxable to CPU)
+- `mudnn`'s `Convolution` covers 2 spatial dims only:
+  - conv1d runs as 2D conv with unit `H` dim (exact against CPU)
+  - conv3d takes the CPU fallback
+- Bias is a separate broadcast `Binary::ADD`; `RunFusion` accepts bias only for non-grouped 2D
+- Algorithm is chosen by trial and cached per shape (since `GetRecommendForwardAlgorithm` can name one that `Run` then rejects)
+
+**Copy and cast** (`csrc/aten/backends/musa/mudnn_copy.cc`):
+- Strided copies and dtype casts use `mudnn`'s `Unary::IDENTITY` / `Unary::CAST`
+- Handles both in a single device pass
+- Without this, `copy_`/`clone`/`contiguous` would reach the CUDA `DispatchStub` and fail
+
+### CPU fallback
+
+Ops with no `mudnn` mode are deliberately left unregistered, so they reach the `cpu_fallback` and stay correct. Examples:
+- `sinh`, `cosh`, `asin`: no `mudnn` mode exists
+
+Registering an op with no kernel behind it would trip the dispatcher's "backend not registered" check.
+
+## Platform-specific Behavior
+
+### Stride and broadcasting support
+
+`mudnn` Tensors carry strides on **both** operands and honor 0-strides. This means:
+- Broadcasting is just `expand()` (a view, no copy)
+- Non-contiguous inputs are read in place
+- No `.contiguous()` materialization needed (contrast with GCU's `topsaten`)
+
+### int64 support
+
+int64 works across Unary/Binary/Reduce/MatMul categories. Unlike GCU's `topsaten` (which has no int64 kernels at all), MUSA only falls back for genuinely unmapped dtypes (complex, quantized).
+
+### TF32 matmul behavior
+
+`mudnn` enables TF32 by default, whereas PyTorch defaults `torch.backends.cuda.matmul.allow_tf32` **off**. The handle is refreshed from torch's flag on every op to match PyTorch semantics. Without this, a 64×64 float `mm` drifts ~2e-2 from CPU.
+
+### Broadcast-reduction SIGFPE workaround
+
+`mudnn` v3300's `Reduce` raises `SIGFPE` (an uncatchable crash, not an error status) when reducing over more than one dim of a tensor that is a broadcast of a single element. Conv bias gradients hit exactly that case, since autograd feeds `ones.expand(...)` into the reduction.
+
+A fully broadcast input is materialized before a multi-dim reduction to avoid this crash.
+
+### Caching allocator
+
+`flagos` keeps its own caching allocator over raw `musaMalloc`. `mudnn` allocates nothing on its own beyond op workspaces, which are served from the same allocator via a `MemoryMaintainer`.
+
+## Limitations
+
+### No continuous validation
+
+MUSA has no CI runner (no `.github/configs/musa.yml` config exists), so all tests are manual. The platform status is **Experimental** (see [`docs/reference/compatibility.md`](../../reference/compatibility.md) line 31).
+
+### Distributed support
+
+Distributed collectives are not validated on MUSA hardware. The architecture recommends the FlagCX-only path unless live evidence proves more. See [`docs/architecture/distributed-flagcx.md`](../../architecture/distributed-flagcx.md).
+
+### Profiler and torch.compile not validated
+
+Neither `torch.compile` nor profiler-tracer parity has been validated on MUSA.
+
+### No FlagGems C++ or Python path
+
+No CUDA boxing kernels or FlagGems dispatch are compiled for MUSA (the toolkit exports no CUDA symbols). The build installs a `lib/flagos_platform` marker so `torch_fl` picks `backends_musa.conf`.
+
+## Build without native kernels
+
+To build the runtime layer only (device/memory/stream support) with no native operator kernels:
+
+```bash
+ACCELERATOR=musa MUSA_KERNEL=OFF pip install --no-build-isolation -v -e .
+```
+
+All compute ops will fall back to CPU. This mode is useful for testing the runtime layer in isolation.
+
+## Reference Documentation
+
+- [Codegen source](../../../scripts/codegen_mudnn.py): category-driven kernel generation for `mudnn`
+- [Compatibility matrix](../../reference/compatibility.md): platform status and limitations
+- [Configuration reference](../../reference/configuration.md): runtime environment variables and backend selection

--- a/docs/vendors/ppu/installation.md
+++ b/docs/vendors/ppu/installation.md
@@ -1,0 +1,242 @@
+# PPU Installation Guide
+
+## Overview
+
+PPU (`PPU_SDK`) presents itself as a **CUDA-compatible** device, reusing the CUDA build directly with no dedicated `ACCELERATOR=ppu` branch. The PPU `torch` wheel is a full CUDA-enabled build (`torch.version.cuda == '13.0'`, `torch.cuda.is_available() == True`), and `PPU_SDK/CUDA_SDK` is a complete CUDA 13 toolkit. This makes PPU the simplest compatibility-boxing case:
+
+- **No stock `+cpu` wheel and no external `libtorch_cuda.so`** are required — the PPU torch wheel ships its own CUDA runtime
+- PPU registers ops under the `CUDA` dispatch key (not `PrivateUse1`), so the generated CUDA boxing kernels are reused unchanged
+- Build selector remains `ACCELERATOR=cuda`; `PPU_SDK` detection disables bundling external CUDA assets
+
+**Status:** Experimental. No CI manifest exists for this platform; validation rests on the build-from-source instructions and setup-specific testing.
+
+## Prerequisites
+
+- PPU hardware with driver installed
+- PPU SDK installed at `/usr/local/PPU_SDK` (or `$PPU_SDK`/`$PPU_HOME`)
+- PPU torch wheel (locally built or vendor-provided, CUDA-enabled)
+- Python 3.8 or later matching the PPU torch build
+- `cmake >= 3.18`, `ninja`
+
+## Installation
+
+### Pure CUDA-Boxing Build (No FlagGems)
+
+```bash
+git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git
+cd PyTorch-Plugin-FL
+
+# CUDA_HOME points at the PPU CUDA_SDK; FLAGOS_SKIP_CUDA_ASSETS=1 skips
+# bundling an external libtorch_cuda.so AND skips pinned nvidia-*-cu12 deps
+# (PPU supplies CUDA 13 via PPU_SDK/CUDA_SDK).
+ACCELERATOR=cuda \
+  CUDA_HOME=/usr/local/PPU_SDK/CUDA_SDK \
+  CUDA_KERNEL=ON \
+  FLAGGEMS_KERNEL=OFF \
+  FLAGGEMS_PYTHON=OFF \
+  FLAGOS_SKIP_CUDA_ASSETS=1 \
+  pip install --no-build-isolation -vvv -e .
+```
+
+**Key differences from NVIDIA CUDA build:**
+- `CUDA_HOME` points to `PPU_SDK/CUDA_SDK`, not `/usr/local/cuda`
+- `FLAGOS_SKIP_CUDA_ASSETS=1` disables bundling external CUDA assets (PPU torch provides them)
+- PPU torch already has `torch.cuda.is_available() == True`, so no CPU wheel is involved
+
+### Runtime Configuration
+
+Set `FLAGOS_DISABLE_CUDA_ASSETS=1` so the import-time preload of bundled `libtorch_cuda.so` is a no-op (there is none — PPU torch provides it):
+
+```bash
+export FLAGOS_DISABLE_CUDA_ASSETS=1
+```
+
+## Verification
+
+### Basic Device Check
+
+```bash
+FLAGOS_DISABLE_CUDA_ASSETS=1 python -c "
+import torch_fl
+import torch
+
+print(f'PyTorch version: {torch.__version__}')
+print(f'torch.cuda available: {torch.cuda.is_available()}')
+print(f'torch.version.cuda: {torch.version.cuda}')
+print(f'flagos devices: {torch.flagos.device_count()}')
+
+# Basic computation
+x = torch.randn(4, 4, device='flagos')
+y = x @ x
+print(f'Sample matmul result shape: {y.shape}')
+print(f'Sample result: {y.cpu()[0, 0].item():.4f}')
+"
+```
+
+Expected output shows `torch.cuda available: True`, `torch.version.cuda: 13.0`, and a floating-point result.
+
+### Operator Validation (Pure Boxing)
+
+```bash
+FLAGOS_DISABLE_CUDA_ASSETS=1 \
+  pytest tests/unit tests/integration/ops \
+    tests/integration/test_factory_ops.py \
+  -q -m "not flaggems and not flaggems_python"
+```
+
+## Optional: FlagGems on PPU
+
+Set `FLAGGEMS_PYTHON=ON` at build time (the default) and `FLAGOS_USE_FLAGGEMS=1` at runtime; `import torch_fl` then selects `backends_flaggems.conf` and routes discovered ops to FlagGems' Triton kernels.
+
+PPU needs no compatibility shim beyond the generic CUDA one: `libcuda.so` is a real driver, so `is_nvidia_cuda_available()` succeeds, `GEMS_VENDOR=nvidia` is set automatically, and `triton.language.extra.cuda.libdevice` resolves.
+
+### Installing PPU Triton
+
+PPU's Triton comes from a vendor index, not PyPI, and its version string (`3.5.0+v0.2.0.ppu2.1.0`) does not satisfy the `triton>=3.5.1` pin. When `PPU_SDK` is detected, `setup.py` drops the `flag_gems`/`triton` requirements, so install them manually:
+
+```bash
+# Vendor index URL varies by PPU SDK release; consult your vendor documentation
+pip install triton==3.5.0+v0.2.0.ppu2.1.0  # from vendor index
+pip install flag_gems
+```
+
+**Troubleshooting: `Invalid cross-device link` installing PPU Triton**
+
+The vendor `triton` sdist is a downloader shim that fetches the real wheel and `rename()`s it into pip's cache. If your pip cache and build directory are on different filesystems (e.g., cache on NFS, build in `/tmp`), that rename fails with `[Errno 18]`.
+
+**Fix:** Fetch the wheel URL the shim reports (`Guessing wheel URL: ...`) with `curl` and `pip install` the file directly.
+
+### FlagGems Build
+
+```bash
+ACCELERATOR=cuda \
+  CUDA_HOME=/usr/local/PPU_SDK/CUDA_SDK \
+  CUDA_KERNEL=ON \
+  FLAGGEMS_PYTHON=ON \
+  FLAGOS_SKIP_CUDA_ASSETS=1 \
+  pip install --no-build-isolation -vvv -e .
+```
+
+### FlagGems Verification
+
+```bash
+FLAGOS_DISABLE_CUDA_ASSETS=1 \
+  FLAGOS_USE_FLAGGEMS=1 \
+  python -c "
+import torch_fl, torch
+x = torch.randn(256, 256, device='flagos')
+result = torch.softmax(x, -1)
+print(f'FlagGems softmax output shape: {result.shape}')
+print(f'Row sum (expect 1.0): {result[0].sum().cpu().item():.6f}')
+"
+```
+
+### FlagGems Operator Tests
+
+```bash
+FLAGOS_DISABLE_CUDA_ASSETS=1 \
+  FLAGOS_USE_FLAGGEMS=1 \
+  pytest tests/integration/ops -q
+```
+
+First run is slow: Triton compiles and autotunes every kernel. Subsequent runs reuse the cache.
+
+## Optional: Distributed with FlagCX
+
+Distributed training works out of the box on the NCCL fallback — `PPU_SDK` ships a vendor-adapted `libnccl.so.2` and the PPU torch wheel is built with `USE_NCCL=1`, so `ProcessGroupNCCL` exists natively and `ProcessGroupFlagOS` uses it on the zero-copy CUDA view.
+
+To use FlagCX (heterogeneous unified comm) instead, build it from source:
+
+```bash
+git clone https://github.com/FlagOpen/FlagCX.git
+cd FlagCX
+
+# --depth 1 skips submodules; without third-party/json the build fails
+git submodule update --init --depth 1 third-party/json
+
+make -j16 USE_PPU=1 \
+  DEVICE_HOME=/usr/local/PPU_SDK/CUDA_SDK \
+  CCL_HOME=/usr/local/PPU_SDK/CUDA_SDK
+
+# Build the torch plugin with the 'nvidia' adaptor (not auto-detected 'ppu').
+# Both produce identical torch-side code (PPU is CUDA-ABI: same CUDAStreamGuard,
+# CUDAEvent, devName="cuda"), but FlagCX only compiles its extended_api creator
+# for NVIDIA and MetaX adaptors. The 'ppu' adaptor also fails to compile —
+# PPU is missing from the plugin's per-adaptor #ifdef chains.
+cd plugin/torch
+FLAGCX_ADAPTOR=nvidia \
+  FLAGCX_HOME=$(git rev-parse --show-toplevel) \
+  python setup.py install
+```
+
+`import torch_fl` then prefers FlagCX automatically (`_try_build_flagcx` runs before the NCCL fallback); no env var is needed beyond putting `libflagcx.so` on the loader path:
+
+```bash
+LD_LIBRARY_PATH=<path-to-FlagCX>/build/lib:$LD_LIBRARY_PATH \
+  python tests/manual/test_flagos_dist_live.py --world-size 4
+```
+
+## Run Tests
+
+### Pure Boxing Path
+
+```bash
+FLAGOS_DISABLE_CUDA_ASSETS=1 \
+  pytest tests/unit tests/integration/ops \
+    tests/integration/test_factory_ops.py \
+  -q -m "not flaggems and not flaggems_python"
+```
+
+### FlagGems Path
+
+```bash
+FLAGOS_DISABLE_CUDA_ASSETS=1 \
+  FLAGOS_USE_FLAGGEMS=1 \
+  pytest tests/integration/ops -q
+```
+
+### Distributed (Collectives + DDP)
+
+```bash
+# Works on NCCL; add LD_LIBRARY_PATH for FlagCX
+FLAGOS_DISABLE_CUDA_ASSETS=1 \
+  python tests/manual/test_flagos_dist_live.py --world-size 4
+```
+
+## Troubleshooting
+
+### `torch.cuda.is_available()` Returns False
+
+**Cause:** PPU torch wheel is not correctly installed, or the PPU driver is not loaded.
+
+**Fix:** Verify PPU torch with `python -c "import torch; print(torch.version.cuda)"` — expect `13.0`. Check PPU driver status with vendor-provided diagnostic tools.
+
+### `FLAGOS_DISABLE_CUDA_ASSETS=1` Not Set
+
+**Symptom:** Import fails with "libtorch_cuda.so not found" or similar.
+
+**Fix:** Export `FLAGOS_DISABLE_CUDA_ASSETS=1` before running Python. This variable disables the import-time preload of bundled CUDA assets (which PPU builds do not ship).
+
+### Build Error: `CUDA_HOME not set`
+
+**Cause:** `CUDA_HOME` environment variable not pointing to `PPU_SDK/CUDA_SDK`.
+
+**Fix:** Export `CUDA_HOME=/usr/local/PPU_SDK/CUDA_SDK` before building, or pass it explicitly in the build command.
+
+### Triton Install: `Invalid cross-device link`
+
+**Cause:** pip cache and build directory are on different filesystems; the vendor Triton sdist's `rename()` call fails.
+
+**Fix:** Download the wheel URL directly from the sdist's output and install the file with `pip install <wheel-file>`.
+
+### FlagCX: `extended_api creator not found`
+
+**Cause:** Built the FlagCX torch plugin with auto-detected `ppu` adaptor, which does not export the extended_api creator.
+
+**Fix:** Rebuild with `FLAGCX_ADAPTOR=nvidia` (see "Optional: Distributed with FlagCX" above).
+
+## Further Reading
+
+- [Environment Variables](../../reference/environment-variables.md) — Complete runtime configuration reference
+- [Distributed (FlagCX)](../../architecture/distributed-flagcx.md) — Multi-GPU collectives and heterogeneous communication
+- [Testing Guide](../../development/testing.md) — Running local validation


### PR DESCRIPTION
## Summary

Redesigns the root README as a concise project landing page (~200 lines, down from 1000+) and migrates platform-specific installation, compatibility, runtime configuration, testing, and troubleshooting material into stable English documentation entry points under `docs/`.

## Changes

### Root README (Task 7)
- **New structure**: Overview → Design Philosophy → Architecture → Capabilities → Hardware Support → Compatibility → Quick Start → Documentation → Contributing → Acknowledgements → License
- **Removed**: 600+ lines of platform-specific build/runtime/testing commands, stale global requirements table, detailed project tree, exhaustive architecture diagrams
- **Added**: Design philosophy section (five principles + three execution paths), compact platform support table with evidence-backed status levels
- **Result**: 193-line landing page that explains what torch-fl is, why it exists, which platforms are supported, and where to go next

### Documentation structure (Tasks 1-6)

**Reference guides**:
- `docs/reference/compatibility.md` — Authoritative platform support matrix (9 platforms: execution paths, validated capabilities, status definitions, version requirements, explicit limitations)
- `docs/reference/environment-variables.md` — 52 build/runtime/routing variables organized by scope

**Getting started**:
- `docs/getting-started/installation.md` — Platform selector and source installation contract
- `docs/getting-started/quickstart.md` — Platform-independent Python examples (basic usage, device movement, synchronization, operator routing)

**Development**:
- `docs/development/testing.md` — Test structure, pytest markers, platform commands, codegen scripts, lint workflow
- `CONTRIBUTING.md` — Concise contribution workflow for operators, runtime, compiler, distributed, tests, documentation

**Platform guides** (one per supported accelerator):
- `docs/vendors/cuda/installation.md` (Stable, CI-validated)
- `docs/vendors/metax/installation.md` (Stable, self-contained boxing wheel)
- `docs/vendors/ascend/installation.md` (Beta, native ACLNN + optional FlagGems)
- `docs/vendors/ppu/installation.md` (Experimental, CUDA 13 compatible)
- `docs/vendors/dcu/installation.md` (Beta, hipified DTK build)
- `docs/vendors/gcu/installation.md` (Experimental, native topsaten + CPU fallback)
- `docs/vendors/musa/installation.md` (Experimental, native mudnn)
- `docs/vendors/bpu/installation.md` (Runtime only, graph-level acceleration)

Each guide follows consistent structure (Prerequisites → Installation → Verification → Troubleshooting) and links to existing detailed analyses where appropriate.

### Validation (Task 8)
- ✅ All 29 Markdown files have valid internal links
- ✅ All documentation in English (no CJK characters)
- ✅ No machine-local paths, credentials, or private registries
- ✅ Support claims match compatibility matrix evidence
- ✅ Clean `ruff check .` and `ruff format --check .`
- ✅ Documentation-only diff (no source/test/build/workflow changes)

## Design rationale

This redesign follows conventions from PyTorch, vLLM, SGLang, and other FlagOS projects:
- **Root README as landing page**, not exhaustive manual
- **Evidence-based support claims** from package metadata, build config, CI manifests, tests, and measured docs
- **Conservative maturity assignments**: uncertain claims default to less mature status
- **Stable entry points** for installation, compatibility, development workflow
- **Platform-specific detail in vendor guides**, not root README

Key principle: the root README must not remain a 1000-line build manual that mixes positioning, stale requirements, and every platform's procedures. Platform installation, runtime configuration, testing commands, and troubleshooting belong under `docs/` and are linked from the README.

## Testing

All platform installation guides verified against:
- Current `setup.py` / `CMakeLists.txt` build logic
- `.github/configs/*.yml` CI validation steps
- `pyproject.toml` / package metadata compatibility claims
- Existing measured documentation and architecture analyses

Cross-validated:
- Python 3.8+ and PyTorch 2.10.x compatibility (from package metadata)
- 9 platform names consistent between README and compatibility matrix
- Support status vocabulary (Stable/Beta/Experimental/Runtime only) applied uniformly
- Execution path claims (native vendor / compatibility boxing / portable compiler) match build and routing code

## Related

- Design spec: `docs/superpowers/specs/2026-08-11-readme-redesign-design.md` (committed in 018d9b6)
- Implementation plan: `docs/superpowers/plans/2026-08-11-readme-redesign.md` (committed in bd6444d)
- Supersedes stale global requirements table (Python 3.12, PyTorch 2.11.0, CUDA 12.8, FlagGems 5.0.2 for all platforms)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
