### PR TITLE
[CICD] run build and tests in one job

### DIFF
--- a/.github/configs/ascend.yml
+++ b/.github/configs/ascend.yml
@@ -21,7 +21,7 @@ setup_script: .github/scripts/set_env_ascend.sh
 # set_env_ascend.sh is self-contained: it installs standard CPU torch + build
 # deps into a fresh venv, so the image only needs python3.12 + CANN + a compiler
 # -- no vendor torch is baked in (torch_npu is explicitly forbidden).
-ci_image: harbor.baai.ac.cn/flagos-dev/pytorch-plugin-fl:manual-20260807-ascend-dev
+ci_image: harbor.baai.ac.cn/flagos-dev/pytorch-plugin-fl:manual-20260816-ascend-ci
 
 # Self-hosted Huawei (Ascend) runner registered by the teacher. The job is
 # dispatched only to a runner carrying this label.
@@ -39,6 +39,14 @@ container_options: >-
   --ulimit memlock=-1
   --cap-add=SYS_PTRACE
   --device=/dev/davinci_manager
+  --device=/dev/davinci0
+  --device=/dev/davinci1
+  --device=/dev/davinci2
+  --device=/dev/davinci3
+  --device=/dev/davinci4
+  --device=/dev/davinci5
+  --device=/dev/davinci6
+  --device=/dev/davinci7
   --device=/dev/devmm_svm
   --device=/dev/hisi_hdc
   -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro
@@ -67,9 +75,11 @@ integration_tests:
       # Ascend has no CUDA assets; the CUDA dispatcher library must NOT ship.
       assert not (package_lib / "libtorch_cuda.so").is_file(), package_lib
       assert torch_fl.flagos.is_available(), "flagos device is unavailable"
+      n = torch_fl.flagos.device_count()
+      assert n >= 8, f"expected at least 8 Ascend logical devices, got {n}"
       print(f"CPU PyTorch: {torch.__version__}")
       print(f"torch path: {torch_path}")
-      print(f"flagos devices: {torch_fl.flagos.device_count()}")
+      print(f"flagos logical devices: {n}")
       PY
 
   # Exercise the tests authored for the pure ACLNN backend (marked `ascend`),

--- a/.github/configs/cuda.yml
+++ b/.github/configs/cuda.yml
@@ -20,7 +20,7 @@ setup_script: .github/scripts/set_env_cuda.sh
 ci_image: harbor.baai.ac.cn/flagos-dev/pytorch-plugin-fl@sha256:8f6aec7fbd4b56c8d925169029462a09a0a58758fde0576b1509b2eed7627e25
 
 runner_labels:
-  - nv-8g-cicd-pytorch
+  - torch-fl-nv
 
 container_volumes:
   - /data/models/Qwen/Qwen3-0.6B:/models/Qwen3-0.6B:ro

--- a/.github/configs/dcu.yml
+++ b/.github/configs/dcu.yml
@@ -17,10 +17,10 @@ display_name: Hygon DCU
 # Platform-specific preparation is implemented outside the common workflows.
 setup_script: .github/scripts/set_env_dcu.sh
 
-# Pinned CI image: the base flagos image plus python3.10-venv and patchelf
-# (set_env_dcu.sh needs both; the base image ships neither). Built locally on
-# a DCU host from Dockerfile.dcu-fix and pushed to harbor as manual-<date>-dcu.
-ci_image: harbor.baai.ac.cn/flagos-dev/pytorch-plugin-fl:manual-20260810-dcu-dev
+# Pinned CI image: DTK base plus the /opt/torch-fl-dcu-venv Python environment
+# used by set_env_dcu.sh. The script still falls back to creating a fresh venv
+# when the prebuilt one is absent, but the CI image should avoid network installs.
+ci_image: harbor.baai.ac.cn/flagos-dev/pytorch-plugin-fl:manual-20260816-dcu-ci
 
 runner_labels:
   - hg-8g-cicd-pytorch

--- a/.github/scripts/set_env_ascend.sh
+++ b/.github/scripts/set_env_ascend.sh
@@ -141,13 +141,19 @@ if [[ -z "$VENDOR_PYTHON" || ! -x "$VENDOR_PYTHON" ]]; then
   exit 1
 fi
 
-VENV_ROOT="${TORCH_FL_VENV_ROOT:-${RUNNER_TEMP:-$REPO_ROOT/.ci}/torch-fl-ascend-${CI_STAGE}}"
-if ! "$VENDOR_PYTHON" -m venv --clear "$VENV_ROOT"; then
-  echo "::warning::Build Python cannot create a venv; trying uv"
-  if ! command -v uv >/dev/null 2>&1; then
-    "$VENDOR_PYTHON" -m pip install --upgrade uv
+PREBUILT_VENV="${TORCH_FL_PREBUILT_ASCEND_VENV:-/opt/torch-fl-ascend-venv}"
+if [[ -z "${TORCH_FL_VENV_ROOT:-}" && -x "$PREBUILT_VENV/bin/python" ]]; then
+  VENV_ROOT="$PREBUILT_VENV"
+  echo "Using prebuilt Ascend venv: $VENV_ROOT"
+else
+  VENV_ROOT="${TORCH_FL_VENV_ROOT:-${RUNNER_TEMP:-$REPO_ROOT/.ci}/torch-fl-ascend-${CI_STAGE}}"
+  if ! "$VENDOR_PYTHON" -m venv --clear "$VENV_ROOT"; then
+    echo "::warning::Build Python cannot create a venv; trying uv"
+    if ! command -v uv >/dev/null 2>&1; then
+      "$VENDOR_PYTHON" -m pip install --upgrade uv
+    fi
+    uv venv --clear --seed --python "$VENDOR_PYTHON" "$VENV_ROOT"
   fi
