### PR TITLE
feat: add MUSA distributed collectives via FlagCX and MCCL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,33 @@ Use standard templates:
 
 See `CONTRIBUTING.md` for detailed contribution guidelines.
 
+### Strict upstream branch policy
+
+**Never create, push, update, or delete a feature branch on an upstream repository.**
+Upstream remotes are read-only for feature development, including when the current
+account happens to have write access.
+
+Before pushing any feature branch:
+
+1. Inspect `git remote -v` and identify the contributor fork and the upstream repository.
+2. Push the feature branch only to the contributor fork (normally `origin`):
+   ```bash
+   git push origin <feature-branch>
+   ```
+3. Create the pull request from `<fork-owner>:<feature-branch>` into the upstream
+   repository's `main` branch:
+   ```bash
+   gh pr create \
+     --repo <upstream-owner>/<upstream-repo> \
+     --head <fork-owner>:<feature-branch> \
+     --base main
+   ```
+4. If a feature branch was accidentally created on the upstream repository, stop,
+   report it, and clean it up only as part of an explicitly authorized correction.
+
+Do **not** run `git push <upstream> <feature-branch>` for ordinary development. A
+successful push is not evidence that the push was appropriate.
+
 ## Commit Message Format
 
 All commits should follow this format:

--- a/docs/vendors/musa/installation.md
+++ b/docs/vendors/musa/installation.md
@@ -167,7 +167,16 @@ MUSA has no CI runner (no `.github/configs/musa.yml` config exists), so all test
 
 ### Distributed support
 
-Distributed collectives are not validated on MUSA hardware. The architecture recommends the FlagCX-only path unless live evidence proves more. See [`docs/architecture/distributed-flagcx.md`](../../architecture/distributed-flagcx.md).
+**Status**: Implementation complete, multi-card validation pending.
+
+MUSA distributed communication routes through FlagCX via the identity view path. The `_flagos_identity_view` binding passes privateuseone tensors directly to FlagCX's MUSA adaptor without storage conversion, since FlagCX extracts `data_ptr()` and `musaStream_t` without validating `device().type()`.
+
+Single-card unit tests pass. Multi-card verification requires:
+- 2+ MUSA cards
+- FlagCX built with MUSA adaptor enabled
+- `tests/manual/test_comm_device_index.py --world-size 2`
+
+No native MCCL fallback is wired; if FlagCX initialization fails, `init_process_group` will raise. See [`docs/architecture/distributed-flagcx.md`](../../architecture/distributed-flagcx.md) for the ProcessGroupFlagOS routing architecture.
 
 ### Profiler and torch.compile not validated
 

--- a/tests/manual/musa/README.md
+++ b/tests/manual/musa/README.md
@@ -1,0 +1,183 @@
+# MUSA Distributed Communication Testing Guide
+
+## Overview
+
+This directory contains manual tests for MUSA distributed communication via FlagCX. These tests verify that the identity view integration works correctly with real multi-GPU workloads.
+
+## Prerequisites
+
+1. **Hardware**: 2+ Moore Threads MUSA GPUs (e.g., MTT S5000)
+2. **Software**:
+   - MUSA toolkit (mudnn + musart runtime)
+   - FlagCX built with MUSA adaptor support
+   - torch_fl built with `ACCELERATOR=musa`
+   - transformers library (for Qwen3 tests)
+
+## Building FlagCX with MUSA Support
+
+```bash
+# Clone FlagCX
+git clone https://github.com/FlagOpen/FlagCX.git
+cd FlagCX
+
+# Build with MUSA adaptor
+mkdir build && cd build
+cmake .. -DADAPTOR_MUSA=ON
+make -j$(nproc)
+
+# The MUSA adaptor libraries will be in build/lib/
+export LD_LIBRARY_PATH=$PWD/lib:$LD_LIBRARY_PATH
+```
+
+## Test Suite
+
+### 1. Basic Collectives (`test_comm_musa.py`)
+
+Tests all fundamental collective operations that DDP and FSDP2 depend on:
+- `all_reduce` (DDP gradient sync)
+- `broadcast` (parameter initialization)
+- `all_gather` / `all_gather_into_tensor` (FSDP parameter gather)
+- `reduce_scatter` / `reduce_scatter_tensor` (FSDP gradient reduction)
+- `barrier` (synchronization)
+
+**Run:**
+```bash
+LD_LIBRARY_PATH=<flagcx-build/lib> \
+    python tests/manual/musa/test_comm_musa.py --world-size 2
+```
+
+**Expected output:**
+```
+[rank 0] inner backend = ProcessGroupFlagCX
+[rank 0] all_reduce -> 3.0 (expect 3.0) OK
+[rank 0] broadcast -> [0.0, 1.0, 2.0, 3.0] OK
+[rank 0] all_gather -> [1.0, 2.0] OK
+[rank 0] all_gather_into_tensor -> [0.0, 1.0] OK
+[rank 0] reduce_scatter_tensor -> [0.0, 2.0] (expect [0.0, 2.0]) OK
+[rank 0] barrier OK
+[rank 0] result device flagos:0 OK
+=== MUSA FlagCX collectives: all checks passed ===
+```
+
+### 2. DDP Training (`test_ddp_musa.py`)
+
+Tests DistributedDataParallel with a 3-layer MLP. Verifies:
+- DDP construction on flagos tensors
+- Python reducer path activation
+- Gradient synchronization across ranks
+- Loss convergence
+
+**Run:**
+```bash
+LD_LIBRARY_PATH=<flagcx-build/lib> \
+    python tests/manual/musa/test_ddp_musa.py --world-size 2 --steps 5
+```
+
+**Expected output:**
+```
+[setup] world_size=2 backend=ProcessGroupFlagCX
+[rank 0] DDP _use_python_reducer=True hooks=5
+[step 0] loss=2.3456 grad_sum=['12.345', '12.345'] synced=OK
+[step 1] loss=2.1234 grad_sum=['10.123', '10.123'] synced=OK
+...
+=== MUSA DDP: 5 steps, losses=['2.346', '2.123', ...], finite=OK decreasing=OK ===
+```
+
+### 3. FSDP2 Training (`test_fsdp2_musa.py`)
+
+Tests PyTorch's FSDP2 (Fully Sharded Data Parallel) with a 3-layer MLP. Verifies:
+- FSDP2 `fully_shard()` succeeds on flagos
+- Forward/backward with sharded parameters
+- Correct use of `_allgather_base` and `_reduce_scatter_base`
+- Loss convergence
+
+**Run:**
+```bash
+LD_LIBRARY_PATH=<flagcx-build/lib> \
+    python tests/manual/musa/test_fsdp2_musa.py --world-size 2 --steps 10
+```
+
+**Expected output:**
+```
+[setup] world_size=2 backend=ProcessGroupFlagCX
+[rank 0] FSDP2 model initialized, total params=332810
+[step 0] loss(per-rank)=['2.4567', '2.3210']
+[step 1] loss(per-rank)=['2.1234', '2.0987']
+...
+=== MUSA FSDP2: 10 steps, losses(rank0)=['2.457', '2.123', ...], finite=OK decreasing=OK ===
+```
+
+### 4. Qwen3 DDP (`test_qwen3_ddp_musa.py`)
+
+End-to-end test with a real transformer model (Qwen3-0.6B). Verifies that DDP gradient synchronization works correctly with a production-scale model.
+
+**Run:**
+```bash
+HF_HOME=<your-hf-cache-dir> HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+LD_LIBRARY_PATH=<flagcx-build/lib> \
+    python tests/manual/musa/test_qwen3_ddp_musa.py --world-size 2 --steps 5
+```
+
+**Expected output:**
+```
+[setup] world_size=2 backend=ProcessGroupFlagCX
+[setup] loading Qwen3 model from Qwen/Qwen3-0.6B
+[rank 0] DDP _use_python_reducer=True hooks=124
+[step 0] loss=10.2345 grad_sum(per-rank)=['123.456', '123.456'] synced=OK
+[step 1] loss=9.8765 grad_sum(per-rank)=['98.765', '98.765'] synced=OK
+...
+=== MUSA Qwen3 DDP: 5 steps, losses=['10.235', '9.877', ...], finite=OK ===
+```
+
+## Debugging
+
+### FlagCX Initialization Failure
+
+If you see:
+```
+RuntimeError: FlagCX init failed: no suitable inner backend
+```
+
+**Check:**
+1. `LD_LIBRARY_PATH` includes FlagCX build/lib
+2. `ldd` on the flagcx Python module shows libflagcx.so resolves
+3. `GEMS_VENDOR=musa` is set (auto-detected from `torch_fl/lib/flagos_platform`)
+
+### Device Type Mismatch
+
+If FlagCX complains about device type:
+```
+RuntimeError: expected CUDA tensor but got PrivateUse1
+```
+
+This means the identity view path failed. **Check:**
+1. `torch_fl/comm/process_group.py` has `"musa": _VendorProfile("musa", "_flagos_identity_view", None)`
+2. `torch_fl._C._flagos_identity_view` is callable: `python -c "import torch_fl; print(hasattr(torch_fl._C, '_flagos_identity_view'))"`
+
+### Stream/Device Index Issues
+
+If you see GPU faults or "invalid resource handle":
+```
+VMFault at address 0x...
+```
+
+This likely means device index pinning failed. **Check:**
+1. The test calls `torch_fl.flagos.set_device(rank)`, not just `torch.cuda.set_device(rank)`
+2. Run `tests/manual/test_comm_device_index.py` first to verify device pinning works
+
+## Performance Notes
+
+- MUSA FlagCX → MCCL should achieve near-native bandwidth for large tensors (>1MB)
+- Small tensor collectives may be slower than NCCL due to launch overhead
+- Identity view has zero overhead (no storage conversion)
+
+## Comparison with CUDA/MetaX
+
+The MUSA tests mirror the structure of:
+- `tests/manual/test_flagos_dist_live.py` (CUDA baseline)
+- `tests/manual/metax/test_*_metax.py` (MetaX FlagCX tests)
+
+Key differences:
+- MUSA uses **identity view** (no storage conversion)
+- CUDA/MetaX use **zero-copy cuda view** (storage reinterpretation)
+- Both paths share the same FlagCX → vendor CCL backend logic

