### PR TITLE
docs: update Chinese README and CI paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,34 @@ name: CI
 on:
   push:
     branches: [main, dev, devops, dev-hygon]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/PULL_REQUEST_TEMPLATE.md"
+    paths:
+      - "cmake/**"
+      - "csrc/**"
+      - "include/**"
+      - "scripts/**"
+      - "tests/**"
+      - "torch_fl/**"
+      - "CMakeLists.txt"
+      - "pyproject.toml"
+      - "setup.py"
+      - ".github/configs/**"
+      - ".github/scripts/**"
+      - ".github/workflows/**"
   pull_request:
     branches: [main, dev, devops, dev-hygon]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/PULL_REQUEST_TEMPLATE.md"
+    paths:
+      - "cmake/**"
+      - "csrc/**"
+      - "include/**"
+      - "scripts/**"
+      - "tests/**"
+      - "torch_fl/**"
+      - "CMakeLists.txt"
+      - "pyproject.toml"
+      - "setup.py"
+      - ".github/configs/**"
+      - ".github/scripts/**"
+      - ".github/workflows/**"
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.8%2B-blue.svg)](https://www.python.org/downloads/)
 [![PyTorch](https://img.shields.io/badge/PyTorch-2.10.x-orange.svg)](https://pytorch.org/)
+[![CI](https://github.com/flagos-ai/PyTorch-Plugin-FL/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/flagos-ai/PyTorch-Plugin-FL/actions/workflows/ci.yml?query=branch%3Amain)
 
 [Documentation](docs/) · [Installation](docs/getting-started/installation.md) · [Quick Start](docs/getting-started/quickstart.md) · [Compatibility](docs/reference/compatibility.md)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -14,802 +14,197 @@
  limitations under the License.
  -->
 
-# torch_fl
+# torch-fl
 
-基于 PyTorch PrivateUse1 扩展机制的自定义设备插件，将 [FlagGems](https://github.com/FlagOpen/FlagGems) 高性能 Triton 算子注册为 `flagos` 设备后端，实现统一的多芯支持。
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.8%2B-blue.svg)](https://www.python.org/downloads/)
+[![PyTorch](https://img.shields.io/badge/PyTorch-2.10.x-orange.svg)](https://pytorch.org/)
+[![CI](https://github.com/flagos-ai/PyTorch-Plugin-FL/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/flagos-ai/PyTorch-Plugin-FL/actions/workflows/ci.yml?query=branch%3Amain)
 
-## 特性
+[文档](docs/) · [安装](docs/getting-started/installation.md) · [快速开始](docs/getting-started/quickstart.md) · [兼容性](docs/reference/compatibility.md) · [English](README.md)
 
-- 自动将 FlagGems Triton 算子注册为 `flagos` 设备的 dispatch 实现
-- 可配置的后端路由：按算子粒度选择 FlagGems 或 原始的厂商后端（CUDA/MetaX/Ascend）
-- 目前支持 CUDA、MetaX 和 Ascend 三种硬件平台
-- 完整的设备管理 API（stream、event、RNG、AMP）
+FlagOS 软件栈的 PyTorch 设备插件。torch-fl 对外提供统一的 `flagos` 设备，并在可复用原生内核、可移植编译器内核、厂商原生实现和显式 CPU 回退之间路由算子。
 
+## 概览
 
-## 环境要求
+不同加速器厂商提供的运行时、编译器栈和 PyTorch 集成方式各不相同。torch-fl 通过统一的运行时和算子路由层屏蔽这些差异，提供符合 PyTorch 使用习惯的设备接口。
 
-| 依赖 | 版本 |
-|------|------|
-| Python | 3.12 |
-| PyTorch | 2.11.0 |
-| CUDA | 12.8 |
-| FlagGems | 5.0.2 |
+用户只需使用标准 PyTorch API 和 `flagos` 设备。插件根据平台能力和配置为每个算子选择内核实现，无需将不同厂商暴露为不同设备名称，也无需在迁移加速器时修改工作负载。
 
-> CUDA 12.2 存在已知的数值精度问题（NaN），请使用 12.9 或更高版本。
+## 设计理念
 
-## 安装
+torch-fl 遵循五项原则：
 
-### 前置依赖
+1. **PyTorch 原生接口** — 标准 PyTorch API 无需修改；用户面向 `flagos` 设备编程，而不是使用厂商专用扩展。
 
-- 硬件 Runtime 依赖：
-    - CUDA toolkit 12.8 （仅在 CUDA 平台需要）
-    - MetaX cu-bridge 库（仅在 MetaX 平台需要）
-    - CANN toolkit（仅在 Ascend 平台需要）
-- PyTorch 2.11.0
-- FlagGems（5.0.2 版本以上）
-  - CUDA 平台：从 [FlagGems 官方仓库](https://github.com/FlagOpen/FlagGems) 安装，需开启 `FLAGGEMS_BUILD_C_EXTENSIONS`
-  - Ascend 平台：从 [Hchnr/FlagGems](https://github.com/Hchnr/FlagGems) 的 `torch_fl` 分支安装，需指定 `FLAGGEMS_BACKEND=FLAGOS`（详见下方 Ascend 安装步骤）
+2. **统一逻辑设备** — 单一设备名称（`flagos`）抽象厂商差异，平台相关路由在算子层透明完成。
 
-### 从源码安装（CUDA 平台）
+3. **分层算子后端** — 每个操作可以分发到不同实现。路由决策以算子为粒度，而不是以设备或模型为粒度。
 
-```bash
-git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+4. **优先复用而非重写** — 在 dispatch 和 ABI 边界允许的情况下集成成熟内核与编译器栈，避免重复实现已有能力。
 
-ACCELERATOR=cuda FLAGGEMS_DIR=/path/to/FlagGems/build/cpython-312/ \
-  FLAGGEMS_KERNEL=1 FLAGGEMS_PYTHON=1 CUDA_KERNEL=1 \
-  pip install --no-build-isolation -vvv -e .
+5. **明确能力边界** — 对不支持的操作和 CPU 回退路径进行明确说明，不将其描述为完整原生覆盖；通过状态等级区分已验证支持与实验性集成。
+
+### 执行路径
+
+torch-fl 主要支持三类算子执行策略：
+
+- **厂商原生内核**：直接调用厂商运行时和算子库（ACLNN、mudnn、topsaten），由插件生成对应厂商 C/C++ API 的绑定代码。
+
+- **兼容性 boxing**：当厂商栈提供可与 PrivateUse1 共存的独立 PyTorch dispatch key 时，以零拷贝方式转换张量元数据。CUDA boxing 通过外部 `libtorch_cuda.so` 复用 NVIDIA 内核。
+
+- **可移植编译器内核**：使用 Triton 或兼容编译器后端生成的 FlagGems 内核，在多个加速器系列之间复用，无需逐平台重写。
+
+同一平台可以组合多种执行路径。这些路径属于内部实现策略，而不是用户选择的产品等级。
+
+## 架构
+
+```text
+PyTorch API
+    |
+flagos 设备（PrivateUse1）
+    |
+设备运行时 + 按算子路由
+    |
+FlagGems/编译器内核 | 兼容性 boxing | 厂商原生内核 | CPU 回退
+    |
+加速器运行时
 ```
 
-### 从源码安装（MetaX 平台）
+上图为概念架构。组件设计、dispatch 内部机制、分布式集合通信、编译集成和 profiler 设计详见 [docs/architecture/](docs/architecture/)。
 
-MetaX 构建与 Ascend 类似：**主工程仅 CXX**，设备算子由 `mxcc`/`cucc` 编译 `csrc/aten/backends/metax/*.cu` 后以 object 链入 `libtorch_fl.so`；运行时走 `runtime/accelerator/metax`（cu-bridge），**不**委托 `at::cuda`/`at::maca`。
+## 能力
 
-**前置依赖**
+torch-fl 在项目层面提供以下能力：
 
-- MetaX MACA SDK（默认 `/opt/maca`），含 cu-bridge 与 `mxcc`/`cucc`
-- 与 MetaX 栈匹配的 PyTorch wheel（见下方[运行时说明](#metax-运行时说明)）
-- FlagGems 5.0.2+（可选；仅当算子路由到 `flagos_python` 时需要）
+- PyTorch eager 张量操作和设备管理
+- Autograd 与模型训练
+- `torch.compile` 集成
+- 通过 `ProcessGroupFlagOS` 支持分布式集合通信和 DDP
+- `torch.profiler` 集成
+- FlagGems/Triton 算子集成
+- 在 PyTorch 语义允许时，为未覆盖操作提供显式 CPU 回退
 
-```bash
-git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+各平台的能力可用性和验证状态并不相同。某项功能存在于 torch-fl 代码库中，并不代表每个平台都已实现或验证该功能。平台详情请参阅[兼容性矩阵](docs/reference/compatibility.md)。
 
-# MetaX SDK 路径（按实际安装位置调整）
-export METAX_PATH=/opt/maca
-export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:/opt/maca/mxgpu_llvm/bin:$PATH
-export LD_LIBRARY_PATH=/opt/maca/lib:/opt/maca/tools/cu-bridge/lib:/opt/maca/mxgpu_llvm/lib:$LD_LIBRARY_PATH
+## 硬件支持
 
-ACCELERATOR=metax METAX_KERNEL=ON FLAGGEMS_PYTHON=1 FLAGGEMS_KERNEL=0 CUDA_KERNEL=0 \
-  pip install --no-build-isolation -vvv -e .
-```
+| 平台 | 执行路径 | 已验证能力 | 状态 | 指南 |
+|---|---|---|---|---|
+| NVIDIA CUDA | 基于外部 `libtorch_cuda.so` 的 CUDA boxing | Eager、autograd、分布式（FlagCX/NCCL）、profiler（CUPTI）、FlagGems（Python + C++） | **稳定** | [CUDA](docs/vendors/cuda/installation.md) |
+| MetaX | 通过 cu-bridge 进行 CUDA boxing，或使用 MetaX 原生内核 | Eager、autograd | **稳定** | [MetaX](docs/vendors/metax/installation.md) |
+| Ascend | 原生 ACLNN 后端，可选通过 triton-ascend 使用 FlagGems | Eager、autograd、RNG 套件 | **Beta** | [Ascend](docs/vendors/ascend/installation.md) |
+| PPU | 针对 PPU CUDA 13 兼容 SDK 的 CUDA boxing | Eager、autograd | **实验性** | [PPU](docs/vendors/ppu/installation.md) |
+| 海光 DCU | 基于 hipify DTK torch 的 CUDA boxing | Eager、autograd、profiler | **Beta** | [DCU](docs/vendors/dcu/installation.md) |
+| 燧原 GCU | 原生 topsaten 后端，未路由及 int64 算子使用 CPU 回退 | Eager | **实验性** | [GCU](docs/vendors/gcu/installation.md) |
+| 摩尔线程 MUSA | 原生 mudnn 后端，未路由算子使用 CPU 回退 | Eager | **实验性** | [MUSA](docs/vendors/musa/installation.md) |
+| 地平线 BPU | 无 eager 内核；通过 hbdk4 使用 `torch.compile` 图执行路径 | 仅图编译 | **仅运行时** | [BPU](docs/vendors/bpu/installation.md) |
+| 清微智能 | 已提供运行时构建选择器 | 尚无安装文档 | **仅运行时** | — |
 
-> 在 MetaX 上，PyPI 通用版 Triton（`nvidia` 后端）无法为 MetaX 硬件 JIT 内核。请使用 `torch_fl/configs/backends_metax.conf` 或 `torch_fl/configs/backends_metax_flagos_py.conf`，将不兼容算子路由到 metax C++ kernel（见[MetaX 后端配置](#metax-后端配置)）。
+**状态定义：**
 
-### 从源码安装（Ascend 平台）
+- **稳定**：关键路径持续接受测试，并已记录受支持的版本组合。
+- **Beta**：主要路径已经验证，但覆盖范围、打包或发布流程尚未稳定。
+- **实验性**：已在特定配置、模型或硬件环境中完成验证；接口或构建流程仍可能变化。
+- **仅运行时**：已提供设备运行时支持，但该平台不是通用 eager 算子后端。
 
-#### 1. 安装 FlagGems（FLAGOS 后端）
+Eager 执行、训练、编译、分布式、profiler、FlagGems 等能力的详细拆分以及真实硬件验证结果，请参阅[兼容性矩阵](docs/reference/compatibility.md)。
 
-Ascend 平台上 FlagGems 需要使用我们 fork 的 `torch_fl` 分支，并以 `FLAGGEMS_BACKEND=FLAGOS` 编译。这样 FlagGems 不依赖 `torch_npu` / `libtorch_npu.so`，而是通过 `torch_fl` 提供的 `GetCurrentStream` C API 获取 ACL stream。
+## 兼容性
 
-```bash
-# 克隆 FlagGems（torch_fl 分支）
-git clone -b torch_fl https://github.com/Hchnr/FlagGems.git
-cd FlagGems
+| 组件 | 支持范围 | 说明 |
+|---|---|---|
+| Python | 3.8 或更高版本 | 平台 SDK 和可用 wheel 可能要求更窄的版本范围。 |
+| PyTorch | 2.10.x（`>=2.10,<2.11`） | 生成的 ATen 绑定与该次版本线绑定。 |
+| FlagGems | 取决于平台 | 仅在平台路由使用 FlagGems 时，从 PyPI 或厂商兼容构建安装。 |
+| Triton/编译器 | 取决于平台 | 使用所选加速器要求的编译器发行版。 |
 
-# 确保 CANN toolkit 环境已激活
-source /usr/local/Ascend/ascend-toolkit/set_env.sh
+### ATen 次版本绑定
 
-# 安装 FlagGems（指定 FLAGOS 后端，跳过 C++ 扩展编译）
-pip install --no-build-isolation -e . \
-  --config-settings=cmake.define.FLAGGEMS_BACKEND=FLAGOS \
-  --config-settings=cmake.define.FLAGGEMS_BUILD_C_EXTENSIONS=OFF
+torch-fl 根据 PyTorch 内部 ATen 算子注册表生成原生绑定。这些绑定对 C++ ABI 和算子 schema 变化敏感，因此项目固定使用一个 PyTorch 次版本线。当前固定版本线为 **2.10.x**。
 
-cd ..
-```
+使用其他 PyTorch 次版本（例如 2.11.x）会导致构建或运行时失败。同一次版本线内的补丁版本（例如 2.10.0 到 2.10.1）兼容。
 
-> **为什么用 FLAGOS 后端？**
-> FlagGems 的 `ascend/npu` 后端会链接 `libtorch_npu.so`，而我们的环境没有 `torch_npu`（`torch_fl` 本身就是 PrivateUse1 后端）。
-> `FLAGOS` 后端通过 `extern "C" void* GetCurrentStream(int)` 获取 stream，由 `torch_fl` 的 `libstream_api.so` 提供实现，完全绕开 `torch_npu` 依赖。
+厂商 SDK、CUDA toolkit 及其他平台特定版本要求记录在各平台安装指南中。
 
-#### 2. 安装 torch_fl
+## 快速开始
 
-```bash
-git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+先在[安装指南](docs/getting-started/installation.md)中选择平台，然后运行：
 
-# 确保 CANN toolkit 环境已激活
-source /usr/local/Ascend/ascend-toolkit/set_env.sh
-
-ACCELERATOR=ascend FLAGGEMS_KERNEL=0 FLAGGEMS_PYTHON=1 \
-  CUDA_KERNEL=0 ASCEND_KERNEL=1 \
-  pip install --no-build-isolation -vvv -e .
-```
-
-说明：
-- `FLAGGEMS_KERNEL=0`：禁用 FlagGems C++ kernel 封装（FLAGOS 后端暂不编译 `liboperators.so`）
-- `FLAGGEMS_PYTHON=1`：启用 FlagGems Python 封装，通过 `python_wrapper` 机制调用 FlagGems Triton kernel
-- `ASCEND_KERNEL=1`：编译 Ascend C++ 算子后端（ACL NN API）
-
-#### 3. Patch triton-ascend
-
-原版 triton-ascend 依赖 `torch_npu` / `libtorch_npu.so`。由于 `torch_fl` 替代了 `torch_npu` 作为 PrivateUse1 后端，需要 patch triton-ascend 使其使用 `flagos` 设备接口：
-
-```bash
-python scripts/patch_triton_ascend.py
-```
-
-脚本会自动检测 triton 安装路径并应用修改。脚本幂等，可重复执行。patch 后请清理 kernel 缓存：
-
-```bash
-rm -rf ~/.triton/cache/
-```
-
-#### 4. 验证安装
-
-```bash
-python -c "
+```python
+import torch
 import torch_fl
-print('device count:', torch_fl.flagos.device_count())
-print('FlagGems enabled:', torch_fl.is_flaggems_enabled())
-print('registered ops:', len(torch_fl.get_registered_ops()))
-"
+
+# 在 flagos 设备上创建张量
+x = torch.randn(4, 4, device="flagos:0")
+
+# 操作会路由到适合当前平台的内核
+y = torch.relu(x @ x)
+
+# 将结果移回 CPU
+print(y.cpu())
 ```
 
-#### 5. 运行推理测试
+算子具体路由到 FlagGems、厂商内核、兼容性 boxing 或 CPU 回退，由平台检测和运行时配置决定。以上代码在所有受支持加速器上保持不变。
 
-```bash
-pytest tests/integration/test_qwen3_infer.py -v -s --model /path/to/Qwen3-0.6B
-```
+设备查询、同步和多设备用法请参阅[快速开始指南](docs/getting-started/quickstart.md)。
 
-#### 6. 运行训练测试
+## 文档
 
-```bash
-pytest tests/integration/test_qwen3_train.py -v -s --model /path/to/Qwen3-0.6B
-```
+### 入门
 
-> **常见问题：`libtorch_npu.so: cannot open shared object file`**
->
-> 如果遇到此错误，说明 triton-ascend 仍在尝试加载 `torch_npu`。请确认：
-> 1. 安装 triton-ascend 后执行了 `python scripts/patch_triton_ascend.py`
-> 2. FlagGems 是从 `https://github.com/Hchnr/FlagGems` 的 `torch_fl` 分支安装的
-> 3. 安装时指定了 `FLAGGEMS_BACKEND=FLAGOS`
-> 4. 已清理 triton kernel 缓存（`rm -rf ~/.triton/cache/`）
+- [安装](docs/getting-started/installation.md) — 平台选择和源码构建
+- [快速开始](docs/getting-started/quickstart.md) — 基本使用方式
 
-### 从源码安装（PPU 平台）
+### 参考
 
-PPU（`PPU_SDK`）以 **CUDA 兼容** 形态呈现，因此直接复用 CUDA 构建，无需单独的
-`ACCELERATOR=ppu` 分支。PPU 的 `torch` wheel 本身就是完整的 CUDA 版本
-（`torch.version.cuda == '13.0'`、`torch.cuda.is_available() == True`），而
-`PPU_SDK/CUDA_SDK` 是完整的 CUDA 13 toolkit（nvcc、头文件、`libcudart.so.13`）。
-这使 PPU 成为 boxing 路线里最省事的情况：
+- [兼容性矩阵](docs/reference/compatibility.md) — 各平台能力验证与状态
+- [环境变量](docs/reference/environment-variables.md) — 构建和运行时配置
 
-- **无需 stock `+cpu` wheel、也无需外挂 `libtorch_cuda.so`**——PPU torch 自带 CUDA
-  运行时，随 `import torch` 正常加载。
-- PPU 的算子注册在独立的 `CUDA` dispatch key（而非 `PrivateUse1`），因此生成的 CUDA
-  boxing 内核（`csrc/aten/generated/cuda_kernels.cc`，PrivateUse1 → CUDA）零改动复用。
+### 架构
 
-```bash
-git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
+- [分布式集合通信](docs/architecture/distributed-flagcx.md) — ProcessGroupFlagOS、FlagCX 和厂商回退
+- [Profiler 集成](docs/architecture/profiler.md) — torch.profiler 对齐与 CUPTI 集成
+- [torch.compile 集成](docs/architecture/torch-compile-integration.md) — Inductor GPU 设备注册
 
-# 纯 CUDA-boxing 构建（不接 FlagGems）。CUDA_HOME 指向 PPU 的 CUDA_SDK；
-# FLAGOS_SKIP_CUDA_ASSETS=1 既跳过外挂 libtorch_cuda.so 的打包，也跳过固定的
-# nvidia-*-cu12 运行时依赖（PPU 由 PPU_SDK/CUDA_SDK 提供 CUDA 13）。
-ACCELERATOR=cuda \
-  CUDA_HOME=/usr/local/PPU_SDK/CUDA_SDK \
-  CUDA_KERNEL=ON FLAGGEMS_KERNEL=OFF FLAGGEMS_PYTHON=OFF \
-  FLAGOS_SKIP_CUDA_ASSETS=1 \
-  pip install --no-build-isolation -vvv -e .
-```
+### 平台指南
 
-运行时设置 `FLAGOS_DISABLE_CUDA_ASSETS=1`，使 import 期对打包版 `libtorch_cuda.so`
-的预载成为 no-op（本就没有打包——由 PPU torch 自身提供）：
+- [CUDA（NVIDIA）](docs/vendors/cuda/installation.md)
+- [MetaX](docs/vendors/metax/installation.md)
+- [Ascend（华为）](docs/vendors/ascend/installation.md)
+- [PPU](docs/vendors/ppu/installation.md)
+- [海光 DCU](docs/vendors/dcu/installation.md)
+- [燧原 GCU](docs/vendors/gcu/installation.md)
+- [摩尔线程 MUSA](docs/vendors/musa/installation.md)
+- [地平线 BPU](docs/vendors/bpu/installation.md)
 
-```bash
-FLAGOS_DISABLE_CUDA_ASSETS=1 python -c "import torch_fl, torch; \
-  x = torch.randn(4, 4, device='flagos'); \
-  print((x @ x).cpu())"
-```
+## 参与贡献
 
-**可选：PPU 上启用 FlagGems。** 构建时设 `FLAGGEMS_PYTHON=ON`（默认即为 ON），运行时设
-`FLAGOS_USE_FLAGGEMS=1`；`import torch_fl` 会自动选择 `backends_flaggems.conf`，把已发现
-的算子路由到 FlagGems 的 Triton 内核。PPU 不需要额外的兼容层，通用 CUDA shim 即可：
-`libcuda.so` 是真实驱动，`is_nvidia_cuda_available()` 成立，于是设置
-`GEMS_VENDOR=nvidia`，`triton.language.extra.cuda.libdevice` 也能正常解析（其中有 `pow`）。
+欢迎参与以下方向的贡献：
 
-PPU 的 Triton 来自厂商私有 index 而非 PyPI，其版本号（`3.5.0+v0.2.0.ppu2.1.0`）不满足
-`triton>=3.5.1` 的约束。因此当检测到 `PPU_SDK` 时，`setup.py` 会移除 `flag_gems`/`triton`
-依赖，改由用户自行安装：
+- **算子**：补充缺失算子，或针对特定后端优化现有实现。
+- **运行时和平台集成**：将 torch-fl 移植到新加速器，或改进现有后端支持。
+- **编译器集成**：扩展 torch.compile 支持、改进 Triton 代码生成或增加编译后端。
+- **分布式与 profiler**：增强集合通信后端或 profiling 集成。
+- **测试**：增加算子正确性测试、模型集成测试或性能基准。
+- **文档**：改进安装指南、故障排查文档或厂商集成说明。
 
-```bash
-pip install triton==3.5.0+v0.2.0.ppu2.1.0   # 厂商 index，见下方说明
-pip install flag_gems
+开发流程、代码生成、测试要求和 PR 规范详见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
-FLAGOS_DISABLE_CUDA_ASSETS=1 FLAGOS_USE_FLAGGEMS=1 python -c "import torch_fl, torch; \
-  x = torch.randn(256, 256, device='flagos'); \
-  print(torch.allclose(torch.softmax(x, -1).cpu(), torch.softmax(x.cpu(), -1), atol=1e-3))"
-```
+**所有 GitHub 对外文本必须使用英文**，包括 PR 标题、PR 描述、commit message、issue 内容和 code review 评论。本仓库的代码、注释和历史记录均使用英文，PR 也由不阅读其他语言的贡献者审阅。
 
-> **排查：安装 PPU Triton 时报 `Invalid cross-device link`**
->
-> 厂商的 `triton` sdist 实际是个下载器，它先取回真实 wheel，再 `rename()` 到 pip 缓存目录。
-> 若 pip 缓存与构建目录不在同一文件系统（例如缓存在 NFS、构建在 `/tmp`），该 rename 会以
-> `[Errno 18]` 失败。此时用 `curl` 手动下载它打印的 wheel 地址
-> （`Guessing wheel URL: ...`），再对该文件执行 `pip install` 即可。
+## 致谢
 
-**可选：PPU 上启用 FlagCX。** 分布式训练默认即可用，走 NCCL 兜底：`PPU_SDK` 自带
-厂商适配的 `libnccl.so.2`，PPU 的 torch wheel 是 `USE_NCCL=1` 构建，因此
-`ProcessGroupNCCL` 原生存在，`ProcessGroupFlagOS` 直接在零拷贝 CUDA view 上使用它。
-若要改用 FlagCX（异构统一通信库），需从源码构建：
+torch-fl 基于多个上游项目构建：
 
-```bash
-git clone https://github.com/FlagOpen/FlagCX.git && cd FlagCX
-# --depth 1 不会拉取 submodule；缺少 third-party/json 会导致构建失败：
-# "nlohmann/json.hpp: No such file or directory"
-git submodule update --init --depth 1 third-party/json
+- **PyTorch** — PrivateUse1 扩展机制和 ATen 算子接口
+- **FlagGems** — 基于 Triton 的可移植算子内核
+- **Triton**（通过 FlagTree 和厂商发行版）— GPU 内核编译基础设施
+- **FlagCX** — 异构集合通信库
+- **厂商运行时和算子库** — ACLNN（Ascend）、mudnn（MUSA）、topsaten（GCU）、cu-bridge（MetaX）、DTK（DCU）等
 
-make -j16 USE_PPU=1 \
-  DEVICE_HOME=/usr/local/PPU_SDK/CUDA_SDK \
-  CCL_HOME=/usr/local/PPU_SDK/CUDA_SDK
-
-# torch plugin 用 *nvidia* adaptor 构建，而非自动探测出的 `ppu`。两者生成的 torch
-# 侧代码完全一致（PPU 是 CUDA-ABI：同样的 CUDAStreamGuard、CUDAEvent、
-# devName="cuda"），但 FlagCX 只为 NVIDIA 和 MetaX adaptor 编译 extended_api
-# creator，所以 `nvidia` 能拿到更完整的 ProcessGroupFlagCX 绑定。而 `ppu` 目前
-# 还编不过 —— PPU 未被加入 plugin 的各 adaptor #ifdef 分支。
-cd plugin/torch && FLAGCX_ADAPTOR=nvidia FLAGCX_HOME=$(git rev-parse --show-toplevel) \
-  python setup.py install
-```
-
-之后 `import torch_fl` 会自动优先使用 FlagCX（`_try_build_flagcx` 在 NCCL 兜底之前
-执行）；除了把 `libflagcx.so` 放到加载路径上，无需额外环境变量：
-
-```bash
-LD_LIBRARY_PATH=/path/to/FlagCX/build/lib:$LD_LIBRARY_PATH \
-  python tests/manual/test_flagos_dist_live.py --world-size 4
-```
-
-**运行测试：**
-
-```bash
-# 纯 boxing
-FLAGOS_DISABLE_CUDA_ASSETS=1 pytest tests/unit tests/integration/ops \
-  tests/integration/test_factory_ops.py -q -m "not flaggems and not flaggems_python"
-
-# FlagGems 路线（首次很慢：Triton 需要逐个编译并 autotune）
-FLAGOS_DISABLE_CUDA_ASSETS=1 FLAGOS_USE_FLAGGEMS=1 pytest tests/integration/ops -q
-
-# 分布式（collectives + DDP）。默认走 NCCL；用 FlagCX 时加上 LD_LIBRARY_PATH。
-python tests/manual/test_flagos_dist_live.py --world-size 4
-```
-
-### 从源码安装（海光 DCU 平台）
-
-海光 DCU（DTK）复用 **CUDA boxing 路线**，通过独立的 `ACCELERATOR=dcu` 分支支持。
-之所以可行，取决于厂商栈的两个特性：
-
-- DCU 的 `torch` wheel 是 **hipify 构建**：HIP 算子注册在 `CUDA` dispatch key 上，
-  张量的设备类型也报告为 `DeviceType::CUDA`（`torch.version.cuda is None`，
-  `torch.version.hip == '6.3.x'`）。因此生成的 PrivateUse1 → CUDA boxing 算子
-  （`csrc/aten/generated/cuda_kernels.cc`）无需改动即可分发进 `libtorch_hip.so`。
-- DTK 在 `$DTK_ROOT/cuda/cuda-*` 提供 **CUDA 兼容 toolkit**，其 `libcudart.so.12`
-  只是 `libgalaxyhip.so` 之上的一层薄壳——与 `libtorch_hip.so` 使用的是同一个
-  runtime，因此只有一份驱动状态，不会出现两套。`csrc/runtime/accelerator/cuda/`
-  下的 runtime 源码可以用普通 host `g++` 原样编译：不需要 `nvcc`、`hipcc`，也不
-  需要 hipify。
-
-该构建是 **纯 boxing**：`CUDA_KERNEL`、`FLAGGEMS_KERNEL`、`FLAGGEMS_PYTHON` 全部
-强制关闭（DTK 自带 Triton，PyPI 上面向 NVIDIA 的 `triton` wheel 是错误产物，因此
-不会被拉取）。
-
-```bash
-git clone https://github.com/flagos-ai/PyTorch-Plugin-FL.git && cd PyTorch-Plugin-FL
-
-source /opt/dtk/env.sh          # 会导出 ROCM_PATH；DTK_ROOT 同样生效
-
-ACCELERATOR=dcu pip install --no-build-isolation -vvv -e .
-```
-
-`DTK_ROOT` 的解析顺序为 `DTK_ROOT` → `ROCM_PATH` → `/opt/dtk`。若 DTK 装在其他
-位置，显式传入即可。
-
-**验证：**
-
-```bash
-python -c "
-import torch, torch_fl
-print('device count:', torch.flagos.device_count())
-x = torch.randn(512, 512, device='flagos')
-print('mm matches .cuda():',
-      torch.allclose(torch.mm(x, x).cpu(), torch.mm(x.cpu().cuda(), x.cpu().cuda()).cpu()))
-"
-```
-
-**跑测试**（纯 boxing 构建，需要反选 FlagGems 相关 marker）：
-
-```bash
-pytest tests/unit tests/integration/test_allocator.py tests/integration/test_factory_ops.py -q
-pytest tests/integration/ops -q -m "not flaggems and not flaggems_python"
-```
-
-说明：
-
-- **内存池。** flagos 张量与 boxing 算子的输出共用一个池。`dcu_memory.h` 通过设备
-  无关的注册表（`c10::getDeviceAllocator(kCUDA)`）把 caching 委托给 torch 自己的
-  分配器，而不是走 `c10::cuda::` 命名空间——DCU wheel 导出的是
-  `c10::hip::HIPCachingAllocator`，完全没有 `c10::cuda` 符号，而且
-  `cuda_runtime.h` 与 `hip/hip_runtime.h` 无法出现在同一个编译单元里。因此
-  `memory_allocated()` / `memory_reserved()` / `empty_cache()` 统计与行为都是真实的。
-- **`record_stream` 在 DCU 上是 no-op**：从裸 stream 句柄构造 `c10::Stream` 需要
-  `c10::cuda::getStreamFromExternal`，该 wheel 未导出此符号。
-- **`.cuda()` 的反向与 `torch_fl` 不能在同一进程中共存。** PyTorch 的
-  `register_privateuse1_backend` 会让 `at::getAccelerator()` 返回 `PrivateUse1`，
-  于是 autograd 引擎在纯 CUDA 图上找不到 stream 元数据，在 `engine.cpp` 里断言失败。
-  这是上游 PrivateUse1 的既有行为，在 CUDA/MetaX/Ascend 上表现一致——flagos 设备
-  自身的反向不受影响。取 `.cuda()` 基准请放到独立进程里。
-- **DTK 导出的 MIOpen CMake 配置** 内嵌了 `/usr/lib/x86_64-linux-gnu/librt.so`
-  这个绝对路径，而 glibc ≥ 2.34 已把 librt 合并进 libc，该文件不再存在。
-  `ACCELERATOR=dcu` 分支会把这类悬空绝对路径改写为 `-lrt`。
-
-#### 在 DCU 上启用 FlagGems
-
-DTK 自带 Triton（`hcu` 后端）和 FlagGems，其 `hygon` vendor 声明的
-`device_name="cuda"` 正好契合 boxing 路线。两者都装在 DTK 的系统解释器里，因此
-直接把环境指过去即可，不要装 PyPI 上面向 NVIDIA 的 wheel：
-
-```bash
-pip install pyyaml sqlalchemy          # flag_gems 依赖
-mkdir -p /path/to/gems_path && cd /path/to/gems_path
-ln -s /usr/local/lib/python3.10/dist-packages/triton .
-ln -s /usr/local/lib/python3.10/dist-packages/flag_gems .
-
-ACCELERATOR=dcu FLAGGEMS_PYTHON=1 pip install --no-build-isolation -e .
-
-export PYTHONPATH=/path/to/gems_path
-export TRITON_BACKENDS_IN_TREE=1       # 该安装没有 dist-info，
-                                       # 基于 entry-point 的后端发现拿不到任何后端
-export FLAGOS_USE_FLAGGEMS=1
-pytest tests/integration/ops -q        # 无需再屏蔽 marker
-```
-
-DCU 构建会自动设置 `GEMS_VENDOR=hygon`，无需再手动导出。这一点不只影响 FlagGems：
-`GEMS_VENDOR` 同时决定通信 profile（见 `torch_fl/comm/process_group.py`），而 DCU
-属于 CUDA-ABI vendor，其 `ProcessGroupNCCL` 底层就是 RCCL。只有需要覆盖时才自行导出。
-
-DCU 构建会把 `ACCELERATOR=dcu` 记录到 `torch_fl/_build_config.py`，因此运行时只需
-`FLAGOS_USE_FLAGGEMS=1` 就会选中 `backends_dcu_flaggems.conf`，不必重新导出
-`ACCELERATOR`。该配置即 `backends_flaggems.conf`，只是把 `hcu` Triton 编译不了或
-跑不通的算子退回 cuda boxing 算子：`silu_backward`（`tl.math.div_rn` 缺少
-`create_precise_divf` lowering）与 `slice_backward`（单独跑结果正确，但其梯度喂给
-MIOpen 的 `convolution_backward` 会触发硬件 VMFault）。可用
-`FLAGOS_OP_<name>=flagos_python|cuda` 按算子覆盖。
-
-#### DCU 多卡
-
-开着 FlagGems 也可以多卡，走 FlagCX 或 RCCL 回退路径均可，无需额外配置：自动设置的
-`GEMS_VENDOR=hygon` 会把 `ProcessGroupFlagOS` 路由到 CUDA-ABI profile（零拷贝
-`_flagos_to_cuda_view` + `ProcessGroupNCCL`，在 DTK 上底层即 RCCL：
-`dist.is_nccl_available()` 为 `True`，`torch.cuda.nccl.version()` 返回
-`(2, 22, 3)`）。
-
-```bash
-export HSA_FORCE_FINE_GRAIN_PCIE=1     # 不设置时 RCCL 会告警；
-                                       # 影响多卡吞吐与稳定性
-python tests/manual/test_flagos_dist_live.py --world-size 2
-```
-
-这里的前提是工厂算子必须遵守传入的 `device` index：每个 rank>0 的 worker 都通过工厂
-算子建张量，若输出分配在 device 0 而 Triton kernel 在 device N 上启动，就是一次跨设备
-写入，会直接把 GPU 打挂。参见 `tests/integration/test_factory_device_index.py`。
-
-### 从源码安装（燧原 GCU 平台）
-
-燧原 GCU 走的是**原生算子路线**（与 Ascend 一致），而不是 CUDA boxing：
-TopsRider 软件栈里没有 CUDA runtime 可以 box，厂商的 `torch-gcu` wheel 自己要占用
-`PrivateUse1`，无法与 `torch_fl` 共存。因此本插件直接链接厂商库：
-
-- `libtopsrt.so`（tops runtime）承载设备 / 内存 / 流层。
-- `libtopsaten.so`（ATen 风格算子库）承载计算算子。它的调用形态是一次直调，
-  没有 aclnn 那样的 workspace/executor 两段式。
-
-```bash
-# 上游 CPU 版 torch 即可，不需要厂商 torch。
-pip install torch==2.10.0 --index-url https://download.pytorch.org/whl/cpu
-
-ACCELERATOR=gcu pip install --no-build-isolation -vvv -e .
-```
-
-算子由 `scripts/codegen_gcu.py` 生成。它会把每个算子与 `libtopsaten.so` 中实际存在的
-`topsaten::topsatenXxx`（demangle 后）符号比对，缺失的直接跳过，因此 codegen 不可能
-生成当前 SDK 里没有的调用。
-
-**GCU 平台注意事项：**
-
-- **没有 topsaten kernel 的算子完全不在 `PrivateUse1` 上注册**，因此会落到
-  `cpu_fallback` 而不是报错。要扩大覆盖面，只需扩充 `scripts/codegen_gcu.py`
-  里的 `OPS` 表。
-- **topsaten 没有 int64 kernel**：任何 `I64` 操作数都会返回 `NOT_SUPPORT`。
-  因此每个生成的 kernel 都会先判断 dtype，int64 情况下在 CPU 上算再拷回，
-  保证索引、mask、计数器这类张量可用。它同样拒绝 rank-0 形状，所以 0 维张量
-  会按 1 元素向量来描述。
-- **tops 设备指针是按设备绑定的**（没有统一寻址）：指针只在*当前*设备上有效，
-  所以 allocator 和每个 kernel 都会先切换设备，默认流也是每设备一条。
-- **带原生 kernel 的构建会安装一个 `lib/flagos_platform` 标记文件**，让
-  `torch_fl` 选用 `backends_gcu.conf`，而不是默认的 CUDA 路由。
-- 用 `-DGCU_KERNEL=OFF` 可以完全跳过 topsaten；此时 runtime 仍可用，
-  所有计算回落到 CPU。
-
-### 构建环境变量
-
-| 变量 | 说明 |
-|------|------|
-| `ACCELERATOR` | 硬件平台：`cuda`（默认）、`metax`、`ascend`、`tsingmicro`、`dcu` 或 `gcu` |
-| `FLAGOS_BUILD_JOBS` | 原生库并行编译线程数（默认 CPU 核数）；日志过长可设 `1` |
-| `CUDA_HOME` | CUDA toolkit 路径 |
-| `DTK_ROOT` | 海光 DTK 路径（依次回退到 `ROCM_PATH`、`/opt/dtk`；DCU 构建必需） |
-| `TOPS_HOME` | 燧原 TopsRider SDK 路径（默认 `/opt/tops`；GCU 构建必需） |
-| `METAX_PATH` | MetaX SDK 路径（默认 `/opt/maca`，metax 构建必需） |
-| `METAX_ARCH` / `METAX_MXCC` | 可选：GPU 架构或 mxcc/cucc 编译器路径 |
-| `METAX_KERNEL` | 启用 MetaX C++ kernel 构建（`ON`/`OFF`；`ACCELERATOR=metax` 时自动开启） |
-| `ASCEND_HOME` | CANN toolkit 路径（默认 `/usr/local/Ascend/ascend-toolkit/latest`） |
-| `FLAGGEMS_DIR` | FlagGems C++ 库路径（启用低开销 C++ dispatch） |
-| `FLAGGEMS_KERNEL` | 启用 FlagGems C++ kernel 封装（`ON`/`OFF`，默认 `ON`；Ascend 设为 `0`） |
-| `FLAGGEMS_PYTHON` | 启用 FlagGems Python kernel 封装（`ON`/`OFF`，默认 `OFF`；设为 `1` 启用） |
-| `CUDA_KERNEL` | 启用 CUDA kernel 构建（`ON`/`OFF`，默认 `ON`；Ascend 设为 `0`） |
-| `ASCEND_KERNEL` | 启用 Ascend kernel 构建（`ON`/`OFF`，默认 `OFF`；Ascend 设为 `1`） |
-| `GCU_KERNEL` | 启用燧原 GCU topsaten kernel 构建（`ON`/`OFF`；`ACCELERATOR=gcu` 时自动开启） |
-
-### 运行时环境变量
-
-| 变量 | 说明 |
-|------|------|
-| `FLAGOS_DISABLE_FLAGGEMS_PY` | 设为 `1` 关闭 FlagGems Python 层注册（C++ stub-only 模式） |
-| `FLAGOS_METAX_CUDART_SHIM` | 设为 `1` 在 import 前加载 libcudart 兼容 shim（通用 PyTorch wheel 常需） |
-| `FLAGOS_METAX_COMPAT` | 设为 `1` 为 FlagGems 修补 `torch.cuda` 设备属性查询 |
-| `GEMS_VENDOR` | FlagGems 厂商名；MetaX 上设为 `metax` |
-| `LD_PRELOAD` | 常设为 `/opt/maca/lib/libsymbol_cu.so`，用于 cu-bridge 符号解析 |
-| `FLAGGEMS_SOURCE_DIR` | FlagGems 源码目录（算子路由到 `flaggems` 或 `flagos_python` 时需设置） |
-| `FLAGOS_BACKEND_CONFIG` | 覆盖后端路由配置（MetaX：`backends_metax.conf` 或 `backends_metax_flagos_py.conf`） |
-| `FLAGOS_LOG_DISPATCH` | 设为 `1` 打印每次算子 dispatch 的后端选择 |
-| `FLAGOS_OP_<name>` | 按算子覆盖后端（算子名中的 `.` 替换为 `__`） |
-
-## 使用
-
-### 基本用法
-
-```python
-import torch
-import torch_fl  # 导入即自动注册 FlagGems 算子
-
-# 在 flagos 设备上创建 tensor
-x = torch.randn(1000, 1000, device="flagos")
-y = torch.randn(1000, 1000, device="flagos")
-
-# 所有运算自动使用 FlagGems Triton 内核
-z = x + y
-mm_result = torch.mm(x, y)
-softmax_result = torch.softmax(x, dim=-1)
-```
-
-### 设备间数据搬移
-
-```python
-cpu_tensor = torch.randn(3, 3)
-flagos_tensor = cpu_tensor.to("flagos")
-back_to_cpu = flagos_tensor.cpu()
-```
-
-### 设备上下文管理
-
-```python
-with torch_fl.flagos.device(0):
-    a = torch.randn(10, 10, device="flagos")
-```
-
-### MetaX 平台导入顺序
-
-在 MetaX 硬件上，**必须**在 `import torch` 之前导入 `torch_fl`：
-
-```python
-import torch_fl  # 必须先导入
-import torch
-```
-
-原因：PyTorch 自带的 CUDA 12.x 运行时与 MetaX 的 cu-bridge（CUDA 11.6 兼容层）ABI 不兼容。`torch_fl` 会预加载一个 shim 库来提供所需的符号版本。
-
-CUDA 平台无此限制。
-
-### MetaX 运行时环境
-
-运行测试或推理前，配置 SDK 路径与混合后端：
-
-```bash
-export METAX_PATH=/opt/maca
-export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:/opt/maca/mxgpu_llvm/bin:$PATH
-export LD_LIBRARY_PATH=/opt/maca/tools/cu-bridge/lib:/opt/maca/lib:/opt/maca/mxgpu_llvm/lib:/opt/mxdriver/lib:$LD_LIBRARY_PATH
-export LD_PRELOAD=/opt/maca/lib/libsymbol_cu.so
-
-export FLAGOS_METAX_CUDART_SHIM=1
-export FLAGOS_METAX_COMPAT=1
-export GEMS_VENDOR=metax
-export FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_metax_flagos_py.conf
-export FLAGGEMS_SOURCE_DIR=$(python -c "import os,flag_gems;print(os.path.dirname(flag_gems.__file__))")
-```
-
-#### MetaX 运行时说明
-
-- **PyTorch + Triton 栈**：官方 `maca-pytorch` 镜像自带 `torch+metax` 与 `triton+metax`（输出 `mcfatbin`）。通用 PyTorch wheel + PyPI Triton 走 NVIDIA 后端，在 MetaX 上会报 `PTX JIT compilation failed`，需将相关算子路由到 metax C++ kernel。
-- **`flash_attn`**：预编译 MetaX `flash_attn` wheel 可能与较新 PyTorch ABI 不兼容；加载 Qwen3/transformers 前需禁用或 patch。
-- **`relu` / `sigmoid`**：当前树中未通过 `m.impl` 注册，走 cpu_fallback；除非已在 `MetaxKernels.cmake` 中启用 GPU kernel，否则不要在配置里写 `metax`。
-
-### C++ Stub-Only 模式
-
-可以完全关闭 FlagGems Python 层注册，仅使用 C++ 统一 wrapper 进行算子 dispatch。适用于验证 C++ stub 覆盖度是否完整。
-
-```bash
-# 必须：告知 FlagGems C++ native API Triton kernel 源码位置
-export FLAGGEMS_SOURCE_DIR=$(python -c "import os;import flag_gems;print(os.path.dirname(flag_gems.__file__))")
-
-python your_script.py
-```
-
-此模式下所有算子 dispatch 由 C++ dispatch stub（`backends.conf` 路由）处理，不经过 FlagGems 的 Python `torch.library` 注册。
-
-### 查询状态
-
-```python
-torch_fl.flagos.is_available()       # 设备是否可用
-torch_fl.flagos.device_count()       # 设备数量
-torch_fl.flagos.current_device()     # 当前设备索引
-torch_fl.flagos.synchronize()        # 同步设备
-torch_fl.is_flaggems_enabled()       # FlagGems 算子是否已注册
-torch_fl.get_registered_ops()        # 已注册的算子列表
-```
-
-## 后端配置
-
-可以按算子粒度配置使用 FlagGems 还是 CUDA 后端执行。
-
-### 配置文件
-
-默认路径 `torch_fl/configs/backends.conf`，可通过 `FLAGOS_BACKEND_CONFIG` 环境变量覆盖：
-
-```ini
-# 格式: op_name = backend
-# backend: "flagos" | "flaggems" | "cuda"
-# 未列出的算子默认使用 flagos (FlagGems)
-mm = cuda
-bmm = flagos
-cat = cuda
-```
-
-### 环境变量覆盖
-
-单个算子可通过环境变量覆盖配置文件（优先级更高）：
-
-```bash
-# 格式: FLAGOS_OP_<op_name>=cuda|flaggems
-# 算子名中的 "." 替换为 "__"
-export FLAGOS_OP_mm=cuda
-export FLAGOS_OP_mm__out=cuda
-```
-
-### MetaX 后端配置
-
-| 文件 | 用途 |
-|------|------|
-| `torch_fl/configs/backends_metax.conf` | 所列算子全部 → `metax` C++ kernel。pytest 检测到 MetaX（`/dev/mxcd`）且未设置 `FLAGOS_BACKEND_CONFIG` 时自动选用。 |
-| `torch_fl/configs/backends_metax_flagos_py.conf` | **集成测试推荐。** 混合路由：多数计算算子 → `flagos_python`；将 Triton 不兼容算子（`mm`/`bmm`/`mean.dim`）以及分配/工厂算子（`zeros`、`scalar_tensor`、`embedding` 等）保留在 `metax`。 |
-
-示例（`backends_metax_flagos_py.conf`）：
-
-     # elementwise / inference-path ops
-     abs = flagos_python
-     add.Tensor = flagos_python
-     cos = flagos_python
-     sin = flagos_python     
-     
-     # Triton 不兼容
-     mm = metax
-     bmm = metax
-     mean.dim = metax
-     # 分配/工厂算子
-     zeros = metax
-     scalar_tensor = metax
-
-### 调试 dispatch
-
-```bash
-export FLAGOS_LOG_DISPATCH=1  # 打印每次算子 dispatch 的后端选择
-```
-
-## 测试
-
-`tests/integration/ops/` 下的测试通过 `@pytest.mark` 标记平台分类：
-
-| 标记 | 含义 | 运行时机 |
-|------|------|----------|
-| `@pytest.mark.anyplatform` | 正确性测试，所有平台都应运行 | 始终 |
-| `@pytest.mark.cuda` | CUDA/FlagGems dispatch 路由测试 | 仅 CUDA 平台 |
-| `@pytest.mark.ascend` | Ascend 后端 dispatch 测试 | 仅 Ascend 平台 |
-
-### CUDA 平台
-
-```bash
-# 算子测试（需要 FlagGems 源码用于 C++ native API）
-FLAGGEMS_SOURCE_DIR=/path_to_repos/FlagGems/src/flag_gems \
-  pytest tests/integration/ops/ -v -m "anyplatform or cuda"
-
-# Qwen3 推理测试
-FLAGGEMS_SOURCE_DIR=/path_to_repos/FlagGems/src/flag_gems \
-  pytest tests/integration/test_qwen3_infer.py -v -s
-
-# Qwen3 训练测试（单卡）
-FLAGGEMS_SOURCE_DIR=/path_to_repos/FlagGems/src/flag_gems \
-  pytest tests/integration/test_qwen3_train.py -v -s --steps 10
-
-# 仅运行 CUDA 相关测试
-pytest tests/integration/ops/ -v -m cuda
-
-# 仅运行 FlagGems (Triton) 后端测试
-pytest tests/integration/ops/ -v -m flaggems
-
-# 仅运行 FlagGems Python wrapper 测试
-pytest tests/integration/ops/ -v -m flaggems_python
-
-# 仅运行平台无关的正确性测试
-pytest tests/integration/ops/ -v -m anyplatform
-
-# FlagGems Python wrapper (flagos_python) 端到端测试
-FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_flagos_py.conf \
-  pytest tests/integration/ops/ -v
-```
-
-### MetaX 平台
-
-```bash
-# 运行时环境（见上文「MetaX 运行时环境」）
-export METAX_PATH=/opt/maca
-export PATH=/opt/maca/tools/cu-bridge/bin:/opt/maca/bin:$PATH
-export LD_LIBRARY_PATH=/opt/maca/tools/cu-bridge/lib:/opt/maca/lib:$LD_LIBRARY_PATH
-export LD_PRELOAD=/opt/maca/lib/libsymbol_cu.so
-export FLAGOS_METAX_CUDART_SHIM=1
-export FLAGOS_METAX_COMPAT=1
-export GEMS_VENDOR=metax
-export FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_metax_flagos_py.conf
-export FLAGGEMS_SOURCE_DIR=$(python -c "import os,flag_gems;print(os.path.dirname(flag_gems.__file__))")
-
-# 基础算子测试（含 Qwen3 推理路径：cos/sin/rsqrt/silu 等）
-pytest tests/integration/test_ops.py -v
-
-# 逐算子 dispatch 测试（混合配置）
-pytest tests/integration/ops/ -v
-
-# Qwen3 推理
-pytest tests/integration/test_qwen3_infer.py -v -s --model /path/to/Qwen3-0.6B
-
-# Qwen3 训练（单卡）
-pytest tests/integration/test_qwen3_train.py -v -s --steps 10
-
-# 纯 metax C++ kernel 模式（不走 flagos_python）
-FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_metax.conf \
-  FLAGOS_DISABLE_FLAGGEMS_PY=1 \
-  pytest tests/integration/test_ops.py -v
-```
-
-未设置 `FLAGOS_BACKEND_CONFIG` 时，`tests/integration/conftest.py` 会在 MetaX 硬件上自动选择 `torch_fl/configs/backends_metax.conf`。
-
-### Ascend 平台
-
-```bash
-# 算子测试
-FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_ascend.conf \
-  pytest tests/integration/ops/ -v -m "anyplatform or ascend"
-
-# Qwen3 推理测试
-FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_ascend.conf \
-  pytest tests/integration/test_qwen3_infer.py -v -s
-
-# Qwen3 训练测试（单卡）
-FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_ascend.conf \
-  pytest tests/integration/test_qwen3_train.py -v -s --steps 10
-```
-
-`test_qwen3_infer.py` 和 `test_qwen3_train.py` 在所有平台上使用相同代码，仅安装方式（`ACCELERATOR=ascend pip install -e .`）和运行时环境变量不同。
-
-### Pytest Marks
-
-`tests/integration/ops/` 中的算子测试使用 pytest mark 标记平台/后端依赖：
-
-| Mark | 说明 |
-|------|------|
-| `@pytest.mark.anyplatform` | 平台无关的正确性测试（shape、dtype、broadcast） |
-| `@pytest.mark.cuda` | 需要 CUDA 后端或 CUDA 参考对比 |
-| `@pytest.mark.flaggems` | 需要 FlagGems (Triton) 后端 |
-| `@pytest.mark.flaggems_python` | 需要 FlagGems Python wrapper (pybind11 路径) |
-| `@pytest.mark.ascend` | 需要 Ascend NPU 后端 |
-
-使用 `-m <mark>` 运行特定类别的测试，例如：`pytest tests/integration/ops/ -m cuda` 仅运行 CUDA 测试。
-
-## 项目结构
-
-```
-PyTorch-Plugin-FL/
-├── include/                  # 公共头文件
-│   ├── flagos.h              #   统一 runtime API（memory、stream、device）
-│   └── macros.h              #   通用宏定义
-├── csrc/
-│   ├── aten/                 # ATen 算子层
-│   │   ├── common.{h,cc}     #   后端配置加载、Backend 枚举
-│   │   ├── dispatcher.h      #   轻量算子 dispatcher（替代 PyTorch DispatchStub）
-│   │   ├── device_boxing.h   #   零拷贝 flagos↔CUDA tensor 元数据转换
-│   │   ├── register.cc       #   PrivateUse1 dispatch key 注册
-│   │   ├── {op}.{h,cc}       #   各算子 stub 定义（add、mm、silu 等）
-│   │   └── backends/         #   后端特定 kernel 实现
-│   │       ├── cuda/         #     CUDA kernel（cuBLAS、修改版 PyTorch kernel）
-│   │       ├── flagos/       #     FlagGems C++ native API wrapper
-│   │       └── ascend/       #     Ascend kernel（ACL NN API）
-│   └── runtime/              # 设备运行时
-│       ├── device_allocator  #   设备内存分配器
-│       ├── host_allocator    #   pinned memory 分配器
-│       ├── guard             #   DeviceGuard 实现
-│       ├── generator         #   RNG generator
-│       ├── hooks             #   运行时 hook
-│       └── accelerator/      #   硬件抽象层
-│           ├── cuda/         #     CUDA runtime 实现
-│           ├── maca/         #     MACA cudart shim（符号版本兼容）
-│           └── ascend/       #     Ascend runtime（基于 ACL 的 memory、stream、device）
-├── torch_fl/
-│   ├── __init__.py           # 插件入口：注册设备、加载 FlagGems 算子
-│   ├── flagos/               # Python 设备模块（stream、event、RNG、AMP）
-│   ├── accelerator/          # Python accelerator 模块（MACA shim 加载器）
-│   ├── backends.conf                  # 默认后端路由配置（CUDA/FlagGems）
-│   ├── backends_metax.conf            # MetaX：所列算子 → metax
-│   ├── backends_metax_flagos_py.conf  # MetaX 混合：metax + flagos_python
-│   ├── backends_flagos_py.conf        # FlagGems Python 封装路由
-│   ├── backends_ascend.conf           # Ascend 后端路由（所有算子 → ascend）
-│   ├── distributed.py        # 分布式训练支持（DDP patch）
-│   ├── integration.py        # FlagGems 算子注册逻辑
-│   ├── csrc/                 # C 扩展（module.cc、stub.c）
-│   └── lib/                  # 编译后的共享库（libtorch_fl.so、libflagos.so）
-├── tests/
-│   ├── integration/          # 自动化集成测试
-│   │   ├── ops/              #   各算子 dispatch 测试
-│   │   ├── test_qwen3_*.py   #   端到端模型测试
-│   │   └── conftest.py       #   Pytest 配置
-│   ├── manual/               # 手动测试脚本
-│   └── common/               # 测试工具
-├── debug/                    # 开发笔记和调试脚本
-├── cmake/                    # CMake 模块
-├── setup.py                  # CMake 构建入口
-└── pyproject.toml
-```
-
-## 架构概览
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│  Python: import torch_fl                                     │
-│  ┌────────────────┐  ┌────────────────────────────┐          │
-│  │ torch_fl.flagos│  │ torch_fl.distributed       │          │
-│  │ (device API)   │  │ (DDP/FSDP patch)           │          │
-│  └────────────────┘  └────────────────────────────┘          │
-├──────────────────────────────────────────────────────────────┤
-│  PrivateUse1 Dispatch                                        │
-│  ┌─────────────┐  ┌──────────┐  ┌───────────┐  ┌────────┐    │
-│  │ FlagGems    │  │ CUDA     │  │ Ascend    │  │ CPU    │    │
-│  │ (Triton)    │  │ (native) │  │ (ACL NN)  │  │fallback│    │
-│  └─────────────┘  └──────────┘  └───────────┘  └────────┘    │
-├──────────────────────────────────────────────────────────────┤
-│  C++ Runtime (csrc/)                                         │
-│  ┌──────────┐ ┌────────┐ ┌───────┐ ┌───────────┐             │
-│  │Allocator │ │ Guard  │ │ RNG   │ │ Hooks     │             │
-│  └──────────┘ └────────┘ └───────┘ └───────────┘             │
-├──────────────────────────────────────────────────────────────┤
-│  Hardware Abstraction (accelerator/)                         │
-│  ┌──────────────┐  ┌─────────────────────┐  ┌────────────┐   │
-│  │ CUDA Runtime │  │ MetaX cu-bridge+shim │  │ Ascend ACL │   │
-│  └──────────────┘  └─────────────────────┘  └────────────┘   │
-└──────────────────────────────────────────────────────────────┘
-```
+以上致谢不代表所列项目或厂商对 torch-fl 的认可或背书。
 
 ## 许可证
 
-Apache-2.0
+torch-fl 使用 [Apache License 2.0](LICENSE) 许可证。


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Update the localized Chinese project overview to match the redesigned English README, and restrict runner-backed CI to changes that can affect code, tests, scripts, builds, platform configs, or workflows.

## Summary
Replace the outdated implementation-focused Chinese README with a localized counterpart of the current project README. Change the main CI workflow from a small documentation ignore list to an explicit path allowlist, so unrelated PRs do not consume runner capacity while all source, test, script, build, CI, and platform-config changes still trigger validation.

## Change Type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [ ] Testing
- [x] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [x] Platform-agnostic (all platforms)

## Problem Analysis
### What was broken/missing?
The Chinese README described an older 2.11-era implementation and supported only three platforms, while the English README now documents the unified architecture, PyTorch 2.10 line, and broader platform matrix. The CI workflow used `paths-ignore`, so many non-runtime files outside the ignore list could still launch the full runner matrix.

### Why did it happen?
The localized README was not updated during the English README redesign. The workflow exclusion model enumerated selected documentation paths instead of defining the files that can actually affect CI results.

### Investigation process:
1. Compared `README_zh.md` with the current `README.md` structure, versions, capabilities, and platform table.
2. Reviewed the main workflow and repository directories that feed source, tests, scripts, builds, platform discovery, and reusable workflows.
3. Validated the resulting workflow as YAML and checked every intended trigger path appears in both push and pull-request filters.

## Solution Design
### Implementation approach:
Translate and synchronize the Chinese README at the same project-overview level as the English README. Replace `paths-ignore` with explicit `paths` entries for `cmake`, `csrc`, `include`, `scripts`, all of `tests`, `torch_fl`, build metadata, platform configs, CI scripts, and workflows.

### Key design decisions:
All test changes remain CI-triggering, including integration, manual, performance, and unit tests. Workflow and platform configuration changes also trigger CI because they can alter runner behavior even without modifying runtime source.

### Code changes by file:
- `README.md`: Add a live CI status badge for the `main` branch.
- `README_zh.md`: Replace stale build-centric content with the current localized project overview and add the same live CI status badge.
- `.github/workflows/ci.yml`: Use explicit trigger paths for code, tests, scripts, build files, platform configs, CI scripts, and workflows.

### Changes by commit:
1. `d08e48b` - `docs: update Chinese README and CI paths`: Update localization and runner trigger rules.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (not applicable)
- [x] **All tests pass** (runtime tests not applicable; no runtime source changed)
- [x] **Manual testing completed**
- [x] **No debug/temporary code**
- [x] **Documentation updated**
- [x] **Commit messages follow conventions**
- [x] **All GitHub-facing text in English**

### Linting Results
```bash
$ python3 -m ruff check .
All checks passed!

$ python3 -m ruff format --check .
156 files already formatted
```

### Test Results
```bash
# Runtime tests not run: this PR changes one localized README and workflow path filters only.
```

### Manual Verification
```bash
$ python3 -m yamllint -d '{extends: default, rules: {document-start: disable, line-length: disable, truthy: disable}}' .github/workflows/ci.yml
# No output

$ python3 - <<'PY'
import yaml
from pathlib import Path
assert yaml.safe_load(Path(".github/workflows/ci.yml").read_text())
print("workflow YAML parsed")
PY
workflow YAML parsed

$ git diff --check flagos/main...HEAD
# No output
```

## Code Quality Verification
### Style Consistency
- [x] Matched existing documentation style
- [x] Followed workflow naming conventions
- [x] Comment density matches surrounding files
- [x] Used native GitHub Actions path filters

### Edge Cases Considered
1. Changes anywhere under `tests/**`, not only unit tests, trigger CI.
2. Reusable workflows, CI scripts, and platform matrix configs trigger CI.
3. Documentation, templates, licenses, and unrelated repository metadata do not launch the runner matrix by themselves.

### Potential Risks
1. A future code-bearing top-level directory must be added to the allowlist.
2. Required-check branch protection must account for workflows intentionally skipped by path filtering.

### Rollback Plan
Revert commit `d08e48b` to restore the prior README and `paths-ignore` behavior.

## Related Work
- Related to #96 and #97.

## Explicitly Not Included
- No runtime source, generated bindings, tests, or scripts are changed.
- No platform capability claims beyond the current English README are introduced.

## Human Review Notes
### Areas needing special attention:
1. Confirm the Chinese terminology accurately represents the current English README.
2. Confirm every runner-relevant directory is present in the CI allowlist.
3. Confirm intentionally skipped PRs do not conflict with required-check branch protection.

### Questions for reviewer:
1. None.

## Additional Context
The allowlist intentionally includes the entire `tests/**` tree.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

