### PR TITLE
fix(boxing): preserve CPU indices and restore devices

### DIFF
--- a/csrc/aten/generated/cuda_kernels.cc
+++ b/csrc/aten/generated/cuda_kernels.cc
@@ -5546,20 +5546,15 @@ at::Tensor & PrivTritonScaledDotAttentionOutKernelCuda(const at::Tensor & q, con
 }
 
 at::Tensor PrivUnsafeIndexTensorKernelCuda(const at::Tensor & self, const c10::List<::std::optional<at::Tensor>> & indices) {
-  BoxToCuda(self);
-  std::vector<at::Tensor> boxed_holders;
+  DeviceBoxingGuard self_guard(self);
+  TensorListBoxingGuard indices_guard;
   for (int64_t i = 0; i < static_cast<int64_t>(indices.size()); ++i) {
     auto opt = indices.get(i);
-    if (opt.has_value() && opt->defined()) {
-      BoxToCuda(*opt);
-      boxed_holders.push_back(*opt);
+    if (opt.has_value()) {
+      indices_guard.box({*opt});
     }
   }
   auto result = at::_unsafe_index(self, indices);
-  UnboxToFlagos(self);
-  for (auto& t : boxed_holders) {
-    UnboxToFlagos(t);
-  }
   UnboxToFlagos(result);
   return result;
 }
@@ -9846,20 +9841,15 @@ at::Tensor & Im2colOutKernelCuda(const at::Tensor & self, at::IntArrayRef kernel
 }
 
 at::Tensor IndexTensorKernelCuda(const at::Tensor & self, const c10::List<::std::optional<at::Tensor>> & indices) {
-  BoxToCuda(self);
-  std::vector<at::Tensor> boxed_holders;
+  DeviceBoxingGuard self_guard(self);
+  TensorListBoxingGuard indices_guard;
   for (int64_t i = 0; i < static_cast<int64_t>(indices.size()); ++i) {
     auto opt = indices.get(i);
-    if (opt.has_value() && opt->defined()) {
-      BoxToCuda(*opt);
-      boxed_holders.push_back(*opt);
+    if (opt.has_value()) {
+      indices_guard.box({*opt});
     }
   }
   auto result = at::index(self, indices);
-  UnboxToFlagos(self);
-  for (auto& t : boxed_holders) {
-    UnboxToFlagos(t);
-  }
   UnboxToFlagos(result);
   return result;
 }

--- a/scripts/codegen_ops.py
+++ b/scripts/codegen_ops.py
@@ -1926,20 +1926,15 @@ def gen_optlist(op, fn_type, ret_type, args, func=None):
     list_name = args[1][1]
     api = f"at::{at_api_base(op)}"
     return f"""{ret_type} {kn}({args_decl(args)}) {{
-  BoxToCuda({self_name});
-  std::vector<at::Tensor> boxed_holders;
+  DeviceBoxingGuard self_guard({self_name});
+  TensorListBoxingGuard indices_guard;
   for (int64_t i = 0; i < static_cast<int64_t>({list_name}.size()); ++i) {{
     auto opt = {list_name}.get(i);
-    if (opt.has_value() && opt->defined()) {{
-      BoxToCuda(*opt);
-      boxed_holders.push_back(*opt);
+    if (opt.has_value()) {{
+      indices_guard.box({{*opt}});
     }}
   }}
   auto result = {api}({self_name}, {list_name});
-  UnboxToFlagos({self_name});
-  for (auto& t : boxed_holders) {{
-    UnboxToFlagos(t);
-  }}
   UnboxToFlagos(result);
   return result;
 }}"""

--- a/tests/integration/ops/test_index_dispatch.py
+++ b/tests/integration/ops/test_index_dispatch.py
@@ -1,0 +1,88 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for CPU indices through the CUDA boxing kernels."""
+
+import pytest
+import torch
+import torch_fl  # noqa: F401
+
+
+DEVICE = "flagos:0"
+
+
+class TestIndexTensor:
+    @pytest.mark.anyplatform
+    def test_cpu_index(self):
+        q_cpu = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+        q = q_cpu.to(DEVICE)
+        index = torch.tensor([0, 2])
+
+        torch.testing.assert_close(q[index].cpu(), q_cpu[index])
+
+    @pytest.mark.anyplatform
+    def test_flagos_index(self):
+        q_cpu = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+        q = q_cpu.to(DEVICE)
+        index_cpu = torch.tensor([0, 2])
+        index = index_cpu.to(DEVICE)
+
+        torch.testing.assert_close(q[index].cpu(), q_cpu[index_cpu])
+
+    @pytest.mark.anyplatform
+    def test_multiple_cpu_indices(self):
+        q_cpu = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+        q = q_cpu.to(DEVICE)
+        index = torch.tensor([0, 2])
+
+        torch.testing.assert_close(q[index, index].cpu(), q_cpu[index, index])
+
+    @pytest.mark.anyplatform
+    def test_whisper_mixed_indices(self):
+        torch.manual_seed(0)
+        logits_cpu = torch.randn(1, 5, 99)
+        logits = logits_cpu.to(DEVICE)
+        positions = torch.arange(5)
+        token_ids_cpu = torch.randint(0, 99, (5,))
+        token_ids = token_ids_cpu.to(DEVICE)
+
+        actual = logits[:, positions, token_ids].cpu()
+        expected = logits_cpu[:, positions, token_ids_cpu]
+        torch.testing.assert_close(actual, expected)
+
+    @pytest.mark.anyplatform
+    def test_unsafe_index_with_cpu_index(self):
+        q_cpu = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+        q = q_cpu.to(DEVICE)
+        index = torch.tensor([0, 2])
+
+        actual = torch.ops.aten._unsafe_index.Tensor(q, [None, index])
+        expected = torch.ops.aten._unsafe_index.Tensor(q_cpu, [None, index])
+        torch.testing.assert_close(actual.cpu(), expected)
+
+    @pytest.mark.anyplatform
+    def test_invalid_index_restores_devices(self):
+        q_cpu = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+        q = q_cpu.to(DEVICE)
+        bad_index = torch.ones(2, device=DEVICE)
+
+        with pytest.raises((RuntimeError, IndexError)):
+            torch.ops.aten.index.Tensor(q, [bad_index])
+
+        assert q.device.type == "flagos"
+        assert bad_index.device.type == "flagos"
+        torch.testing.assert_close((q + 1).cpu(), q_cpu + 1)
+        torch.testing.assert_close(
+            (bad_index + 1).cpu(), torch.ones(2, dtype=bad_index.dtype) + 1
+        )


### PR DESCRIPTION
## Summary

Fixes the CUDA-boxing dispatch for `aten::index.Tensor` and `aten::_unsafe_index.Tensor`. CPU index tensors now remain on the host, while PrivateUse1 inputs are restored reliably on both successful and exceptional paths, preventing invalid device metadata from contaminating subsequent operations.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [x] CUDA
- [x] MetaX
- [ ] Ascend
- [ ] PPU
- [ ] Platform-agnostic

## Detailed Description

### Problem

The generated optional-index-list kernels unconditionally called `BoxToCuda` for every defined index tensor. Legal CPU indices were therefore mislabeled as CUDA tensors, and exceptions from the underlying indexing operation skipped the manual unboxing sequence, leaving mutated device metadata behind.

### Solution

- Use `DeviceBoxingGuard` for the indexed tensor.
- Use `TensorListBoxingGuard` for optional index tensors, which boxes only PrivateUse1 tensors.
- Rely on RAII restoration during normal returns and stack unwinding.
- Regenerate the two affected CUDA boxing kernels.
- Add integration coverage for CPU, flagos, mixed Whisper-style, `_unsafe_index`, and exception-cleanup cases.

### Changes by Commit
1. `37d7275`: Preserve CPU indices and restore boxed devices with RAII guards.

## Testing

### Test Coverage
- [x] Unit tests added/updated
- [x] Integration tests pass
- [x] Manual testing completed

### Test Commands
```bash
ruff check .
ruff format --check .

LD_LIBRARY_PATH=".maca_full_so:build/csrc:build/lib.linux-x86_64-cpython-312/torch_fl/lib:/opt/maca/lib:/opt/maca/lib64:${LD_LIBRARY_PATH:-}" \
PYTHONPATH="build/lib.linux-x86_64-cpython-312:." \
FLAGOS_DISABLE_CUDA_ASSETS=1 \
FLAGOS_METAX_BOXING=1 \
python -m pytest tests/integration/ops/test_index_dispatch.py -v
```

### Test Results
```text
ruff 0.15.12
All checks passed!
157 files already formatted

6 passed in 0.10s

Transformers v5.12.1 Whisper assisted-decoding subset:
6 passed, 646 deselected in 8.12s
```

`WhisperStandaloneDecoderModelTest::test_assisted_decoding_sample` passed independently in 4.43s. The full generator was also run twice with `FLAGOS_CODEGEN_ALL=1`; the second run produced identical output. Environment-dependent FlagGems/codegen churn unrelated to these two kernels was excluded from the commit.

## Verification

### Pre-merge Checklist
- [x] All tests pass (see test results above)
- [x] Code follows project style (ran linters)
- [x] Documentation updated (not applicable)
- [x] CLAUDE.md updated (not applicable)
- [x] Commit messages follow conventions
- [x] No debug code or temporary changes
- [x] PR description is in **English** (required per CLAUDE.md)

### Linting
```text
ruff check .              -> All checks passed!
ruff format --check .     -> 157 files already formatted
```

## Explicitly Not Included
- No changes to indexing semantics outside the CUDA ABI boxing path.
- No unrelated generated changes caused by local FlagGems/schema discovery.

## Related Issues/PRs
Fixes #86

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