--- a/tests/manual/musa/test_comm_musa.py
+++ b/tests/manual/musa/test_comm_musa.py
@@ -1,0 +1,153 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Basic collective communication tests for MUSA via FlagCX identity view.
+
+Tests all fundamental collectives that FSDP2 and DDP depend on:
+  - all_reduce (DDP gradient sync)
+  - broadcast (parameter initialization)
+  - all_gather / all_gather_into_tensor (FSDP parameter gather)
+  - reduce_scatter / reduce_scatter_tensor (FSDP gradient reduction)
+  - barrier (synchronization)
+
+Verifies:
+  1. FlagCX (MUSA adaptor) init succeeds with identity view
+  2. Tensors stay on flagos device through the round trip
+  3. Numerical results match expected collective semantics
+  4. Device index is correctly pinned (no cross-device stream hazards)
+
+Usage:
+    LD_LIBRARY_PATH=<flagcx build/lib> \
+        python tests/manual/musa/test_comm_musa.py --world-size 2
+"""
+
+import argparse
+import os
+
+# torch_fl MUST be imported before torch (registers MUSA backend)
+import torch_fl  # noqa: F401
+import torch
+
+try:
+    import flagcx  # noqa: F401 -- self-registers "flagcx" backend (MUSA adaptor)
+except ImportError:
+    flagcx = None
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def worker(rank: int, world_size: int):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29618")
+
+    dev = torch.device(f"flagos:{rank}")
+    # MUSA: flagos:i is PrivateUse1 device i, shares physical GPU i
+    torch_fl.flagos.set_device(rank)
+
+    dist.init_process_group(backend="flagos", rank=rank, world_size=world_size)
+
+    inner = type(getattr(dist.distributed_c10d._get_default_group(), "_inner", None))
+    print(f"[rank {rank}] inner backend = {inner.__name__}", flush=True)
+
+    failures = []
+
+    # --- all_reduce (DDP gradient synchronization) ---
+    t = torch.ones(4, device=dev, dtype=torch.float32) * (rank + 1)
+    dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    expected_sum = float(sum(range(1, world_size + 1)))
+    got = t.cpu()[0].item()
+    ok_ar = abs(got - expected_sum) < 1e-5
+    failures += [] if ok_ar else [f"all_reduce got {got} want {expected_sum}"]
+    print(
+        f"[rank {rank}] all_reduce -> {got} (expect {expected_sum}) "
+        f"{'OK' if ok_ar else 'FAIL'}",
+        flush=True,
+    )
+
+    # --- broadcast (parameter initialization) ---
+    b = torch.arange(4, device=dev, dtype=torch.float32) + rank * 10
+    dist.broadcast(b, src=0)
+    expected_bc = list(range(4))
+    ok_bc = b.cpu().tolist() == expected_bc
+    failures += [] if ok_bc else [f"broadcast got {b.cpu().tolist()} want {expected_bc}"]
+    print(f"[rank {rank}] broadcast -> {b.cpu().tolist()} {'OK' if ok_bc else 'FAIL'}", flush=True)
+
+    # --- all_gather (parameter gathering) ---
+    src = torch.ones(2, device=dev, dtype=torch.float32) * (rank + 1)
+    gathered = [torch.zeros(2, device=dev) for _ in range(world_size)]
+    dist.all_gather(gathered, src)
+    vals = [g[0].item() for g in gathered]
+    expected_ag = [float(i + 1) for i in range(world_size)]
+    ok_ag = vals == expected_ag
+    failures += [] if ok_ag else [f"all_gather got {vals} want {expected_ag}"]
+    print(f"[rank {rank}] all_gather -> {vals} {'OK' if ok_ag else 'FAIL'}", flush=True)
+
+    # --- all_gather_into_tensor (_allgather_base: FSDP parameter gather) ---
+    agb = torch.empty(world_size, device=dev, dtype=torch.float32)
+    dist.all_gather_into_tensor(agb, torch.full((1,), float(rank), device=dev))
+    expected_agb = [float(i) for i in range(world_size)]
+    ok_agb = agb.cpu().tolist() == expected_agb
+    failures += [] if ok_agb else [f"all_gather_into_tensor got {agb.cpu().tolist()} want {expected_agb}"]
+    print(
+        f"[rank {rank}] all_gather_into_tensor -> {agb.cpu().tolist()} "
+        f"{'OK' if ok_agb else 'FAIL'}",
+        flush=True,
+    )
+
+    # --- reduce_scatter_tensor (_reduce_scatter_base: FSDP gradient reduction) ---
+    # Each rank contributes the same arange, so rank r's output shard is
+    # world_size * arange[2*r : 2*r+2]
+    rs_in = torch.arange(2 * world_size, dtype=torch.float32, device=dev)
+    rs_out = torch.empty(2, device=dev, dtype=torch.float32)
+    dist.reduce_scatter_tensor(rs_out, rs_in)
+    exp_rs = [float(world_size) * (2 * rank), float(world_size) * (2 * rank + 1)]
+    ok_rs = rs_out.cpu().tolist() == exp_rs
+    failures += [] if ok_rs else [f"reduce_scatter_tensor got {rs_out.cpu().tolist()} want {exp_rs}"]
+    print(
+        f"[rank {rank}] reduce_scatter_tensor -> {rs_out.cpu().tolist()} "
+        f"(expect {exp_rs}) {'OK' if ok_rs else 'FAIL'}",
+        flush=True,
+    )
+
+    # --- barrier (synchronization primitive) ---
+    dist.barrier()
+    print(f"[rank {rank}] barrier OK", flush=True)
+
+    # --- device consistency check ---
+    # Result tensors must stay on flagos:rank, not leak to flagos:0 or CPU
+    ok_dev = t.device.type == "flagos" and t.device.index == rank
+    failures += [] if ok_dev else [f"result on {t.device}, want flagos:{rank}"]
+    print(
+        f"[rank {rank}] result device {t.device} {'OK' if ok_dev else 'FAIL'}",
+        flush=True,
+    )
+
+    if failures:
+        raise AssertionError(f"[rank {rank}] " + "; ".join(failures))
+
+    dist.destroy_process_group()
+    if rank == 0:
+        print("=== MUSA FlagCX collectives: all checks passed ===", flush=True)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--world-size", type=int, default=2)
+    args = ap.parse_args()
+    if torch_fl.flagos.device_count() < args.world_size:
+        raise SystemExit(
+            f"needs {args.world_size} flagos devices, "
+            f"have {torch_fl.flagos.device_count()}"
+        )
+    mp.spawn(worker, args=(args.world_size,), nprocs=args.world_size, join=True)

--- a/tests/manual/musa/test_comm_musa.py
+++ b/tests/manual/musa/test_comm_musa.py
@@ -80,8 +80,13 @@ def worker(rank: int, world_size: int):
     dist.broadcast(b, src=0)
     expected_bc = list(range(4))
     ok_bc = b.cpu().tolist() == expected_bc
-    failures += [] if ok_bc else [f"broadcast got {b.cpu().tolist()} want {expected_bc}"]
-    print(f"[rank {rank}] broadcast -> {b.cpu().tolist()} {'OK' if ok_bc else 'FAIL'}", flush=True)
+    failures += (
+        [] if ok_bc else [f"broadcast got {b.cpu().tolist()} want {expected_bc}"]
+    )
+    print(
+        f"[rank {rank}] broadcast -> {b.cpu().tolist()} {'OK' if ok_bc else 'FAIL'}",
+        flush=True,
+    )
 
     # --- all_gather (parameter gathering) ---
     src = torch.ones(2, device=dev, dtype=torch.float32) * (rank + 1)
@@ -98,7 +103,11 @@ def worker(rank: int, world_size: int):
     dist.all_gather_into_tensor(agb, torch.full((1,), float(rank), device=dev))
     expected_agb = [float(i) for i in range(world_size)]
     ok_agb = agb.cpu().tolist() == expected_agb
-    failures += [] if ok_agb else [f"all_gather_into_tensor got {agb.cpu().tolist()} want {expected_agb}"]
+    failures += (
+        []
+        if ok_agb
+        else [f"all_gather_into_tensor got {agb.cpu().tolist()} want {expected_agb}"]
+    )
     print(
         f"[rank {rank}] all_gather_into_tensor -> {agb.cpu().tolist()} "
         f"{'OK' if ok_agb else 'FAIL'}",
@@ -113,7 +122,11 @@ def worker(rank: int, world_size: int):
     dist.reduce_scatter_tensor(rs_out, rs_in)
     exp_rs = [float(world_size) * (2 * rank), float(world_size) * (2 * rank + 1)]
     ok_rs = rs_out.cpu().tolist() == exp_rs
-    failures += [] if ok_rs else [f"reduce_scatter_tensor got {rs_out.cpu().tolist()} want {exp_rs}"]
+    failures += (
+        []
+        if ok_rs
+        else [f"reduce_scatter_tensor got {rs_out.cpu().tolist()} want {exp_rs}"]
+    )
     print(
         f"[rank {rank}] reduce_scatter_tensor -> {rs_out.cpu().tolist()} "
         f"(expect {exp_rs}) {'OK' if ok_rs else 'FAIL'}",

--- a/tests/manual/musa/test_ddp_musa.py
+++ b/tests/manual/musa/test_ddp_musa.py
@@ -66,7 +66,9 @@ def worker(rank: int, world_size: int, steps: int):
     dist.init_process_group(backend="flagos", rank=rank, world_size=world_size)
 
     if rank == 0:
-        inner = type(getattr(dist.distributed_c10d._get_default_group(), "_inner", None))
+        inner = type(
+            getattr(dist.distributed_c10d._get_default_group(), "_inner", None)
+        )
         print(f"[setup] world_size={world_size} backend={inner.__name__}", flush=True)
 
     # --- Build a small 3-layer MLP ---
@@ -151,4 +153,6 @@ if __name__ == "__main__":
         )
 
     mp.set_start_method("spawn", force=True)
-    mp.spawn(worker, args=(args.world_size, args.steps), nprocs=args.world_size, join=True)
+    mp.spawn(
+        worker, args=(args.world_size, args.steps), nprocs=args.world_size, join=True
+    )

--- a/tests/manual/musa/test_ddp_musa.py
+++ b/tests/manual/musa/test_ddp_musa.py
@@ -1,0 +1,154 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DDP forward/backward test for MUSA via FlagCX.
+
+Verifies that DistributedDataParallel correctly synchronizes gradients across
+MUSA devices using ProcessGroupFlagOS → FlagCX (MUSA adaptor) → MCCL.
+
+Tests:
+  1. DDP construction on flagos tensors succeeds
+  2. DDP picks python_reducer path and installs accum-grad hooks
+  3. After backward, gradients are identical across all ranks
+  4. Loss remains finite and decreases over training steps
+
+Usage:
+    LD_LIBRARY_PATH=<flagcx build/lib> \
+        python tests/manual/musa/test_ddp_musa.py --world-size 2 --steps 5
+"""
+
+import argparse
+import os
+
+# torch_fl MUST be imported before torch
+import torch_fl  # noqa: F401
+import torch
+
+try:
+    import flagcx  # noqa: F401 -- self-registers "flagcx" backend (MUSA adaptor)
+except ImportError:
+    flagcx = None
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel
+
+
+def _hash_grads(model):
+    """Deterministic scalar summary of all gradients for cross-rank comparison."""
+    total = 0.0
+    n = 0
+    for name, p in sorted(model.named_parameters()):
+        if p.grad is not None:
+            total += p.grad.double().sum().item()
+            n += p.grad.numel()
+    return total, n
+
+
+def worker(rank: int, world_size: int, steps: int):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29619")
+
+    dev = torch.device(f"flagos:{rank}")
+    torch_fl.flagos.set_device(rank)
+
+    dist.init_process_group(backend="flagos", rank=rank, world_size=world_size)
+
+    if rank == 0:
+        inner = type(getattr(dist.distributed_c10d._get_default_group(), "_inner", None))
+        print(f"[setup] world_size={world_size} backend={inner.__name__}", flush=True)
+
+    # --- Build a small 3-layer MLP ---
+    torch.manual_seed(42)  # same initial weights across ranks
+    model = nn.Sequential(
+        nn.Linear(128, 256),
+        nn.ReLU(),
+        nn.Linear(256, 256),
+        nn.ReLU(),
+        nn.Linear(256, 10),
+    ).to(dev)
+
+    ddp = DistributedDataParallel(model)
+    print(
+        f"[rank {rank}] DDP _use_python_reducer={ddp._use_python_reducer} "
+        f"hooks={len(ddp._accum_grad_hooks)}",
+        flush=True,
+    )
+    assert ddp._use_python_reducer, "flagos DDP must use python_reducer"
+    assert len(ddp._accum_grad_hooks) > 0, "no accum-grad hooks installed"
+
+    optimizer = torch.optim.SGD(ddp.parameters(), lr=0.01)
+
+    losses = []
+    # Each rank sees DIFFERENT data (real data parallelism)
+    torch.manual_seed(100 + rank)
+
+    for step in range(steps):
+        x = torch.randn(16, 128, device=dev)
+        y = torch.randint(0, 10, (16,), device=dev)
+
+        out = ddp(x)
+        loss = nn.functional.cross_entropy(out, y)
+        loss.backward()
+
+        # Verify gradients synchronized across ranks
+        gsum, gn = _hash_grads(ddp.module)
+        buf = torch.tensor([gsum], device=dev, dtype=torch.float64)
+        gathered = [torch.zeros_like(buf) for _ in range(world_size)]
+        dist.all_gather(gathered, buf)
+        vals = [g.item() for g in gathered]
+        synced = max(abs(v - vals[0]) for v in vals) < 1e-3
+
+        if rank == 0:
+            print(
+                f"[step {step}] loss={loss.item():.4f} "
+                f"grad_sum={[f'{v:.3f}' for v in vals]} "
+                f"synced={'OK' if synced else 'FAIL'}",
+                flush=True,
+            )
+
+        assert synced, f"grads diverge at step {step}: {vals}"
+
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+        losses.append(loss.item())
+
+    dist.barrier()
+
+    if rank == 0:
+        finite = all(abs(x) < 1e6 for x in losses)
+        decreasing = losses[-1] < losses[0]
+        print(
+            f"=== MUSA DDP: {steps} steps, losses={['%.3f' % x for x in losses]}, "
+            f"finite={'OK' if finite else 'FAIL'} decreasing={'OK' if decreasing else 'FAIL'} ===",
+            flush=True,
+        )
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--world-size", type=int, default=2)
+    ap.add_argument("--steps", type=int, default=5)
+    args = ap.parse_args()
+
+    if torch_fl.flagos.device_count() < args.world_size:
+        raise SystemExit(
+            f"needs {args.world_size} MUSA devices, "
+            f"have {torch_fl.flagos.device_count()}"
+        )
+
+    mp.set_start_method("spawn", force=True)
+    mp.spawn(worker, args=(args.world_size, args.steps), nprocs=args.world_size, join=True)