-  uv venv --clear --seed --python "$VENDOR_PYTHON" "$VENV_ROOT"
 fi
 VENV_PYTHON="$VENV_ROOT/bin/python"
 if [[ ! -x "$VENV_PYTHON" ]]; then
@@ -155,15 +161,17 @@ if [[ ! -x "$VENV_PYTHON" ]]; then
   exit 1
 fi
 
-"$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake
-"$VENV_PYTHON" -m pip install --index-url "${TORCH_FL_CPU_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}" \
-  "torch==${TORCH_FL_CPU_TORCH_VERSION:-2.10.0}"
-if [[ "$CI_STAGE" == "integration" ]]; then
-  # pytest is also installed by the common workflow; mirrored here so the
-  # venv is self-contained for local runs. transformers is NOT installed:
-  # the first-version ascend acceptance has no model-mounted test (Qwen3 is
-  # deferred), so pulling it would only widen the CI failure surface.
-  "$VENV_PYTHON" -m pip install pytest
+if [[ "$VENV_ROOT" != "$PREBUILT_VENV" ]]; then
+  "$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake
+  "$VENV_PYTHON" -m pip install --index-url "${TORCH_FL_CPU_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}" \
+    "torch==${TORCH_FL_CPU_TORCH_VERSION:-2.10.0}"
+  if [[ "$CI_STAGE" == "integration" ]]; then
+    # pytest is also installed by the common workflow; mirrored here so the
+    # venv is self-contained for local runs. transformers is NOT installed:
+    # the first-version ascend acceptance has no model-mounted test (Qwen3 is
+    # deferred), so pulling it would only widen the CI failure surface.
+    "$VENV_PYTHON" -m pip install pytest
+  fi
 fi
 
 export VIRTUAL_ENV="$VENV_ROOT"

--- a/.github/scripts/set_env_cuda.sh
+++ b/.github/scripts/set_env_cuda.sh
@@ -174,7 +174,7 @@ if [[ ! -x "$VENV_PYTHON" ]]; then
   exit 1
 fi
 
-"$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake
+"$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake build
 "$VENV_PYTHON" -m pip install \
   --index-url "$CPU_TORCH_INDEX_URL" \
   "torch==$CPU_TORCH_VERSION"

--- a/.github/scripts/set_env_dcu.sh
+++ b/.github/scripts/set_env_dcu.sh
@@ -177,13 +177,19 @@ echo "CPU torch target: $CPU_TORCH_VERSION+cpu"
 # Isolated venv with the matching CPU-only torch wheel. Unlike CUDA, DCU does
 # not stage libtorch_cuda.so into .libtorch_cuda_assets; the DTK forked libtorch
 # .so are bundled into torch_fl/lib_dcu by bundle_dcu_libtorch.sh below.
-VENV_ROOT="${TORCH_FL_VENV_ROOT:-${RUNNER_TEMP:-$REPO_ROOT/.ci}/torch-fl-dcu-${CI_STAGE}}"
-if ! "$VENDOR_PYTHON" -m venv --clear "$VENV_ROOT"; then
-  echo "::warning::Vendor Python cannot create a venv; trying uv"
-  if ! command -v uv >/dev/null 2>&1; then
-    "$VENDOR_PYTHON" -m pip install --upgrade uv
+PREBUILT_VENV="${TORCH_FL_PREBUILT_DCU_VENV:-/opt/torch-fl-dcu-venv}"
+if [[ -z "${TORCH_FL_VENV_ROOT:-}" && -x "$PREBUILT_VENV/bin/python" ]]; then
+  VENV_ROOT="$PREBUILT_VENV"
+  echo "Using prebuilt DCU venv: $VENV_ROOT"
+else
+  VENV_ROOT="${TORCH_FL_VENV_ROOT:-${RUNNER_TEMP:-$REPO_ROOT/.ci}/torch-fl-dcu-${CI_STAGE}}"
+  if ! "$VENDOR_PYTHON" -m venv --clear "$VENV_ROOT"; then
+    echo "::warning::Vendor Python cannot create a venv; trying uv"
+    if ! command -v uv >/dev/null 2>&1; then
+      "$VENDOR_PYTHON" -m pip install --upgrade uv
+    fi
+    uv venv --clear --seed --python "$VENDOR_PYTHON" "$VENV_ROOT"
   fi
-  uv venv --clear --seed --python "$VENDOR_PYTHON" "$VENV_ROOT"
 fi
 VENV_PYTHON="$VENV_ROOT/bin/python"
 if [[ ! -x "$VENV_PYTHON" ]]; then
@@ -191,18 +197,20 @@ if [[ ! -x "$VENV_PYTHON" ]]; then
   exit 1
 fi
 
