### PR TITLE
fix: preserve module parameters without global swap mode

### DIFF
--- a/csrc/aten/register.cc
+++ b/csrc/aten/register.cc
@@ -365,7 +365,24 @@ static std::tuple<at::Tensor, at::Tensor> WrapperMatmulBackward(
 }
 #endif
 
+bool HasCompatibleShallowCopyType(
+    const at::Tensor& self, const at::Tensor& from) {
+  const auto self_keys = self.key_set();
+  const auto from_keys = from.key_set();
+  const auto is_dense = [](c10::DispatchKeySet keys) {
+    return keys.has(c10::DispatchKey::CPU) ||
+        keys.has(c10::DispatchKey::PrivateUse1);
+  };
+  return self_keys == from_keys || (is_dense(self_keys) && is_dense(from_keys));
+}
+
 } // namespace
+
+TORCH_LIBRARY_IMPL(aten, CatchAll, m) {
+  m.impl(
+      "_has_compatible_shallow_copy_type",
+      TORCH_FN(HasCompatibleShallowCopyType));
+}
 
 // Register basic operators for PrivateUse1 dispatch key
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {

--- a/tests/integration/test_factory_ops.py
+++ b/tests/integration/test_factory_ops.py
@@ -177,6 +177,45 @@ class TestShapeOps:
 
 
 class TestCopyTransfer:
+    def test_cpu_and_device_have_compatible_shallow_copy_types(self, device):
+        cpu_tensor = torch.ones(1)
+        device_tensor = cpu_tensor.to(device)
+
+        assert torch._has_compatible_shallow_copy_type(cpu_tensor, device_tensor)
+        assert torch._has_compatible_shallow_copy_type(device_tensor, cpu_tensor)
+
+    def test_module_to_device_preserves_tied_parameters(self, device):
+        previous = torch.__future__.get_swap_module_params_on_conversion()
+        torch.__future__.set_swap_module_params_on_conversion(False)
+
+        class TiedParameters(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.first = torch.nn.Linear(4, 4, bias=False)
+                self.second = torch.nn.Linear(4, 4, bias=False)
+                self.second.weight = self.first.weight
+
+        try:
+            model = TiedParameters().to(device)
+            assert model.first.weight is model.second.weight
+            assert not torch.__future__.get_swap_module_params_on_conversion()
+        finally:
+            torch.__future__.set_swap_module_params_on_conversion(previous)
+
+    def test_module_cpu_after_forward(self, device):
+        model = torch.nn.Sequential(
+            torch.nn.Linear(8, 8),
+            torch.nn.ReLU(),
+            torch.nn.Linear(8, 8),
+        ).to(device)
+        output = model(torch.randn(4, 8, device=device)).sum()
+
+        model.cpu()
+
+        assert output.grad_fn is not None
+        assert all(parameter.device.type == "cpu" for parameter in model.parameters())
+        assert not torch.__future__.get_swap_module_params_on_conversion()
+
     def test_to_cpu(self, device):
         x = torch.randn(4, 4, device=device)
         assert x.cpu().device.type == "cpu"

--- a/tests/unit/test_module_conversion.py
+++ b/tests/unit/test_module_conversion.py
@@ -1,0 +1,20 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch_fl  # noqa: F401
+
+
+def test_import_does_not_enable_swap_module_params_globally():
+    assert not torch.__future__.get_swap_module_params_on_conversion()

--- a/torch_fl/__init__.py
+++ b/torch_fl/__init__.py
@@ -440,13 +440,6 @@ torch.utils.generate_methods_for_privateuse1_backend(for_storage=True)
 # rename, not a stub. Harmless on backends that never trigger lazy init.
 sys.modules.setdefault("torch_flagos", flagos)
 
-# Enable swap_tensors in Module._apply so that .to("flagos") preserves weight
-# tying.  Without this, _apply creates new Parameter objects for PrivateUse1
-# tensors (since _has_compatible_shallow_copy_type returns False for cross-device),
-# breaking shared-storage relationships like lm_head.weight ↔ embed_tokens.weight.
-# swap_tensors modifies the Parameter in-place, keeping object identity intact.
-torch.__future__.set_swap_module_params_on_conversion(True)
-
 
 # Global library instance to keep registrations alive
 _flaggems_lib = None


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Investigated issue #80, reproduced the interaction between the global module-conversion swap flag and autograd parameter references, then implemented the same dispatcher-level compatibility strategy used by torch-npu.

## Summary
This fixes module CPU offload after a flagos forward pass without monkeypatching `torch.nn.Module`. CPU and PrivateUse1 tensors are now considered compatible shallow-copy types, allowing PyTorch's native `Module._apply()` `set_data` path to preserve shared `Parameter` identity. The process-global swap future flag is no longer enabled during `torch_fl` import.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [x] CUDA
- [x] MetaX
- [x] Ascend
- [x] PPU
- [x] Platform-agnostic (all PrivateUse1 platforms)

## Problem Analysis
### What was broken/missing?
`torch_fl` enabled `torch.__future__.set_swap_module_params_on_conversion(True)` globally at import time. After a model performed a forward pass, autograd could retain an additional parameter reference. A later `model.cpu()` then entered `torch.utils.swap_tensors()` and failed because its use-count precondition was no longer satisfied.

### Why did it happen?
The global flag was introduced to preserve tied `Parameter` objects when moving modules between CPU and flagos. Without an explicit compatibility rule, PyTorch considered CPU and PrivateUse1 tensors incompatible for shallow-copy assignment and replaced `Parameter` objects. Global swap mode solved that identity problem but changed every later `Module._apply()` conversion in the process, including flagos-to-CPU offload after autograd had built a graph.

### Investigation process:
1. Reproduced issue #80 and confirmed that a post-forward parameter had a use count of 3 when `model.cpu()` reached `swap_tensors()`.
2. Traced PyTorch 2.10 `Module._apply()` and identified `_has_compatible_shallow_copy_type` as the predicate selecting the native `param.data = param_applied` path.
3. Compared torch-npu's PrivateUse1 implementation and adopted its dispatcher-level CPU/PrivateUse1 dense compatibility rule instead of wrapping `Module.to()` or toggling global process state.

## Solution Design
### Implementation approach:
Register a CatchAll implementation of `aten::_has_compatible_shallow_copy_type` that treats CPU and PrivateUse1 tensors as compatible dense tensor types. Remove the import-time global swap-mode mutation. Add a hardware-independent import-state regression and hardware-backed integration coverage for compatibility, tied parameters, and post-forward CPU conversion.

### Key design decisions:
The fix belongs in the dispatcher compatibility predicate because this is the exact extension point used by `Module._apply()` to determine whether `Parameter.data` can be updated while preserving identity. This keeps PyTorch's public module methods untouched and avoids process-global state, exception restoration, and concurrency hazards associated with scoped monkeypatches.

### Code changes by file:
- `csrc/aten/register.cc`: Register CPU/PrivateUse1 shallow-copy compatibility with `aten::_has_compatible_shallow_copy_type`.
- `torch_fl/__init__.py`: Remove import-time activation of the global module-parameter swap flag.
- `tests/unit/test_module_conversion.py`: Verify importing `torch_fl` leaves the global swap flag disabled.
- `tests/integration/test_factory_ops.py`: Verify cross-device shallow-copy compatibility, tied-parameter identity, and CPU offload after a forward pass.

### Changes by commit:
1. `156abb4` - `fix: preserve module parameters without global swap mode`: Implements the dispatcher fix and all regressions.

## Verification
### Pre-submission Checklist
- [x] **Linting passed**
- [ ] **Type checking passed** (not configured for this C++/Python change)
- [ ] **All tests pass** (focused tests pass; hardware integration cannot run because this host reports zero flagos devices; the full unit suite reaches an unrelated device-dependent profiler abort)
- [ ] **Manual testing completed** (the original hardware reproduction cannot run on this zero-device host)
- [x] **No debug/temporary code**
- [x] **Documentation updated** (not required; no public API change)
- [x] **Commit messages follow conventions**
- [x] **All text in English**

### Linting Results
```bash
$ conda run -n torch-fl-210 python -m ruff check .
All checks passed!

$ conda run -n torch-fl-210 python -m ruff format --check .
157 files already formatted
```

### Test Results
```bash
$ conda run -n torch-fl-210 python -m pytest tests/unit/test_module_conversion.py -v --tb=short
collected 1 item

tests/unit/test_module_conversion.py::test_import_does_not_enable_swap_module_params_globally PASSED [100%]

============================== 1 passed in 3.94s ===============================

$ conda run -n torch-fl-210 python -m pytest tests/integration/test_factory_ops.py -v --tb=short
Exit: flagos device is not available.

$ conda run -n torch-fl-210 python -m pytest tests/unit/ -v --tb=short
...
tests/unit/test_module_conversion.py::test_import_does_not_enable_swap_module_params_globally PASSED [82%]
tests/unit/test_profiler_privateuse1.py::test_guard_stream_is_real_not_synthetic
Fatal Python error: Aborted
# The device-dependent profiler test aborts in torch.accelerator.current_stream()
# on this host, which reports flagos device count 0.
```

### Build Results
```bash
$ ACCELERATOR=cuda CUDA_KERNEL=1 CUDA_HOME=/usr/local/cuda \
    conda run -n torch-fl-210 python -m pip install --no-build-isolation -v -e .
[100%] Built target torch_bindings
Successfully built torch_fl
Successfully installed torch_fl-0.1.0
```

### Manual Verification
```bash
$ conda run -n torch-fl-210 python -c \
  'import torch_fl, torch; print("devices", torch_fl.flagos.device_count()); print("swap", torch.__future__.get_swap_module_params_on_conversion()); print("cpu_cpu", torch._has_compatible_shallow_copy_type(torch.ones(1), torch.ones(1)))'
devices 0
swap False
cpu_cpu True
```

The original issue and the new CPU-to-flagos integration regressions require a platform runner. `tests/integration/test_factory_ops.py` is already executed by the CUDA, DCU, Ascend, and MetaX general-test CI jobs.

## Code Quality Verification
### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions
- [x] Comment density matches surrounding code
- [x] Used PyTorch's existing dispatcher extension point

### Edge Cases Considered
1. CPU-to-flagos and flagos-to-CPU compatibility are both asserted.
2. Shared `Parameter` object identity remains intact during module conversion.
3. A live autograd graph exists when converting the model back to CPU.
4. Importing `torch_fl` does not modify process-global future behavior.

### Potential Risks
1. CatchAll registration overrides PyTorch's composite implementation; the implementation preserves the original exact-key-set behavior and only expands compatibility to CPU/PrivateUse1 dense pairs.
2. Hardware behavior must be validated by platform CI because the local host has no available flagos device.

### Rollback Plan
Revert commit `156abb4` to restore the previous global swap-mode behavior.

## Related Work
- Fixes #80

## Explicitly Not Included
- No monkeypatch or wrapper around `torch.nn.Module.to()`, `.cpu()`, or `.flagos()`.
- No changes to generated operator files or backend configuration.
- No changes to PyTorch's swap implementation.

## Human Review Notes
### Areas needing special attention:
1. Confirm the CatchAll compatibility rule is appropriate for every PrivateUse1 vendor backend.
2. Confirm CUDA and at least one non-CUDA platform CI exercise all three new integration regressions.
3. Review whether the dispatcher override warning is acceptable and consistent with torch-npu's implementation.

### Questions for reviewer:
1. Should the compatibility implementation remain in central `register.cc`, or be split into a dedicated operator source file later?

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