--- a/tests/manual/musa/test_fsdp2_musa.py
+++ b/tests/manual/musa/test_fsdp2_musa.py
@@ -61,7 +61,9 @@ def worker(rank: int, world_size: int, steps: int):
     dist.init_process_group(backend="flagos", rank=rank, world_size=world_size)
 
     if rank == 0:
-        inner = type(getattr(dist.distributed_c10d._get_default_group(), "_inner", None))
+        inner = type(
+            getattr(dist.distributed_c10d._get_default_group(), "_inner", None)
+        )
         print(f"[setup] world_size={world_size} backend={inner.__name__}", flush=True)
 
     # --- Build a 3-layer MLP and apply FSDP2 ---
@@ -88,7 +90,10 @@ def worker(rank: int, world_size: int, steps: int):
 
     if rank == 0:
         param_count = sum(p.numel() for p in model.parameters())
-        print(f"[rank {rank}] FSDP2 model initialized, total params={param_count}", flush=True)
+        print(
+            f"[rank {rank}] FSDP2 model initialized, total params={param_count}",
+            flush=True,
+        )
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
 
@@ -110,7 +115,7 @@ def worker(rank: int, world_size: int, steps: int):
         dist.all_gather(gathered_losses, loss_buf)
 
         if rank == 0:
-            loss_vals = [l.item() for l in gathered_losses]
+            loss_vals = [t.item() for t in gathered_losses]
             print(
                 f"[step {step}] loss(per-rank)={['%.4f' % v for v in loss_vals]}",
                 flush=True,
@@ -148,4 +153,6 @@ if __name__ == "__main__":
         )
 
     mp.set_start_method("spawn", force=True)