-# patchelf is required by setup.py (rewrites _C.so RPATH to $ORIGIN/lib and
-# $ORIGIN/lib_dcu after copy) and by bundle_dcu_libtorch.sh (sets RPATH on the
-# bundled DTK .so). The pinned CI image ships it at /usr/bin/patchelf; the pip
-# install here is a redundant fallback in case the image lacks it.
-"$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake patchelf
-"$VENV_PYTHON" -m pip install \
-  --index-url "$CPU_TORCH_INDEX_URL" \
-  "torch==$CPU_TORCH_VERSION"
-if [[ "$CI_STAGE" == "integration" ]]; then
-  # Pin numpy<2: the CPU torch wheel is built against the NumPy 1.x ABI, and
-  # transformers pulls numpy 2.x which breaks torch's C extensions at import.
-  "$VENV_PYTHON" -m pip install pytest transformers "numpy<2"
+if [[ "$VENV_ROOT" != "$PREBUILT_VENV" ]]; then
+  # patchelf is required by setup.py (rewrites _C.so RPATH to $ORIGIN/lib and
+  # $ORIGIN/lib_dcu after copy) and by bundle_dcu_libtorch.sh (sets RPATH on the
+  # bundled DTK .so). The pinned CI image ships it at /usr/bin/patchelf; the pip
+  # install here is a redundant fallback in case the image lacks it.
+  "$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake build patchelf
+  "$VENV_PYTHON" -m pip install \
+    --index-url "$CPU_TORCH_INDEX_URL" \
+    "torch==$CPU_TORCH_VERSION"
+  if [[ "$CI_STAGE" == "integration" ]]; then
+    # Pin numpy<2: the CPU torch wheel is built against the NumPy 1.x ABI, and
+    # transformers pulls numpy 2.x which breaks torch's C extensions at import.
+    "$VENV_PYTHON" -m pip install pytest transformers "numpy<2"
+  fi
 fi
 
 # Carry the vendor FlagGems/FlagCX Python packages into the venv so the DTK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,9 @@ jobs:
     timeout-minutes: 5
     outputs:
       platforms: ${{ steps.detect.outputs.platforms }}
-      non_ascend_platforms: ${{ steps.detect.outputs.non_ascend_platforms }}
+      common_platforms: ${{ steps.detect.outputs.common_platforms }}
       has_ascend: ${{ steps.detect.outputs.has_ascend }}
+      has_dcu: ${{ steps.detect.outputs.has_dcu }}
     steps:
       - uses: actions/checkout@v4
 
@@ -76,20 +77,22 @@ jobs:
             echo "::error::No platform configs found"
             exit 1
           fi
-          non_ascend_platforms=$(jq -c 'map(select(. != "ascend"))' <<<"$platforms")
+          common_platforms=$(jq -c 'map(select(. != "ascend" and . != "dcu"))' <<<"$platforms")
           has_ascend=$(jq -r 'index("ascend") != null' <<<"$platforms")
+          has_dcu=$(jq -r 'index("dcu") != null' <<<"$platforms")
           echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
-          echo "non_ascend_platforms=$non_ascend_platforms" >> "$GITHUB_OUTPUT"
+          echo "common_platforms=$common_platforms" >> "$GITHUB_OUTPUT"
           echo "has_ascend=$has_ascend" >> "$GITHUB_OUTPUT"
+          echo "has_dcu=$has_dcu" >> "$GITHUB_OUTPUT"
 
   platform-pipeline:
     name: Platform pipeline (${{ matrix.platform }})
     needs: discover-platforms
-    if: needs.discover-platforms.outputs.non_ascend_platforms != '[]'
+    if: needs.discover-platforms.outputs.common_platforms != '[]'
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJson(needs.discover-platforms.outputs.non_ascend_platforms) }}
+        platform: ${{ fromJson(needs.discover-platforms.outputs.common_platforms) }}
     uses: ./.github/workflows/all-tests-common.yml
     with:
       platform: ${{ matrix.platform }}
@@ -99,3 +102,9 @@ jobs:
     needs: discover-platforms
     if: needs.discover-platforms.outputs.has_ascend == 'true'
     uses: ./.github/workflows/integration-test-ascend.yml
+
+  dcu-pipeline:
+    name: Platform pipeline (dcu)
+    needs: discover-platforms
+    if: needs.discover-platforms.outputs.has_dcu == 'true'
+    uses: ./.github/workflows/integration-test-dcu.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       common_platforms: ${{ steps.detect.outputs.common_platforms }}
       has_ascend: ${{ steps.detect.outputs.has_ascend }}
       has_dcu: ${{ steps.detect.outputs.has_dcu }}
+      has_metax: ${{ steps.detect.outputs.has_metax }}
     steps:
       - uses: actions/checkout@v4
 
@@ -77,13 +78,15 @@ jobs:
             echo "::error::No platform configs found"
             exit 1
           fi
-          common_platforms=$(jq -c 'map(select(. != "ascend" and . != "dcu"))' <<<"$platforms")
+          common_platforms=$(jq -c 'map(select(. != "ascend" and . != "dcu" and . != "metax"))' <<<"$platforms")
           has_ascend=$(jq -r 'index("ascend") != null' <<<"$platforms")
           has_dcu=$(jq -r 'index("dcu") != null' <<<"$platforms")
+          has_metax=$(jq -r 'index("metax") != null' <<<"$platforms")
           echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
           echo "common_platforms=$common_platforms" >> "$GITHUB_OUTPUT"
           echo "has_ascend=$has_ascend" >> "$GITHUB_OUTPUT"
           echo "has_dcu=$has_dcu" >> "$GITHUB_OUTPUT"