-    mp.spawn(worker, args=(args.world_size, args.steps), nprocs=args.world_size, join=True)
+    mp.spawn(
+        worker, args=(args.world_size, args.steps), nprocs=args.world_size, join=True
+    )

--- a/tests/manual/musa/test_fsdp2_musa.py
+++ b/tests/manual/musa/test_fsdp2_musa.py
@@ -1,0 +1,151 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FSDP2 training test for MUSA via FlagCX.
+
+Verifies that PyTorch's FSDP2 (fully sharded data parallel) works correctly on
+MUSA devices through ProcessGroupFlagOS → FlagCX (MUSA adaptor) → MCCL.
+
+FSDP2 requires:
+  - all_gather_into_tensor (_allgather_base) for parameter unshard
+  - reduce_scatter_tensor (_reduce_scatter_base) for gradient shard
+  - all_reduce for optimizer state sync (optional, not tested here)
+
+Tests:
+  1. FSDP2 fully_shard() succeeds on flagos tensors
+  2. Forward/backward with sharded parameters completes
+  3. Gradients are correctly reduced and sharded across ranks
+  4. Loss converges over training steps
+
+Usage:
+    LD_LIBRARY_PATH=<flagcx build/lib> \
+        python tests/manual/musa/test_fsdp2_musa.py --world-size 2 --steps 10
+"""
+
+import argparse
+import os
+
+# torch_fl MUST be imported before torch
+import torch_fl  # noqa: F401
+import torch_fl.distributed as flagos_dist
+import torch
+
+try:
+    import flagcx  # noqa: F401 -- self-registers "flagcx" backend (MUSA adaptor)
+except ImportError:
+    flagcx = None
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+from torch.distributed._composable.fsdp import fully_shard
+
+
+def worker(rank: int, world_size: int, steps: int):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29620")
+
+    dev = torch.device(f"flagos:{rank}")
+    torch_fl.flagos.set_device(rank)
+
+    dist.init_process_group(backend="flagos", rank=rank, world_size=world_size)
+
+    if rank == 0:
+        inner = type(getattr(dist.distributed_c10d._get_default_group(), "_inner", None))
+        print(f"[setup] world_size={world_size} backend={inner.__name__}", flush=True)
+
+    # --- Build a 3-layer MLP and apply FSDP2 ---
+    torch.manual_seed(42)  # same initial weights across ranks
+
+    class MLP(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = nn.Linear(128, 512)
+            self.fc2 = nn.Linear(512, 512)
+            self.fc3 = nn.Linear(512, 10)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            return self.fc3(self.relu(self.fc2(self.relu(self.fc1(x)))))
+
+    model = MLP().to(dev)
+    flagos_dist.move_buffers_to_device(model, dev)
+
+    # Apply FSDP2 sharding to each layer separately
+    for layer in [model.fc1, model.fc2, model.fc3]:
+        fully_shard(layer)
+    fully_shard(model)  # root FSDP wrapper
+
+    if rank == 0:
+        param_count = sum(p.numel() for p in model.parameters())
+        print(f"[rank {rank}] FSDP2 model initialized, total params={param_count}", flush=True)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+    losses = []
+    # Each rank sees DIFFERENT data (real data parallelism)
+    torch.manual_seed(200 + rank)
+
+    for step in range(steps):
+        x = torch.randn(16, 128, device=dev)
+        y = torch.randint(0, 10, (16,), device=dev)
+
+        out = model(x)
+        loss = nn.functional.cross_entropy(out, y)
+        loss.backward()
+
+        # Gather loss values to rank 0 for monitoring
+        loss_buf = torch.tensor([loss.item()], device=dev, dtype=torch.float32)
+        gathered_losses = [torch.zeros_like(loss_buf) for _ in range(world_size)]
+        dist.all_gather(gathered_losses, loss_buf)
+
+        if rank == 0:
+            loss_vals = [l.item() for l in gathered_losses]
+            print(
+                f"[step {step}] loss(per-rank)={['%.4f' % v for v in loss_vals]}",
+                flush=True,
+            )
+
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+        losses.append(loss.item())
+
+    dist.barrier()
+
+    if rank == 0:
+        finite = all(abs(x) < 1e6 for x in losses)
+        decreasing = losses[-1] < losses[0] + 0.1  # allow for noise
+        print(
+            f"=== MUSA FSDP2: {steps} steps, losses(rank0)={['%.4f' % x for x in losses]}, "
+            f"finite={'OK' if finite else 'FAIL'} decreasing={'OK' if decreasing else 'FAIL'} ===",
+            flush=True,
+        )
+        assert finite, "loss diverged"
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--world-size", type=int, default=2)
+    ap.add_argument("--steps", type=int, default=10)
+    args = ap.parse_args()
+
+    if torch_fl.flagos.device_count() < args.world_size:
+        raise SystemExit(
+            f"needs {args.world_size} MUSA devices, "
+            f"have {torch_fl.flagos.device_count()}"
+        )
+
+    mp.set_start_method("spawn", force=True)
+    mp.spawn(worker, args=(args.world_size, args.steps), nprocs=args.world_size, join=True)

--- a/tests/manual/musa/test_qwen3_ddp_musa.py
+++ b/tests/manual/musa/test_qwen3_ddp_musa.py
@@ -1,0 +1,167 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3 DDP training test for MUSA via FlagCX.
+
+End-to-end test with a real transformer model (Qwen3-0.6B) to verify that DDP
+gradient synchronization works correctly on MUSA through FlagCX.
+
+Requires:
+    - Qwen3-0.6B model checkpoint (downloaded via HuggingFace)
+    - transformers library
+    - 2+ MUSA GPUs
+
+Usage:
+    HF_HOME=<your-hf-cache-dir> HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
+    LD_LIBRARY_PATH=<flagcx build/lib> \
+        python tests/manual/musa/test_qwen3_ddp_musa.py --world-size 2 --steps 5
+"""
+
+import argparse
+import os
+
+# torch_fl MUST be imported before torch
+import torch_fl  # noqa: F401
+import torch_fl.distributed as flagos_dist
+import torch
+
+try:
+    import flagcx  # noqa: F401 -- self-registers "flagcx" backend (MUSA adaptor)
+except ImportError:
+    flagcx = None
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.nn.parallel import DistributedDataParallel
+
+
+def _hash_grads(model):
+    """Deterministic scalar summary of all grads, order-stable across ranks."""
+    total = 0.0
+    n = 0
+    for name, p in sorted(model.named_parameters()):
+        if p.grad is not None:
+            total += p.grad.double().sum().item()
+            n += p.grad.numel()
+    return total, n
+
+
+def worker(rank: int, world_size: int, model_path: str, steps: int, seq_len: int):
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29621")
+
+    dev = torch.device(f"flagos:{rank}")
+    torch_fl.flagos.set_device(rank)
+
+    dist.init_process_group(backend="flagos", rank=rank, world_size=world_size)
+    if rank == 0:
+        inner = type(getattr(dist.distributed_c10d._get_default_group(), "_inner", None))
+        print(f"[setup] world_size={world_size} backend={inner.__name__}", flush=True)
+
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    if rank == 0:
+        print(f"[setup] loading Qwen3 model from {model_path}", flush=True)
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path,
+        torch_dtype=torch.float32,
+        device_map="cpu",
+        attn_implementation="eager",
+    ).to(dev)
+    model.train()
+    flagos_dist.move_buffers_to_device(model, dev)
+
+    ddp = DistributedDataParallel(model)
+    print(
+        f"[rank {rank}] DDP _use_python_reducer={ddp._use_python_reducer} "
+        f"hooks={len(ddp._accum_grad_hooks)}",
+        flush=True,
+    )
+    assert ddp._use_python_reducer, "flagos DDP must use python_reducer"
+    assert len(ddp._accum_grad_hooks) > 0, "no accum-grad hooks installed"
+
+    optimizer = torch.optim.AdamW(
+        [p for p in ddp.parameters() if p.requires_grad], lr=1e-4
+    )
+
+    # Each rank sees a DIFFERENT batch (real DDP data parallelism)
+    torch.manual_seed(1234 + rank)
+    losses = []
+
+    for step in range(steps):
+        input_ids = torch.randint(0, 1000, (2, seq_len), device=dev)
+        labels = input_ids.clone()
+
+        out = ddp(input_ids=input_ids, labels=labels, use_cache=False)
+        loss = out.loss
+        loss.backward()
+
+        # Verify gradients synchronized across ranks
+        gsum, gn = _hash_grads(ddp.module)
+        buf = torch.tensor([gsum], device=dev, dtype=torch.float64)
+        gathered = [torch.zeros_like(buf) for _ in range(world_size)]
+        dist.all_gather(gathered, buf)
+        vals = [g.item() for g in gathered]
+        synced = max(abs(v - vals[0]) for v in vals) < 1e-3
+
+        if rank == 0:
+            print(
+                f"[step {step}] loss={loss.item():.4f} "
+                f"grad_sum(per-rank)={[f'{v:.3f}' for v in vals]} "
+                f"synced={'OK' if synced else 'FAIL'}",
+                flush=True,
+            )
+        assert synced, f"grads diverge at step {step}: {vals}"
+
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+        losses.append(loss.item())
+
+    dist.barrier()
+    if rank == 0:
+        finite = all(abs(x) < 1e6 for x in losses)
+        print(
+            f"=== MUSA Qwen3 DDP: {steps} steps, losses={['%.3f' % x for x in losses]}, "
+            f"finite={'OK' if finite else 'FAIL'} ===",
+            flush=True,
+        )
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--world-size", type=int, default=2)
+    ap.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    ap.add_argument("--steps", type=int, default=5)
+    ap.add_argument("--seq-len", type=int, default=128)
+    args = ap.parse_args()
+
+    if torch_fl.flagos.device_count() < args.world_size:
+        raise SystemExit(
+            f"needs {args.world_size} MUSA devices, "
+            f"have {torch_fl.flagos.device_count()}"
+        )
+
+    mp.set_start_method("spawn", force=True)
+    mp.spawn(
+        worker,
+        args=(args.world_size, args.model, args.steps, args.seq_len),
+        nprocs=args.world_size,
+        join=True,
+    )

--- a/tests/manual/musa/test_qwen3_ddp_musa.py
+++ b/tests/manual/musa/test_qwen3_ddp_musa.py
@@ -65,7 +65,9 @@ def worker(rank: int, world_size: int, model_path: str, steps: int, seq_len: int
 
     dist.init_process_group(backend="flagos", rank=rank, world_size=world_size)
     if rank == 0:
-        inner = type(getattr(dist.distributed_c10d._get_default_group(), "_inner", None))
+        inner = type(
+            getattr(dist.distributed_c10d._get_default_group(), "_inner", None)
+        )
         print(f"[setup] world_size={world_size} backend={inner.__name__}", flush=True)
 
     from transformers import AutoModelForCausalLM, AutoTokenizer

--- a/tests/manual/test_musa_routing_live.py
+++ b/tests/manual/test_musa_routing_live.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Live test of MUSA vendor routing in ProcessGroupFlagOS.
+
+This test verifies that:
+1. GEMS_VENDOR=musa is correctly recognized
+2. MUSA profile uses identity view
+3. Routing logic attempts FlagCX then MCCL
+4. Appropriate error messages when backends unavailable
+
+Does NOT require actual multi-GPU communication, just backend initialization.
+"""
+
+import os
+import sys
+import warnings
+
+# Force MUSA vendor
+os.environ['GEMS_VENDOR'] = 'musa'
+
+
+def test_musa_profile():
+    """Verify MUSA vendor profile configuration."""
+    from torch_fl.comm.process_group import _VENDOR_PROFILES, _get_profile
+
+    print("=" * 60)
+    print("Test 1: MUSA Vendor Profile")
+    print("=" * 60)
+
+    # Check MUSA profile exists
+    assert 'musa' in _VENDOR_PROFILES, "MUSA profile missing"
+
+    prof = _get_profile('musa')
+    print(f"✓ MUSA profile found")
+    print(f"  flagcx_dev: {prof.flagcx_dev}")
+    print(f"  view: {prof.view}")
+    print(f"  native: {prof.native}")
+
+    assert prof.flagcx_dev == "musa", f"Wrong flagcx_dev: {prof.flagcx_dev}"
+    assert prof.view == "_flagos_identity_view", f"Wrong view: {prof.view}"
+    assert prof.native == "_try_build_mccl", f"Wrong native: {prof.native}"
+
+    print("✓ MUSA profile correct: musa + identity view + MCCL fallback")
+
+
+def test_identity_view_binding():
+    """Verify _flagos_identity_view C++ binding is accessible."""
+    import torch
+    import torch_fl
+
+    print("\n" + "=" * 60)
+    print("Test 2: Identity View Binding")
+    print("=" * 60)
+
+    torch_fl._C._init()
+
+    # Test identity view
+    t = torch.randn(3, 4, device='flagos:0')
+    viewed = torch_fl._C._flagos_identity_view(t)
+
+    assert viewed is t, "Identity view must return same object"
+    assert viewed.data_ptr() == t.data_ptr(), "Data pointer must match"
+
+    print(f"✓ _flagos_identity_view works correctly")
+    print(f"  Same object: {viewed is t}")
+    print(f"  Same data_ptr: {hex(viewed.data_ptr())} == {hex(t.data_ptr())}")
+
+
+def test_backend_routing():
+    """Test ProcessGroupFlagOS initialization routing logic."""
+    import torch
+    import torch_fl
+    from torch_fl.comm.process_group import ProcessGroupFlagOS
+
+    print("\n" + "=" * 60)
+    print("Test 3: Backend Routing Logic")
+    print("=" * 60)
+
+    torch_fl._C._init()
+
+    # Attempt to create ProcessGroupFlagOS
+    # This will fail because neither FlagCX nor MCCL backend is available,
+    # but we can verify the error message is correct for MUSA
+    try:
+        # Mock store for testing (won't actually communicate)
+        from torch.distributed import TCPStore
+        store = TCPStore("127.0.0.1", 0, 1, True)
+
+        pg = ProcessGroupFlagOS(store, 0, 1)
+        print("✗ Unexpected success - should have failed with no backend")
+        sys.exit(1)
+    except RuntimeError as e:
+        error_msg = str(e)
+        print(f"✓ Got expected RuntimeError")
+        print(f"  Message: {error_msg}")
+
+        # Verify error message mentions MUSA and MCCL
+        assert "GEMS_VENDOR='musa'" in error_msg, \
+            f"Error should mention MUSA vendor: {error_msg}"
+        assert "_try_build_mccl" in error_msg, \
+            f"Error should mention MCCL fallback: {error_msg}"
+
+        print("✓ Error message correctly identifies MUSA and MCCL requirement")
+
+
+def main():
+    print("MUSA Vendor Routing Live Test")
+    print("=" * 60)
+    print(f"GEMS_VENDOR: {os.environ.get('GEMS_VENDOR')}")
+    print("=" * 60)
+
+    try:
+        test_musa_profile()
+        test_identity_view_binding()
+        test_backend_routing()
+
+        print("\n" + "=" * 60)
+        print("ALL TESTS PASSED")
+        print("=" * 60)
+        print("\nSummary:")
+        print("  ✓ MUSA vendor profile correctly configured")
+        print("  ✓ Identity view binding accessible and working")
+        print("  ✓ Routing logic attempts FlagCX → MCCL for MUSA")
+        print("\nTo enable actual distributed communication:")
+        print("  - Install FlagCX with MUSA adaptor, OR")
+        print("  - Install torch_musa with ProcessGroupMCCL")
+
+    except Exception as e:
+        print(f"\n✗ TEST FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/manual/test_musa_routing_live.py
+++ b/tests/manual/test_musa_routing_live.py
@@ -12,10 +12,9 @@ Does NOT require actual multi-GPU communication, just backend initialization.
 
 import os
 import sys
-import warnings
 
 # Force MUSA vendor
-os.environ['GEMS_VENDOR'] = 'musa'
+os.environ["GEMS_VENDOR"] = "musa"
 
 
 def test_musa_profile():
@@ -27,10 +26,10 @@ def test_musa_profile():
     print("=" * 60)
 
     # Check MUSA profile exists
-    assert 'musa' in _VENDOR_PROFILES, "MUSA profile missing"
+    assert "musa" in _VENDOR_PROFILES, "MUSA profile missing"
 
-    prof = _get_profile('musa')
-    print(f"✓ MUSA profile found")
+    prof = _get_profile("musa")
+    print("✓ MUSA profile found")
     print(f"  flagcx_dev: {prof.flagcx_dev}")
     print(f"  view: {prof.view}")
     print(f"  native: {prof.native}")
@@ -54,20 +53,19 @@ def test_identity_view_binding():
     torch_fl._C._init()
 
     # Test identity view
-    t = torch.randn(3, 4, device='flagos:0')
+    t = torch.randn(3, 4, device="flagos:0")
     viewed = torch_fl._C._flagos_identity_view(t)
 
     assert viewed is t, "Identity view must return same object"
     assert viewed.data_ptr() == t.data_ptr(), "Data pointer must match"
 
-    print(f"✓ _flagos_identity_view works correctly")
+    print("✓ _flagos_identity_view works correctly")
     print(f"  Same object: {viewed is t}")
     print(f"  Same data_ptr: {hex(viewed.data_ptr())} == {hex(t.data_ptr())}")
 
 
 def test_backend_routing():
     """Test ProcessGroupFlagOS initialization routing logic."""
-    import torch
     import torch_fl
     from torch_fl.comm.process_group import ProcessGroupFlagOS
 
@@ -83,21 +81,24 @@ def test_backend_routing():
     try:
         # Mock store for testing (won't actually communicate)
         from torch.distributed import TCPStore
+
         store = TCPStore("127.0.0.1", 0, 1, True)
 
-        pg = ProcessGroupFlagOS(store, 0, 1)
+        ProcessGroupFlagOS(store, 0, 1)
         print("✗ Unexpected success - should have failed with no backend")
         sys.exit(1)
     except RuntimeError as e:
         error_msg = str(e)
-        print(f"✓ Got expected RuntimeError")
+        print("✓ Got expected RuntimeError")
         print(f"  Message: {error_msg}")
 
         # Verify error message mentions MUSA and MCCL
-        assert "GEMS_VENDOR='musa'" in error_msg, \
+        assert "GEMS_VENDOR='musa'" in error_msg, (
             f"Error should mention MUSA vendor: {error_msg}"
-        assert "_try_build_mccl" in error_msg, \
+        )
+        assert "_try_build_mccl" in error_msg, (
             f"Error should mention MCCL fallback: {error_msg}"
+        )
 
         print("✓ Error message correctly identifies MUSA and MCCL requirement")
 
@@ -127,9 +128,10 @@ def main():
     except Exception as e:
         print(f"\n✗ TEST FAILED: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/unit/test_vendor_routing.py
+++ b/tests/unit/test_vendor_routing.py
@@ -42,13 +42,13 @@ def test_all_vendors_have_consistent_profiles():
     for name, prof in pg._VENDOR_PROFILES.items():
         assert prof.flagcx_dev, f"{name} missing flagcx_dev"
         # cuda-ABI vendors must expose the zero-copy cuda view + NCCL fallback;
-        # non-cuda vendors must NOT claim the cuda view (except enflame, which
-        # has view=None because FlagCX accepts PrivateUse1 directly).
+        # non-cuda vendors must NOT claim the cuda view. Enflame accepts
+        # PrivateUse1 directly; MUSA uses an explicit identity view.
         if prof.flagcx_dev == "cuda":
             assert prof.view == "_flagos_to_cuda_view", name
             assert prof.native == "_try_build_nccl", name
         else:
-            assert prof.view is None, (
+            assert prof.view in (None, "_flagos_identity_view"), (
                 f"{name} is not a cuda alias but claims view {prof.view!r}"
             )
 
@@ -187,6 +187,7 @@ def _make(monkeypatch, vendor, *, flagcx_ok, native_ok, view_present=True):
     fake_c = types.ModuleType("torch_fl._C")
     if view_present:
         fake_c._flagos_to_cuda_view = sentinel_view
+        fake_c._flagos_identity_view = sentinel_view  # same marker for identity
     monkeypatch.setitem(sys.modules, "torch_fl._C", fake_c)
     torch_fl_pkg = sys.modules.get("torch_fl")
     if torch_fl_pkg is not None:
@@ -215,6 +216,22 @@ def test_no_backend_raises(monkeypatch):
         obj._build_inner(None, 0, 1, None)
 
 
+def test_musa_flagcx_identity_view(monkeypatch):
+    """MUSA uses _flagos_identity_view: FlagCX's MUSA adaptor receives
+    privateuseone tensors as-is, no storage conversion needed."""
+    obj, calls, _ = _make(
+        monkeypatch, "musa", flagcx_ok=True, native_ok=False, view_present=True
+    )
+    # Fake the identity view helper in torch_fl._C
+    identity_marker = object()
+    fake_c = sys.modules["torch_fl._C"]
+    fake_c._flagos_identity_view = identity_marker
+
+    view_fn = obj._build_inner(None, 0, 1, None)
+    assert calls["flagcx"] and not calls["native"]
+    assert view_fn is identity_marker  # identity view resolved
+
+
 def test_musa_flagcx_only_no_native_fallback(monkeypatch):
     # musa has native=None: if flagcx fails there is nothing to fall back to.
     obj, calls, _ = _make(
@@ -225,14 +242,13 @@ def test_musa_flagcx_only_no_native_fallback(monkeypatch):
     assert not calls["native"]
 
 
-def test_musa_flagcx_ok_but_no_view_raises(monkeypatch):
-    # musa flagcx path succeeds, but no flagos->musa view is implemented and musa
-    # is not marked direct=True -> must fail loudly rather than pass a raw flagos
-    # tensor to the backend.
+def test_musa_flagcx_ok_but_identity_view_missing_raises(monkeypatch):
+    # musa profile claims _flagos_identity_view, but the C++ binding wasn't
+    # compiled in -> must fail with a clear error pointing to the missing symbol.
     obj, calls, _ = _make(
         monkeypatch, "musa", flagcx_ok=True, native_ok=False, view_present=False
     )
-    with pytest.raises(NotImplementedError, match="no flagos->device view"):
+    with pytest.raises(RuntimeError, match=r"torch_fl\._C\._flagos_identity_view not found"):
         obj._build_inner(None, 0, 1, None)
 
 

--- a/tests/unit/test_vendor_routing.py
+++ b/tests/unit/test_vendor_routing.py
@@ -175,9 +175,16 @@ def _make(monkeypatch, vendor, *, flagcx_ok, native_ok, view_present=True):
             self._inner = object()
         return native_ok
 
+    def fake_mccl(self, store, rank, ws, timeout):
+        calls["native"] = True
+        if native_ok:
+            self._inner = object()
+        return native_ok
+
     monkeypatch.setattr(pg.ProcessGroupFlagOS, "_try_build_flagcx", fake_flagcx)
     monkeypatch.setattr(pg.ProcessGroupFlagOS, "_try_build_nccl", fake_nccl)
     monkeypatch.setattr(pg.ProcessGroupFlagOS, "_try_build_hccl", fake_hccl)
+    monkeypatch.setattr(pg.ProcessGroupFlagOS, "_try_build_mccl", fake_mccl)
 
     # Fake torch_fl._C so _resolve_view finds (or misses) the view helper.
     # _resolve_view does `import torch_fl._C as _C`; when torch_fl is already
@@ -232,14 +239,32 @@ def test_musa_flagcx_identity_view(monkeypatch):
     assert view_fn is identity_marker  # identity view resolved
 
 
-def test_musa_flagcx_only_no_native_fallback(monkeypatch):
-    # musa has native=None: if flagcx fails there is nothing to fall back to.
+def test_musa_uses_mccl_native_when_flagcx_unavailable(monkeypatch):
+    # musa has native=_try_build_mccl: if flagcx fails, MCCL is attempted.
     obj, calls, _ = _make(
-        monkeypatch, "musa", flagcx_ok=False, native_ok=True, view_present=False
+        monkeypatch, "musa", flagcx_ok=False, native_ok=True, view_present=True
     )
-    with pytest.raises(RuntimeError, match="none wired"):
+    # Fake the identity view helper
+    identity_marker = object()
+    fake_c = sys.modules["torch_fl._C"]
+    fake_c._flagos_identity_view = identity_marker
+
+    view_fn = obj._build_inner(None, 0, 1, None)
+    assert calls["flagcx"] and calls["native"]  # flagcx tried first, mccl succeeded
+    assert obj._inner is not None
+    assert view_fn is identity_marker  # identity view for MCCL too
+
+
+def test_musa_no_backend_raises(monkeypatch):
+    # Neither FlagCX nor MCCL available -> must raise with clear error.
+    obj, calls, _ = _make(
+        monkeypatch, "musa", flagcx_ok=False, native_ok=False, view_present=True
+    )
+    with pytest.raises(RuntimeError, match="no suitable inner backend"):
         obj._build_inner(None, 0, 1, None)
-    assert not calls["native"]
+    assert calls["flagcx"] and calls["native"]  # both attempted
+
+
 
 
 def test_musa_flagcx_ok_but_identity_view_missing_raises(monkeypatch):

--- a/tests/unit/test_vendor_routing.py
+++ b/tests/unit/test_vendor_routing.py
@@ -265,15 +265,15 @@ def test_musa_no_backend_raises(monkeypatch):
     assert calls["flagcx"] and calls["native"]  # both attempted
 
 
-
-
 def test_musa_flagcx_ok_but_identity_view_missing_raises(monkeypatch):
     # musa profile claims _flagos_identity_view, but the C++ binding wasn't
     # compiled in -> must fail with a clear error pointing to the missing symbol.
     obj, calls, _ = _make(
         monkeypatch, "musa", flagcx_ok=True, native_ok=False, view_present=False
     )
-    with pytest.raises(RuntimeError, match=r"torch_fl\._C\._flagos_identity_view not found"):
+    with pytest.raises(
+        RuntimeError, match=r"torch_fl\._C\._flagos_identity_view not found"
+    ):
         obj._build_inner(None, 0, 1, None)
 
 

--- a/torch_fl/comm/process_group.py
+++ b/torch_fl/comm/process_group.py
@@ -130,8 +130,10 @@ _VENDOR_PROFILES = {
     # ProcessGroup. Needs the device guard below (GCU streams/pointers are
     # device-scoped).
     "enflame": _VendorProfile("gcu", None, None, direct=True),
-    # MUSA / Cambricon: FlagCX only (no cuda alias, no native fallback wired).
-    "musa": _VendorProfile("musa", None, None),
+    # MUSA: FlagCX only (identity view lets FlagCX's MUSA adaptor receive
+    # privateuseone tensors directly). No native fallback wired yet.
+    "musa": _VendorProfile("musa", "_flagos_identity_view", None),
+    # Cambricon: FlagCX only (no cuda alias, no native fallback wired).
     "cambricon": _VendorProfile("mlu", None, None),
 }
 

--- a/torch_fl/comm/process_group.py
+++ b/torch_fl/comm/process_group.py
@@ -130,9 +130,9 @@ _VENDOR_PROFILES = {
     # ProcessGroup. Needs the device guard below (GCU streams/pointers are
     # device-scoped).
     "enflame": _VendorProfile("gcu", None, None, direct=True),
-    # MUSA: FlagCX only (identity view lets FlagCX's MUSA adaptor receive
-    # privateuseone tensors directly). No native fallback wired yet.
-    "musa": _VendorProfile("musa", "_flagos_identity_view", None),
+    # MUSA: FlagCX preferred (identity view lets FlagCX's MUSA adaptor receive
+    # privateuseone tensors directly), with MCCL native fallback.
+    "musa": _VendorProfile("musa", "_flagos_identity_view", "_try_build_mccl"),
     # Cambricon: FlagCX only (no cuda alias, no native fallback wired).
     "cambricon": _VendorProfile("mlu", None, None),
 }
@@ -406,6 +406,26 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
         if hccl_cls is None:
             return False
         self._inner = hccl_cls(store, rank, world_size)
+        return True
+
+    def _try_build_mccl(self, store, rank, world_size, timeout) -> bool:
+        """Build a ProcessGroupMCCL via torch_musa (MUSA native fallback).
+
+        Returns True and sets self._inner on success, False if torch_musa / MCCL
+        is unavailable. MCCL is Moore Threads' collective communication library,
+        analogous to NCCL for CUDA. Combined with the identity view, this provides
+        a pure-MUSA distributed path without requiring FlagCX.
+        """
+        try:
+            import torch_musa.distributed  # noqa: F401
+        except ImportError:
+            return False
+        mccl_cls = getattr(torch.distributed, "ProcessGroupMCCL", None) or getattr(
+            torch_musa.distributed, "ProcessGroupMCCL", None
+        )
+        if mccl_cls is None:
+            return False
+        self._inner = mccl_cls(store, rank, world_size)
         return True
 
     def _try_build_flagcx(self, store, rank, world_size, timeout) -> bool:

--- a/torch_fl/csrc/module.cc
+++ b/torch_fl/csrc/module.cc
@@ -273,6 +273,20 @@ PyObject* _cuda_to_flagos_view(PyObject* self, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
+PyObject* _flagos_identity_view(PyObject* self, PyObject* arg) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(THPVariable_Check(arg), "Expected a tensor argument");
+  // Identity view: return the tensor unchanged. This allows FlagCX's MUSA
+  // adaptor to receive privateuseone tensors directly, bypassing the need for
+  // a zero-copy flagos->musa storage view. FlagCX extracts data_ptr() and the
+  // musaStream_t from the tensor without validating device().type(), so a
+  // privateuseone tensor works as-is. Verified with FlagCX main branch
+  // (flagcx/adaptor/device/musa_adaptor.cc + plugin/torch/flagcx/src/).
+  Py_INCREF(arg);
+  return arg;
+  END_HANDLE_TH_ERRORS
+}
+
 // --- Caching Allocator APIs ---
 
 PyObject* _empty_cache(PyObject* self, PyObject* noargs) {
@@ -357,6 +371,7 @@ static PyMethodDef methods[] = {
     {"_synchronize", _synchronize, METH_NOARGS, nullptr},
     {"_flagos_to_cuda_view", _flagos_to_cuda_view, METH_O, nullptr},
     {"_cuda_to_flagos_view", _cuda_to_flagos_view, METH_VARARGS, nullptr},
+    {"_flagos_identity_view", _flagos_identity_view, METH_O, nullptr},
     {"_empty_cache", _empty_cache, METH_NOARGS, nullptr},
     {"_memory_stats", _memory_stats, METH_O, nullptr},
     {"_memory_allocated", _memory_allocated, METH_O, nullptr},


### PR DESCRIPTION
<!--
AI-generated PR: all required sections below are completed.
-->

## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @aoyulong
- **Session Summary**: Investigated the reserved MUSA distributed backend route, verified the FlagCX MUSA/MUSACCL implementation, implemented the identity-view and MCCL fallback paths, added routing and multi-GPU test coverage, and validated the affected logic on the available MUSA environment.

## Summary

Add MUSA distributed communication support to `ProcessGroupFlagOS`. The MUSA route now passes tensors through an identity view for FlagCX and falls back to `ProcessGroupMCCL` when FlagCX is unavailable. This removes the previous initialization failure caused by an unimplemented MUSA tensor view and provides a complete, dependency-aware routing path for MUSA collectives.

## Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)
- [x] MUSA (vendor-specific; added because the legacy template does not list MUSA)

## Problem Analysis

### What was broken/missing?

The MUSA vendor profile in `ProcessGroupFlagOS` used `view=None` and `native=None`. Initialization therefore failed before any collective could be issued: the process group had neither a MUSA tensor view for FlagCX nor a native MUSA backend fallback.

### Why did it happen?

The generic routing framework was added before the MUSA distributed integration. MUSA uses PyTorch's `PrivateUse1` extension point, while the existing CUDA path relies on a dedicated storage view. No MUSA-specific view or native MCCL creator had been registered.

### Investigation process:
1. Read `torch_fl/comm/process_group.py`, `torch_fl/csrc/module.cc`, and the existing vendor-routing tests to trace profile selection, view resolution, and inner-backend construction.
2. Inspected the upstream FlagCX MUSA implementation at https://github.com/flagos-ai/FlagCX, including `musa_adaptor.cc`, `musa_mccl_adaptor.cc`, and the Torch plugin event/stream integration.
3. Confirmed the machine exposes 8 MUSA devices and confirmed that `/usr/local/musa/lib/libmccl.so.2.28.9` exists.
4. Reproduced the pre-integration routing failure with `GEMS_VENDOR=musa`: no suitable inner backend was available because neither FlagCX nor torch_musa was installed.
5. Added fake-backend tests for FlagCX preference, MCCL fallback, missing-view errors, and no-backend errors.

## Solution Design

### Implementation approach:

1. Add `_flagos_identity_view` as a C++ binding that returns the original tensor with an incremented Python reference count.
2. Configure the MUSA profile with `flagcx_dev="musa"` and the identity view so FlagCX can consume the tensor pointer and stream without storage reinterpretation.
3. Add `_try_build_mccl`, which imports `torch_musa` lazily and creates `ProcessGroupMCCL` when available.
4. Keep the existing routing order: try FlagCX first, then the configured native backend, and report an actionable error if neither is available.
5. Add unit, live-routing, and hardware-oriented manual tests plus MUSA installation/test documentation.

### Key design decisions:

- **Identity view instead of storage reinterpretation:** avoids unsafe storage construction, deprecated PyTorch storage APIs, and possible `PrivateUse1` ownership conflicts.
- **FlagCX before MCCL:** preserves the existing heterogeneous communication preference while retaining a pure-MUSA native fallback.
- **Lazy torch_musa import:** keeps torch_fl importable in environments that have MUSA runtime support but do not install torch_musa.
- **No unconditional MCCL dependency:** backend initialization remains optional and fails with a clear installation message when external communication components are absent.

### Code changes by file:
- `torch_fl/csrc/module.cc: _flagos_identity_view binding`: returns the input tensor unchanged for the FlagCX MUSA identity-view path.
- `torch_fl/comm/process_group.py: _VENDOR_PROFILES and _try_build_mccl`: configures the MUSA route and adds the lazy MCCL native-backend creator.
- `tests/unit/test_vendor_routing.py`: covers MUSA identity-view resolution, FlagCX preference, MCCL fallback, missing view, and no-backend errors.
- `tests/manual/test_musa_routing_live.py`: verifies the compiled identity binding and the live MUSA routing error path.
- `tests/manual/musa/test_comm_musa.py`: exercises basic collectives and device-index behavior when a two-rank backend is available.
- `tests/manual/musa/test_ddp_musa.py`: provides a MUSA DDP training smoke test.
- `tests/manual/musa/test_fsdp2_musa.py`: provides FSDP2 sharding coverage for base all-gather and reduce-scatter operations.
- `tests/manual/musa/test_qwen3_ddp_musa.py`: provides a Qwen3 DDP workload test.
- `tests/manual/musa/README.md`: documents prerequisites, launch commands, expected behavior, and troubleshooting.
- `docs/vendors/musa/installation.md`: documents the MUSA distributed-support status and external backend requirements.
- `CLAUDE.md`: enforces fork-only feature branches and read-only upstream remotes.

### Changes by commit:
1. `87ac578` - `feat: distributed collectives via FlagCX identity view`: adds the identity binding and initial MUSA FlagCX route.
2. `9e305d1` - `docs: update distributed support status`: documents the initial MUSA distributed status.
3. `626e524` - `test: add distributed comm test suite (collectives, DDP, FSDP2)`: adds manual multi-GPU test coverage and the test guide.
4. `39fe5f6` - `feat: distributed collectives via FlagCX/MCCL with identity view`: adds the MCCL fallback and routing tests.
5. `441582e` - `test: format MUSA distributed tests`: resolves Ruff findings and formats all changed Python tests.
6. `f7b5e4c` - `docs: enforce fork-only feature branches`: prevents feature branches from being pushed to upstream repositories.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (`ruff check`, `ruff format --check`)
- [ ] **Type checking passed** (not configured for this change)
- [ ] **All tests pass** (the affected unit suite passed; the full repository suite was not run)
- [x] **Manual testing completed** (live routing and identity binding verified; real multi-GPU collectives require an external torch_musa/FlagCX Torch integration)
- [x] **No debug/temporary code** (the `print()` calls in manual tests are intentional test reporting)
- [x] **Documentation updated** (MUSA installation and manual-test documentation)
- [x] **Commit messages follow conventions** (`<type>: <description>`)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```text
$ ruff check .
All checks passed!

$ ruff format --check .
254 files already formatted
```

### Test Results
```text
$ pytest tests/unit/test_vendor_routing.py -v
============================= test session starts ==============================
platform linux -- Python 3.10.20 -- pytest-9.1.1
collected 17 items

17 passed in 2.74s
```

### Manual Verification
```text
$ source /publi-flash/lvyufeng/env/miniconda3/bin/activate torch210cpu
$ GEMS_VENDOR=musa python tests/manual/test_musa_routing_live.py
MUSA profile correct: musa + identity view + MCCL fallback
_flagos_identity_view works correctly
Same object: True
Same data_ptr: 0x1000ca00000 == 0x1000ca00000
Got expected RuntimeError
Error message correctly identifies MUSA and MCCL requirement
ALL TESTS PASSED
```

The available environment reports 8 MUSA devices. A two-rank collective launch was also attempted with:

```text
$ GEMS_VENDOR=musa torchrun --nproc_per_node=2 tests/manual/musa/test_comm_musa.py
RuntimeError: ProcessGroupFlagOS: no suitable inner backend for GEMS_VENDOR='musa'.
Install/import flagcx (heterogeneous), or provide the vendor-native backend
(_try_build_mccl).
```

This is the expected dependency boundary for the current environment: `flagcx` and `torch_musa` are not installed in the test environment. The code-level fallback behavior is covered by the unit tests above. The upstream FlagCX MUSA Torch plugin additionally includes torch_musa event/stream headers, so end-to-end MUSA collectives require the corresponding torch_musa integration.

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions and existing vendor-profile patterns
- [x] Comment density matches surrounding code
- [x] Used the existing `ProcessGroupFlagOS` routing and view-resolution helpers

### Edge Cases Considered
1. FlagCX succeeds: FlagCX is selected and the MUSA identity view is resolved.
2. FlagCX is unavailable but torch_musa/MCCL is available: the native MCCL creator is attempted.
3. Both backends are unavailable: initialization raises an actionable MUSA-specific error.
4. The configured identity binding is missing: initialization raises a clear missing-symbol error.
5. The MUSA vendor is explicitly selected through `GEMS_VENDOR=musa` rather than relying on platform auto-detection.

### Potential Risks
1. The identity-view path depends on the FlagCX MUSA adaptor consuming tensor pointers and streams without requiring a CUDA-specific storage type.
2. End-to-end communication remains dependent on external FlagCX/torch_musa compatibility and was not runnable in this environment.

### Rollback Plan
Revert commits `f7b5e4c`, `441582e`, `39fe5f6`, `626e524`, `9e305d1`, and `87ac578` together to restore the previous MUSA profile and remove the distributed test/documentation additions. No existing non-MUSA vendor route is changed.

## Related Work
- Related to #19 (ProcessGroupFlagOS framework)
- Related to #40 (MUSA backend integration)
- Depends on the upstream FlagCX MUSA/MUSACCL adaptor: https://github.com/flagos-ai/FlagCX

## Explicitly Not Included
- Installation or vendoring of `torch_musa`.
- A new MUSA storage reinterpretation implementation; the identity-view path intentionally avoids it.
- Changes to existing CUDA, MetaX, Ascend, PPU, or other vendor communication routes.
- A claim of successful end-to-end multi-GPU communication without the required external Torch backend integration.

## Human Review Notes

### Areas needing special attention:
1. Confirm that the upstream FlagCX MUSA Torch plugin accepts `PrivateUse1` tensors through the identity view in the target deployment.
2. Review `_try_build_mccl` compatibility with the installed `torch_musa` versions and constructor signatures.
3. Review the `_allgather_base` and `_reduce_scatter_base` delegation coverage used by FSDP2.

### Questions for reviewer:
1. Should the MUSA native fallback support any additional `ProcessGroupMCCL` constructor options for the supported torch_musa release?
2. Is there a preferred FlagCX/torch_musa wheel or build configuration for the upstream MUSA CI environment?

## Additional Context

- The current host exposes 8 MUSA devices and has `/usr/local/musa/lib/libmccl.so.2.28.9`.
- The upstream FlagCX repository documents MUSACCL support and provides `USE_MUSA=1` build configuration.
- The upstream CI lint check passed after the formatting commit; the PR body includes the required AI-agent sections and actual local command output.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)