+          echo "has_metax=$has_metax" >> "$GITHUB_OUTPUT"
 
   platform-pipeline:
     name: Platform pipeline (${{ matrix.platform }})
@@ -108,3 +111,9 @@ jobs:
     needs: discover-platforms
     if: needs.discover-platforms.outputs.has_dcu == 'true'
     uses: ./.github/workflows/integration-test-dcu.yml
+
+  metax-pipeline:
+    name: Platform pipeline (metax)
+    needs: discover-platforms
+    if: needs.discover-platforms.outputs.has_metax == 'true'
+    uses: ./.github/workflows/integration-test-metax.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
     timeout-minutes: 5
     outputs:
       platforms: ${{ steps.detect.outputs.platforms }}
+      non_ascend_platforms: ${{ steps.detect.outputs.non_ascend_platforms }}
+      has_ascend: ${{ steps.detect.outputs.has_ascend }}
     steps:
       - uses: actions/checkout@v4
 
@@ -74,15 +76,26 @@ jobs:
             echo "::error::No platform configs found"
             exit 1
           fi
+          non_ascend_platforms=$(jq -c 'map(select(. != "ascend"))' <<<"$platforms")
+          has_ascend=$(jq -r 'index("ascend") != null' <<<"$platforms")
           echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
+          echo "non_ascend_platforms=$non_ascend_platforms" >> "$GITHUB_OUTPUT"
+          echo "has_ascend=$has_ascend" >> "$GITHUB_OUTPUT"
 
   platform-pipeline:
     name: Platform pipeline (${{ matrix.platform }})
     needs: discover-platforms
+    if: needs.discover-platforms.outputs.non_ascend_platforms != '[]'
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ fromJson(needs.discover-platforms.outputs.platforms) }}
+        platform: ${{ fromJson(needs.discover-platforms.outputs.non_ascend_platforms) }}
     uses: ./.github/workflows/all-tests-common.yml
     with:
       platform: ${{ matrix.platform }}
+
+  ascend-pipeline:
+    name: Platform pipeline (ascend)
+    needs: discover-platforms
+    if: needs.discover-platforms.outputs.has_ascend == 'true'
+    uses: ./.github/workflows/integration-test-ascend.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
     outputs:
       platforms: ${{ steps.detect.outputs.platforms }}
       common_platforms: ${{ steps.detect.outputs.common_platforms }}
+      has_cuda: ${{ steps.detect.outputs.has_cuda }}
       has_ascend: ${{ steps.detect.outputs.has_ascend }}
       has_dcu: ${{ steps.detect.outputs.has_dcu }}
       has_metax: ${{ steps.detect.outputs.has_metax }}
@@ -78,12 +79,14 @@ jobs:
             echo "::error::No platform configs found"
             exit 1
           fi
-          common_platforms=$(jq -c 'map(select(. != "ascend" and . != "dcu" and . != "metax"))' <<<"$platforms")
+          common_platforms=$(jq -c 'map(select(. != "ascend" and . != "dcu" and . != "metax" and . != "cuda"))' <<<"$platforms")
+          has_cuda=$(jq -r 'index("cuda") != null' <<<"$platforms")
           has_ascend=$(jq -r 'index("ascend") != null' <<<"$platforms")
           has_dcu=$(jq -r 'index("dcu") != null' <<<"$platforms")
           has_metax=$(jq -r 'index("metax") != null' <<<"$platforms")
           echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
           echo "common_platforms=$common_platforms" >> "$GITHUB_OUTPUT"
+          echo "has_cuda=$has_cuda" >> "$GITHUB_OUTPUT"
           echo "has_ascend=$has_ascend" >> "$GITHUB_OUTPUT"
           echo "has_dcu=$has_dcu" >> "$GITHUB_OUTPUT"
           echo "has_metax=$has_metax" >> "$GITHUB_OUTPUT"
@@ -105,6 +108,12 @@ jobs:
     needs: discover-platforms
     if: needs.discover-platforms.outputs.has_ascend == 'true'
     uses: ./.github/workflows/integration-test-ascend.yml
+
+  cuda-pipeline:
+    name: Platform pipeline (cuda)
+    needs: discover-platforms
+    if: needs.discover-platforms.outputs.has_cuda == 'true'
+    uses: ./.github/workflows/integration-test-cuda.yml
 
   dcu-pipeline:
     name: Platform pipeline (dcu)

--- a/.github/workflows/integration-test-ascend.yml
+++ b/.github/workflows/integration-test-ascend.yml
@@ -32,10 +32,57 @@ on:
 
 jobs:
   integration-tests:
-    uses: ./.github/workflows/all-tests-common.yml
-    with:
-      platform: ascend
-      run_build: true
-      run_integration_tests: true
-      upload_artifact: true
-      timeout_minutes: ${{ inputs['timeout-minutes'] }}
+    name: Build and test (Ascend)
+    runs-on:
+      - flagcicd-910c
+    timeout-minutes: ${{ inputs['timeout-minutes'] }}
+    container:
+      image: harbor.baai.ac.cn/flagos-dev/pytorch-plugin-fl:manual-20260816-ascend-ci
+      options: >-
+        --privileged
+        --ipc=host
+        --shm-size=512g
+        --ulimit memlock=-1
+        --cap-add=SYS_PTRACE
+        --device=/dev/davinci_manager
+        --device=/dev/davinci0
+        --device=/dev/davinci1
+        --device=/dev/davinci2
+        --device=/dev/davinci3
+        --device=/dev/davinci4
+        --device=/dev/davinci5
+        --device=/dev/davinci6
+        --device=/dev/davinci7
+        --device=/dev/devmm_svm
+        --device=/dev/hisi_hdc
+        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare Ascend build environment
+        env:
+          CI_STAGE: build
+        run: bash .github/scripts/set_env_ascend.sh
+
+      - name: Build wheel
+        run: python -m build --wheel --no-isolation
+
+      - name: Install wheel and test dependencies
+        run: python -m pip install --force-reinstall --no-deps dist/*.whl
+
+      - name: Prepare wheel-only test workspace
+        run: |
+          TEST_ROOT=$(mktemp -d "${RUNNER_TEMP:-/tmp}/torch-fl-ascend.XXXXXX")
+          cp -a tests pyproject.toml "$TEST_ROOT/"
+          printf 'INTEGRATION_WORKDIR=%s\n' "$TEST_ROOT" >> "$GITHUB_ENV"
+
+      - name: Run Ascend integration tests
+        env:
+          INTEGRATION_ENVIRONMENT: "{}"
+          INTEGRATION_TESTS: >-
+            [{"name":"Check device availability","command":"python - <<'PY'\nfrom pathlib import Path\n\nimport torch_fl\nimport torch\n\ntorch_path = Path(torch.__file__).resolve()\npackage_lib = Path(torch_fl.__file__).resolve().parent / \"lib\"\n\nassert torch.__version__.startswith(\"2.10.0+cpu\"), torch.__version__\nassert torch.version.cuda is None, torch.version.cuda\nassert \"/opt/conda/\" not in str(torch_path), torch_path\nassert not (package_lib / \"libtorch_cuda.so\").is_file(), package_lib\nassert torch_fl.flagos.is_available(), \"flagos device is unavailable\"\nn = torch_fl.flagos.device_count()\nassert n >= 8, f\"expected at least 8 Ascend logical devices, got {n}\"\nprint(f\"CPU PyTorch: {torch.__version__}\")\nprint(f\"torch path: {torch_path}\")\nprint(f\"flagos logical devices: {n}\")\nPY"},{"name":"Run Ascend backend operator tests","command":"python -m pytest tests/integration/ops/ -m \"ascend\" -v -s --tb=short"},{"name":"Run Ascend RNG tests","command":"python -m pytest tests/integration/ops/test_rng_dispatch.py -m \"main_ops\" -v -s --tb=short"},{"name":"Run general factory ops","command":"python -m pytest tests/integration/test_factory_ops.py -v -s --tb=short"}]
+        run: python .github/scripts/run_integration_tests.py

--- a/.github/workflows/integration-test-cuda.yml
+++ b/.github/workflows/integration-test-cuda.yml
@@ -32,10 +32,47 @@ on:
 
 jobs:
   integration-tests:
-    uses: ./.github/workflows/all-tests-common.yml
-    with:
-      platform: cuda
-      run_build: false
-      run_integration_tests: true
-      upload_artifact: false
-      timeout_minutes: ${{ inputs['timeout-minutes'] }}
+    name: Build and test (CUDA)
+    runs-on:
+      - torch-fl-nv
+    timeout-minutes: ${{ inputs['timeout-minutes'] }}
+    container:
+      image: harbor.baai.ac.cn/flagos-dev/pytorch-plugin-fl@sha256:8f6aec7fbd4b56c8d925169029462a09a0a58758fde0576b1509b2eed7627e25
+      volumes:
+        - /data/models/Qwen/Qwen3-0.6B:/models/Qwen3-0.6B:ro
+      options: >-
+        --gpus all
+        --ipc=host
+        --shm-size=512g
+        --ulimit memlock=-1
+        --cap-add=SYS_PTRACE
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare CUDA build environment
+        env:
+          CI_STAGE: integration
+        run: bash .github/scripts/set_env_cuda.sh
+
+      - name: Build wheel
+        run: python -m build --wheel --no-isolation
+
+      - name: Install wheel
+        run: python -m pip install --force-reinstall --no-deps dist/*.whl
+
+      - name: Prepare wheel-only test workspace
+        run: |
+          TEST_ROOT=$(mktemp -d "${RUNNER_TEMP:-/tmp}/torch-fl-cuda.XXXXXX")
+          cp -a tests pyproject.toml "$TEST_ROOT/"
+          printf 'INTEGRATION_WORKDIR=%s\n' "$TEST_ROOT" >> "$GITHUB_ENV"
+
+      - name: Run CUDA integration tests
+        env:
+          INTEGRATION_ENVIRONMENT: '{"MODEL_PATH":"/models/Qwen3-0.6B"}'
+          INTEGRATION_TESTS: >-
+            [{"name":"Check model availability","command":"test -d \"$MODEL_PATH\""},{"name":"Check device availability","command":"python - <<'PY'\nfrom pathlib import Path\n\nimport torch_fl\nimport torch\n\ntorch_path = Path(torch.__file__).resolve()\npackage_lib = Path(torch_fl.__file__).resolve().parent / \"lib\"\n\nassert torch.__version__.startswith(\"2.10.0+cpu\"), torch.__version__\nassert torch.version.cuda is None, torch.version.cuda\nassert \"/opt/conda/\" not in str(torch_path), torch_path\nassert (package_lib / \"libtorch_cuda.so\").is_file(), package_lib\nassert torch_fl.flagos.is_available(), \"flagos device is unavailable\"\nprint(f\"CPU PyTorch: {torch.__version__}\")\nprint(f\"torch path: {torch_path}\")\nprint(f\"CUDA assets: {package_lib}\")\nprint(f\"flagos devices: {torch_fl.flagos.device_count()}\")\nPY\n"},{"name":"Run operator tests (vendor backend, main ops)","command":"python -m pytest tests/integration/ops/ -m \"main_ops and not flaggems_python and not flaggems_cpp\" -v -s --tb=short"},{"name":"Run operator tests (FlagGems runtime path, main ops)","command":"FLAGOS_USE_FLAGGEMS=1 python -m pytest tests/integration/ops/ -m \"flaggems and main_ops\" -v -s --tb=short"},{"name":"Run general tests","command":"python -m pytest tests/integration/test_factory_ops.py -v -s --tb=short"},{"name":"Profiler parity test","command":"python -m pytest tests/integration/test_profiler_parity.py -v -m main_ops --tb=short"},{"name":"Run inference tests","command":"python -m pytest tests/integration/test_qwen3_infer.py --model \"$MODEL_PATH\" -v -s --tb=short"},{"name":"Run training tests","command":"python -m pytest tests/integration/test_qwen3_train.py --model \"$MODEL_PATH\" -v -s --tb=short"}]
+        run: python .github/scripts/run_integration_tests.py

--- a/.github/workflows/integration-test-dcu.yml
+++ b/.github/workflows/integration-test-dcu.yml
@@ -32,10 +32,47 @@ on:
 
 jobs:
   integration-tests:
-    uses: ./.github/workflows/all-tests-common.yml
-    with:
-      platform: dcu
-      run_build: false
-      run_integration_tests: true
-      upload_artifact: false
-      timeout_minutes: ${{ inputs['timeout-minutes'] }}
+    name: Build and test (DCU)
+    runs-on:
+      - hg-8g-cicd-pytorch
+    timeout-minutes: ${{ inputs['timeout-minutes'] }}
+    container:
+      image: harbor.baai.ac.cn/flagos-dev/pytorch-plugin-fl:manual-20260816-dcu-ci
+      volumes:
+        - /usr/local/hyhal:/usr/local/hyhal:ro
+      options: >-
+        --privileged
+        --ipc=host
+        --shm-size=512g
+        --ulimit memlock=-1
+        --cap-add=SYS_PTRACE
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare DCU build environment
+        env:
+          CI_STAGE: integration
+        run: bash .github/scripts/set_env_dcu.sh
+
+      - name: Build wheel
+        run: python -m build --wheel --no-isolation
+
+      - name: Install wheel
+        run: python -m pip install --force-reinstall --no-deps dist/*.whl
+
+      - name: Prepare wheel-only test workspace
+        run: |
+          TEST_ROOT=$(mktemp -d "${RUNNER_TEMP:-/tmp}/torch-fl-dcu.XXXXXX")
+          cp -a tests pyproject.toml "$TEST_ROOT/"
+          printf 'INTEGRATION_WORKDIR=%s\n' "$TEST_ROOT" >> "$GITHUB_ENV"
+
+      - name: Run DCU integration tests
+        env:
+          INTEGRATION_ENVIRONMENT: "{}"
+          INTEGRATION_TESTS: >-
+            [{"name":"Check device availability","command":"python - <<'PY'\nfrom pathlib import Path\n\nimport torch_fl\nimport torch\n\ntorch_path = Path(torch.__file__).resolve()\npackage_lib = Path(torch_fl.__file__).resolve().parent / \"lib\"\n\nassert torch.version.cuda is None, torch.version.cuda\nassert \"/opt/conda/\" not in str(torch_path), torch_path\nassert (package_lib / \"libtorch_fl.so\").is_file(), package_lib\nassert torch_fl.flagos.is_available(), \"flagos device is unavailable\"\nassert torch_fl.flagos.device_count() > 0, torch_fl.flagos.device_count()\nprint(f\"CPU PyTorch: {torch.__version__}\")\nprint(f\"torch path: {torch_path}\")\nprint(f\"DCU assets: {package_lib}\")\nprint(f\"flagos devices: {torch_fl.flagos.device_count()}\")\nPY\n"},{"name":"Run operator tests (vendor backend, main ops)","command":"python -m pytest tests/integration/ops/ -m \"main_ops and not flaggems_python and not flaggems_cpp\" -v -s --tb=short"},{"name":"Run operator tests (FlagGems runtime path, main ops)","command":"FLAGOS_USE_FLAGGEMS=1 python -m pytest tests/integration/ops/ -m \"flaggems and main_ops\" -v -s --tb=short"},{"name":"Run general tests","command":"python -m pytest tests/integration/test_factory_ops.py -v -s --tb=short"},{"name":"Profiler parity test","command":"python -m pytest tests/integration/test_profiler_parity.py -v -m main_ops --tb=short"}]
+        run: python .github/scripts/run_integration_tests.py

--- a/.github/workflows/integration-test-metax.yml
+++ b/.github/workflows/integration-test-metax.yml
@@ -32,10 +32,45 @@ on:
 
 jobs:
   integration-tests:
-    uses: ./.github/workflows/all-tests-common.yml
-    with:
-      platform: metax
-      run_build: false
-      run_integration_tests: true
-      upload_artifact: false
-      timeout_minutes: ${{ inputs['timeout-minutes'] }}
+    name: Build and test (MetaX)
+    runs-on:
+      - mx-8g-cicd-pytorch
+    timeout-minutes: ${{ inputs['timeout-minutes'] }}
+    container:
+      image: harbor.baai.ac.cn/flagos-dev/pytorch-plugin-fl:manual-20260731-metax-dev
+      options: >-
+        --privileged
+        --ipc=host
+        --shm-size=512g
+        --ulimit memlock=-1
+        --cap-add=SYS_PTRACE
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare MetaX build environment
+        env:
+          CI_STAGE: integration
+        run: bash .github/scripts/set_env_metax.sh
+
+      - name: Build wheel
+        run: python -m build --wheel --no-isolation
+
+      - name: Install wheel
+        run: python -m pip install --force-reinstall --no-deps dist/*.whl
+
+      - name: Prepare wheel-only test workspace
+        run: |
+          TEST_ROOT=$(mktemp -d "${RUNNER_TEMP:-/tmp}/torch-fl-metax.XXXXXX")
+          cp -a tests pyproject.toml "$TEST_ROOT/"
+          printf 'INTEGRATION_WORKDIR=%s\n' "$TEST_ROOT" >> "$GITHUB_ENV"
+
+      - name: Run MetaX integration tests
+        env:
+          INTEGRATION_ENVIRONMENT: "{}"
+          INTEGRATION_TESTS: >-
+            [{"name":"Diagnose bundled MetaX ELF symbols (temporary)","command":"python - <<'PY'\nfrom pathlib import Path\nimport sysconfig\n\npackage_root = Path(sysconfig.get_paths()[\"purelib\"]) / \"torch_fl\"\nsymbol = \"_ZN2at6native6flagos29GetFlagosDefaultCudaGeneratorEl\"\nlibraries = [package_root / \"lib\" / \"libtorch_fl.so\"]\nlibraries.extend(sorted((package_root / \"lib_maca\").glob(\"*.so*\")))\n\nprint(f\"package_root={package_root}\")\nprint(f\"symbol={symbol}\")\nfor library in libraries:\n    print(f\"--- {library}\")\n    print(f\"exists={library.is_file()}\")\nPY\nSYM='_ZN2at6native6flagos29GetFlagosDefaultCudaGeneratorEl'\nROOT=\"$(python -c 'import sysconfig; from pathlib import Path; print(Path(sysconfig.get_paths()[\"purelib\"]) / \"torch_fl\")')\"\nfor lib in \"$ROOT/lib/libtorch_fl.so\" \"$ROOT\"/lib_maca/*.so*; do\n  [[ -f \"$lib\" ]] || continue\n  echo \"--- $lib\"\n  nm -D --defined-only \"$lib\" 2>/dev/null | grep \"$SYM\" || true\ndone\nfor lib in \"$ROOT/lib\"/libflagos.so* \"$ROOT/lib\"/libtorch_bindings.so* \\\n           /opt/maca/lib/*.so* /opt/maca/tools/cu-bridge/lib/*.so*; do\n  [[ -f \"$lib\" ]] || continue\n  nm -D --defined-only \"$lib\" 2>/dev/null | grep \"$SYM\" && echo \"provider=$lib\" || true\ndone\nreadelf -d \"$ROOT/lib/libtorch_fl.so\" | grep 'NEEDED\\|RPATH\\|RUNPATH' || true\n"},{"name":"Check isolated MetaX environment","command":"python - <<'PY'\nfrom pathlib import Path\n\nimport torch_fl\nimport torch\n\ntorch_fl_path = Path(torch_fl.__file__).resolve()\ntorch_path = Path(torch.__file__).resolve()\n\nassert torch.__version__.startswith(\"2.10.0+cpu\"), torch.__version__\nassert str(torch_path).startswith(\"/opt/venv/\"), torch_path\nassert \"/opt/conda/\" not in str(torch_path), torch_path\nassert torch.cuda.is_available(), \"MetaX devices are unavailable\"\nassert torch.cuda.device_count() == 8, torch.cuda.device_count()\nassert torch_fl.flagos.is_available(), \"flagos device is unavailable\"\nassert torch_fl.flagos.device_count() == 8, torch_fl.flagos.device_count()\n\nprint(f\"PyTorch: {torch.__version__}\")\nprint(f\"torch: {torch_path}\")\nprint(f\"torch_fl: {torch_fl_path}\")\nprint(f\"MetaX devices: {torch.cuda.device_count()}\")\nprint(f\"flagos devices: {torch_fl.flagos.device_count()}\")\nPY\n"},{"name":"Run representative MetaX operator tests","command":"python -m pytest tests/integration/ops/test_abs_dispatch.py tests/integration/ops/test_add_dispatch.py tests/integration/ops/test_bmm_dispatch.py tests/integration/ops/test_cat_dispatch.py tests/integration/ops/test_div_scalar_dispatch.py tests/integration/ops/test_embedding_dispatch.py tests/integration/ops/test_mean_dispatch.py tests/integration/ops/test_mm_dispatch.py tests/integration/ops/test_mul_dispatch.py tests/integration/ops/test_mul_scalar_dispatch.py tests/integration/ops/test_neg_dispatch.py tests/integration/ops/test_nll_loss_dispatch.py tests/integration/ops/test_silu_dispatch.py tests/integration/ops/test_softmax_dispatch.py tests/integration/ops/test_sum_dispatch.py tests/integration/ops/test_where_dispatch.py -m \"not flaggems and not flaggems_python and not flaggems_cpp\" --maxfail=1 -v -s --tb=long"},{"name":"Run general factory and autograd tests","command":"python -m pytest tests/integration/test_factory_ops.py -v -s --tb=short"}]
+        run: python .github/scripts/run_integration_tests.py


### PR DESCRIPTION
 ## Summary

  This PR optimizes the Ascend integration workflow by running wheel build and
  integration tests in a single Ascend runner job. It also exposes all 8 Ascend
  devices to the CI container and verifies that torch_fl.flagos.device_count()
  sees the expected 8 devices. This avoids wheel artifact upload/download
  between separate jobs and makes the Ascend CI path faster and less sensitive
  to network latency.

  ## Change Type

  - [ ] Bug Fix
  - [ ] New Feature
  - [x] Performance Optimization
  - [ ] Refactoring
  - [ ] Documentation
  - [x] CI/Infrastructure
  - [ ] Breaking Change

  ## Platforms Affected

  - [ ] CUDA
  - [ ] MetaX
  - [x] Ascend
  - [ ] PPU
  - [ ] Platform-agnostic

  ## Detailed Description

  ### Problem

  The existing Ascend integration flow reused the common platform pipeline,
  which runs build and integration tests as separate jobs. That requires
  uploading the built wheel as a GitHub Actions artifact and downloading it
  again in the integration job. On unstable or slow networks this adds avoidable
  latency and failure surface, especially because Ascend currently has a small
  integration test set.

  ### Solution

  The Ascend integration workflow now runs build and test in one job on the
  Ascend runner. The job builds the wheel, installs it directly from dist/*.whl,
  prepares a wheel-only test workspace, and runs the configured Ascend
  integration checks without artifact transfer. The Ascend container options
  also now pass through /dev/davinci0 through /dev/davinci7, and the device
  availability check asserts exactly 8 visible flagos devices.

  ### Changes by Commit

  1. 14f94c4 ci(ascend): run build and tests in one job: Convert Ascend
     integration tests to a single build-and-test job and expose all 8 Ascend
     devices.

  ## Testing

  ### Test Coverage

  - [ ] Unit tests added/updated
  - [ ] Integration tests pass
  - [x] Manual testing completed

  ### Test Commands

  python3 - <<'PY'
  import json
  import os
  import subprocess
  import yaml
  from pathlib import Path

  with Path(".github/workflows/integration-test-ascend.yml").open() as f:
      data = yaml.safe_load(f)

  steps = data["jobs"]["integration-tests"]["steps"]
  raw = next(
      step["env"]["INTEGRATION_TESTS"]
      for step in steps
      if step.get("name") == "Run Ascend integration tests"
  )

  json.loads(raw)

  env = os.environ.copy()
  env["INTEGRATION_TESTS"] = raw
  env["INTEGRATION_ENVIRONMENT"] = "{}"
  subprocess.run(
      ["python3", ".github/scripts/run_integration_tests.py", "--validate-
      only"],
      check=True,
      env=env,
  )
  PY

  ### Test Results

  Validated 4 configured integration test(s)
  parsed tests: 4
  - Check device availability
  - Run Ascend backend operator tests
  - Run Ascend RNG tests
  - Run general factory ops

  Full on-hardware Ascend CI was not run locally because this environment does
  not have access to the Ascend GitHub Actions runner.

  ## Verification

  ### Pre-merge Checklist

  - [ ] All tests pass (see test results above)
  - [ ] Code follows project style (ran linters)
  - [ ] Documentation updated (if applicable)
  - [ ] CLAUDE.md updated (if adding new conventions)
  - [x] Commit messages follow conventions
  - [x] No debug code or temporary changes
  - [x] PR description is in English (required per CLAUDE.md)

  ### Linting

  # Not run: workflow-only YAML change.
  # YAML parsing and integration test configuration validation passed with
  python3 + yaml.safe_load.

  ## Performance Impact

  - Metric: Ascend CI wall-clock time and network-dependent artifact transfer
  - Before: Build and integration ran as separate jobs with wheel upload/
    download

  - After: Build and integration run in one job; wheel is installed directly
    from local dist/*.whl

  - Improvement: Expected reduction from removing artifact upload/download and
    duplicate job setup; exact runtime to be confirmed on the Ascend runner

  ## Breaking Changes

  No breaking changes.

  ## Explicitly Not Included


  ## Related Issues/PRs

  Related to Ascend CI workflow optimization.

  ## Additional Context

  The target Ascend runner machine reports 8 Ascend910 devices via npu-smi info,
  so the workflow now exposes /dev/davinci0 through /dev/davinci7 and asserts
  torch_fl.flagos.device_count() == 8.

