### PR TITLE
docs: add four-command integration harness skills

### DIFF
--- a/.claude/skills/cuda-compat-vendor/SKILL.md
+++ b/.claude/skills/cuda-compat-vendor/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: cuda-compat-vendor
+description: >
+  Enable operators on a CUDA-compatible accelerator (MetaX, Hygon DCU, PPU,
+  or any chip whose SDK ships a CUDA-shaped torch build) by extracting
+  libtorch_cuda.so from the vendor's own torch wheel and bundling it, instead of
+  writing kernels. Use this after runtime-bringup passes, once you have confirmed
+  the vendor ships a CUDA-compatible torch. Covers: proving compatibility before
+  committing, extracting the vendor .so set, the mandatory LD_PRELOAD-before-
+  import-torch constraint, wheel bundling via setup.py, and the boxing-path tests.
+---
+
+# CUDA-compatible vendor enablement (torch_fl)
+
+## What this achieves
+
+For a chip whose SDK provides a CUDA-shaped PyTorch build, torch_fl writes
+**zero operator kernels**. It instead:
+
+1. **Boxes** flagos (PrivateUse1) tensors to CUDA device metadata — no data copy,
+   since flagos and the vendor's CUDA-compatible device share the same memory —
+   calls the vendor's already-compiled kernel through the public `at::` API, then
+   **unboxes** the result back to flagos.
+2. **Reuses** the generated `csrc/aten/generated/cuda_kernels.cc` produced by
+   [[torch-version-port]]. Nothing per-operator is written here.
+3. Runs against an **external `libtorch_cuda.so`** extracted from the vendor
+   wheel and `LD_PRELOAD`ed before `import torch`, so the pip environment stays
+   CPU-only.
+
+This is roughly an order of magnitude less work than [[native-op-backend]], which
+is why proving compatibility (Step 1) is worth real effort before defaulting to
+the native route.
+
+**Prerequisite:** [[runtime-bringup]] must be green. Boxing does not remove the
+need for the 28-function runtime contract — allocation, streams and copies still
+go through flagos.
+
+## Step 1 — prove compatibility before committing to this path
+
+Do not infer compatibility from marketing claims about "CUDA ecosystem support".
+The question is narrow and mechanically checkable: **does the vendor ship a
+`libtorch_cuda.so` whose ATen symbols register kernels under the CUDA dispatch
+key?**
+
+```bash
+# 1. Find the vendor's torch build (usually a vendor pip index or SDK tarball)
+find /opt/<vendor> -name 'libtorch_cuda.so*' -o -name 'libtorch_*.so*' | head
+
+# 2. Are the ATen CUDA symbols actually present?
+nm -D --defined-only <path>/libtorch_cuda.so | grep -cE ' T .*at.*(add|mm|cat)'
+
+# 3. Decisive test: load it and ask the dispatcher what it registered.
+#    Note the load must happen before torch initializes -- see Step 3.
+python - <<'PY'
+import ctypes, torch
+print(torch._C._dispatch_dump("aten::mm"))   # before: CPU only
+ctypes.CDLL("<path>/libtorch_cuda.so", mode=ctypes.RTLD_GLOBAL)
+print(torch._C._dispatch_dump("aten::mm"))   # after: a CUDA entry must appear
+PY
+```
+
+If a CUDA entry appears for `mm`, `add`, `_softmax` and `bmm`, this path is
+viable. If not, stop and use [[native-op-backend]].
+
+`docs/vendors/cuda/external-libtorch-cuda.md` records the same four gates
+measured on NVIDIA, including the exact commands and the four hard constraints.
+Read it once before proceeding — the constraints are not obvious and one of them
+is fatal if missed.
+
+### Which shape is this vendor?
+
+Three shapes exist, in increasing order of work:
+
+| Shape | Example | Runtime dir | Operator work |
+|---|---|---|---|
+| SDK ships a `libcudart` shim, `cuda_runtime.h` compiles | Hygon DCU (DTK) | **reuses `accelerator/cuda/*.cc` verbatim** — no vendor dir | none |
+| CUDA-compatible SDK, own detection | PPU | reuses `cuda` sources, `ACCELERATOR=cuda` + `PPU_SDK` detection | none |
+| CUDA-compatible but needs a shim layer | MetaX (cu-bridge/mxcc) | `accelerator/metax/` incl. `cudart_shim.c` + a `.version` script | none |
+
+Read `csrc/runtime/accelerator/CMakeLists.txt` for how each is wired; DCU's
+branch (which globs `cuda/*.cc` from a non-cuda ACCELERATOR) is the cleanest
+precedent and worth copying when the shim exists.
+
+## Step 2 — extract the vendor .so set
+
+Download-only, then extract. Do **not** `pip install` the vendor torch into the
+working env — that replaces your CPU-only pin and reintroduces exactly the
+duplicate-symbol problem the scheme avoids.
+
+```bash
+pip download <vendor-torch>==<exact-version> -d /tmp/vt --no-deps
+cd /tmp/vt && unzip -o *.whl -d unpacked
+ls -la unpacked/torch/lib/libtorch_cuda.so unpacked/torch/lib/libc10_cuda.so
+```
+
+Stage what you extracted into the assets directory `setup.py` looks for:
+
+```bash
+mkdir -p .libtorch_cuda_assets
+cp unpacked/torch/lib/libtorch_cuda.so \
+   unpacked/torch/lib/libc10_cuda.so .libtorch_cuda_assets/
+```
+
+`setup.py:_bundle_cuda_assets()` copies every `*.so*` from
+`.libtorch_cuda_assets` (override with `FLAGOS_CUDA_ASSETS_DIR`) into
+`torch_fl/lib/` at build time, skipping same-size files so the ~1GB copy does not
+repeat. `FLAGOS_SKIP_CUDA_ASSETS=1` produces a slim wheel for machines that
+supply the `.so` out-of-band.
+
+### Version matching is exact, not approximate
+
+Constraint 3 in the CUDA doc: the `libtorch_cuda.so` version must match the
+installed CPU torch **exactly**. `2.9.0+cpu` pairs only with a `2.9.0` CUDA
+build. A minor mismatch does not fail cleanly at load — it fails as an ABI
+crash somewhere later, which is a much worse debugging experience.
+
+Also note constraint 4: the scheme relies on the CPU wheel exposing a complete
+enough symbol set for the CUDA library to link against. That is not officially
+guaranteed by PyTorch. It has held across the versions measured, but it is the
+reason this path warrants an on-hardware test rather than a build-only check.
+
+## Step 3 — the load-timing constraint (the one that bites)
+
+**`libtorch_cuda.so` must be loaded before `import torch`.** This is constraint 1
+and it is hard, not advisory. Loading afterwards leaves the dispatcher table
+already built without CUDA entries, and no later `CDLL` repairs it. The failure
+is silent — ops quietly run on CPU, or you get a device-mismatch error far from
+the cause.
+
+`scripts/with_cuda_libtorch.sh` exists precisely so nobody has to remember the
+`LD_PRELOAD` + `LD_LIBRARY_PATH` incantation. Run **everything** through it:
+
+```bash
+scripts/with_cuda_libtorch.sh python -c "import torch_fl, torch; \
+    print(torch.randn(4,4,device='flagos') @ torch.randn(4,4,device='flagos'))"
+scripts/with_cuda_libtorch.sh pytest tests/integration/ops/ -v
+```
+
+If the vendor's `.so` lives somewhere non-default, point the script at it rather
+than reinventing the preload — read the script first and extend it if the vendor
+needs extra libs (MetaX needs its shim, DCU pulls from the DTK tree).
+
+## Step 4 — build wiring
+
+Which `ACCELERATOR` value to use depends on the shape from Step 1, and the choice
+is not cosmetic:
+
+- **Shim present, `cuda_runtime.h` compiles** — follow DCU: add an `ACCELERATOR`
+  branch in `csrc/runtime/accelerator/CMakeLists.txt` that globs
+  `${CMAKE_CURRENT_SOURCE_DIR}/cuda/*.cc`, and add no vendor runtime directory at
+  all. Least code, least drift.
+- **CUDA-compatible with its own detection** — follow PPU: keep
+  `ACCELERATOR=cuda` and add SDK detection in `setup.py`.
+- **Needs a shim layer** — follow MetaX: a real `accelerator/<vendor>/` directory
+  with `cudart_shim.c` and a linker `.version` script.
+
+The build must still be **g++ only, no nvcc**, linking only `torch_cpu_library`.
+CUDA symbols resolve at runtime from the preloaded library. If the build starts
+wanting nvcc, something has pulled in a real CUDA dependency and the scheme's main
+benefit is gone.
+
+```bash
+ACCELERATOR=<vendor> CUDA_KERNEL=ON FLAGGEMS_KERNEL=OFF FLAGGEMS_PYTHON=OFF \
+  pip install -e . --no-build-isolation
+```
+
+## Step 5 — verify on hardware
+
+Build-only success proves very little here — constraint 4 means the interesting
+failures are at runtime. Compare against CPU:
+
+```bash
+scripts/with_cuda_libtorch.sh pytest tests/integration/ops/ \
+  -m "not flaggems and not flaggems_python" -v
+```
+
+Then confirm boxing is actually happening rather than silently falling back to
+CPU. A passing numerical test does **not** prove the vendor kernel ran:
+
+```bash
+scripts/with_cuda_libtorch.sh python - <<'PY'
+import torch_fl, torch
+x = torch.randn(64, 64, device="flagos")
+y = (x @ x).sum()
+print(y.item(), x.device)      # device must stay flagos, not cpu
+PY
+```
+
+Check `torch.__version__` still ends in `+cpu`. If it does not, a vendor torch got
+installed somewhere and the measurement is invalid.
+
+### Known cold-start artifact
+
+Under this scheme the first CUDA op in a fresh process can hit
+`Allocator not initialized for device`, because PyTorch normally primes its CUDA
+caching allocator inside `torch.cuda._lazy_init()` — which this path deliberately
+never calls. It surfaces on **out-variant** ops (`mm.out`, `bmm.out`) run as the
+very first CUDA op; non-out ops warm the allocator as a side effect. This is an
+environment artifact, not a codegen defect. Accept/xfail those log-only tests, or
+prime once at import with a throwaway functional op. Do **not** hand-initialize
+PyTorch's CUDA allocator — that reaches into the `torch.cuda` internals the whole
+scheme exists to avoid.
+
+## Done criteria
+
+- Step 1's dispatcher dump shows CUDA entries for `mm`/`add`/`_softmax`/`bmm`
+- Build succeeds with g++ only, no nvcc, linking only `torch_cpu_library`
+- `import torch_fl` clean through `scripts/with_cuda_libtorch.sh`
+- Operator suite passes, modulo the cold-start artifact above
+- Tensors stay on `flagos` through a compute chain (boxing confirmed, not fallback)
+- `torch.__version__` still ends in `+cpu`
+- `docs/vendors/<vendor>/installation.md` written, and
+  `docs/reference/compatibility.md` plus `docs/reference/operator-support.md`
+  updated from **measured** results — per CLAUDE.md, unavailable hardware is
+  marked *not revalidated* rather than assumed
+
+## Related
+
+[[runtime-bringup]] (prerequisite) · [[torch-version-port]] (supplies the
+generated kernels) · [[native-op-backend]] (the fallback if Step 1 fails) ·
+[[cuda-op-integration]] (the NVIDIA-specific version of this path) ·
+[[pre-pr-checks]] (before opening the PR)

--- a/.claude/skills/native-op-backend/SKILL.md
+++ b/.claude/skills/native-op-backend/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: native-op-backend
+description: >
+  Enable operators on an accelerator that is NOT CUDA-compatible, by binding its
+  native operator library (Ascend ACLNN, Enflame topsaten, Moore Threads mudnn,
+  Kunlun XDNN, …) per operator through category-based codegen. Use this after
+  runtime-bringup passes and after cuda-compat-vendor has been ruled out by
+  measurement. Covers: the category system that makes codegen tractable, writing
+  the vendor op_api_common/op_preparation layer, the OPS mapping table, the
+  kAscend-style backend slot and conf routing, and per-op CPU comparison tests.
+---
+
+# Native operator backend (torch_fl, non-CUDA-compatible chip)
+
+## When this is the right path
+
+Only after [[cuda-compat-vendor]] Step 1 has been *measured* and failed. This
+route is roughly an order of magnitude more work, so the cheap check is always
+worth running first.
+
+**Prerequisite:** [[runtime-bringup]] green. Every kernel here allocates its
+output through the flagos allocator and runs on a flagos stream; neither exists
+until the 28-function contract is implemented.
+
+## Why the CUDA codegen cannot be copied
+
+On the CUDA-compatible path a generated kernel body is a single line —
+`at::op(args)` — because `DeviceBoxingGuard` rewrites device metadata and
+PyTorch's own registered kernel does the work. **That shortcut does not exist
+here.** A native kernel body must call the vendor C ABI itself, which means it has
+to marshal arguments into vendor wrapper types, **allocate its own output and
+infer the output shape and dtype**, and then run the vendor's call sequence
+(often two-stage: query workspace size, then execute).
+
+| | CUDA-compatible codegen | native codegen |
+|---|---|---|
+| Kernel body | one line, `at::op(args)` | marshalling + output allocation + vendor call |
+| Information source | entirely in the ATen schema | the schema **does not carry** the vendor API name or marshalling rules |
+| Coverage strategy | enumerate every operator | **by category + mapping table**, expanded category by category |
+
+`docs/vendors/ascend/aclnn-codegen.md` is the reference write-up for this whole
+approach — read it before starting. It also documents two dead ends that were
+measured and closed off (boxing into torch_npu's key, and intercept-based
+routing), so you do not need to re-explore them.
+
+## The central insight: categories, not operators
+
+Hand-writing 138 kernels is intractable; generating 138 kernels from 63
+**categories** is not. The vendor calling convention is highly uniform, and the
+real variation — how arguments are marshalled and how the output is allocated —
+is **completely consistent within a category**.
+
+Ascend reached 138 operators from 63 categories. Adding a category costs one
+template; adding an operator to an existing category costs **one line** in a
+mapping table.
+
+Representative categories (see the Ascend doc for the full table):
+
+| category | Criterion | Output shape / dtype | Body shape |
+|---|---|---|---|
+| `unary` | 1 Tensor in, Tensor out | = input | `vendorOp(self, out)` |
+| `unary_bool` | 1 Tensor in, predicate | input shape, **bool** out | `vendorOp(self, out)` |
+| `binary` | 2 Tensors, broadcasting | `at::infer_size` | `vendorOp(self, other, out)` |
+| `binary_scalar` | Tensor + Scalar | = input | scalar wrapper + `vendorOp` |
+| `reduce` | dim list + keepdim | reduced shape | int-array wrapper + `vendorOp` |
+| `gemm` | matmul family | contracted shape | often needs transpose flags |
+
+**Do not start by picking your favourite operators.** Start with `unary`, get one
+operator through the entire pipeline to a passing CPU-comparison test, and only
+then widen. The first operator pays all the infrastructure cost; the second
+should cost minutes.
+
+## Step 1 — SDK reconnaissance
+
+Answer these five questions from the headers before writing any code. Each one
+determines a template decision, and guessing any of them means rewriting every
+category later.
+
+```bash
+find /opt/<vendor> -name '*.h' | xargs grep -l 'Tensor\|tensor' | head
+nm -D --defined-only /opt/<vendor>/lib/lib<vendorops>.so | grep ' T ' | head -40
+```
+
+1. **Tensor descriptor type** — what struct describes a tensor (shape, strides,
+   dtype, data pointer)? This becomes your `<Vendor>TensorWrapper`.
+2. **Call convention** — single call, or two-stage
+   `GetWorkspaceSize` + `Execute`? Two-stage needs a workspace allocation in the
+   macro.
+3. **dtype enum mapping** — `torch.float32` → which vendor enum? Enumerate all
+   dtypes you intend to support; a missing mapping must raise, not silently pick a
+   default.
+4. **Output ownership** — does the vendor allocate the output, or does the caller?
+   (Caller, almost always — hence `op_preparation`.)
+5. **Stream/context argument** — what does the op take, and how do you get it
+   from the flagos stream? This is where [[runtime-bringup]]'s
+   `GetDefault<Vendor>Stream` accessor gets used.
+
+Record the answers in `docs/vendors/<vendor>/` as you go. Reconstructing them
+later from generated code is far harder than writing them down now.
+
+## Step 2 — the vendor support layer (hand-written, once)
+
+Two headers, mirroring the Ascend layout:
+
+```
+csrc/aten/backends/<vendor>/
+├── op_api_common.h      # <Vendor>TensorWrapper / ScalarWrapper /
+│                        # IntArrayWrapper + the EXEC_<VENDOR>_CMD macro
+├── op_preparation.h     # apply_tensor_without_format(): allocate an output
+│                        # tensor with a given shape/dtype on the flagos device
+└── generated/
+    └── <vendor>_kernels.cc   # emitted by the generator, never hand-edited
+```
+
+`EXEC_<VENDOR>_CMD` must hide the entire call sequence — workspace query,
+workspace allocation, execute, error check — so that a category template stays
+one readable line. If a template needs to know about workspaces, the macro is not
+doing its job.
+
+Error handling: convert every vendor status into a `TORCH_CHECK` with the
+operator name and the vendor error string. A native backend without this is
+extremely unpleasant to debug, because failures surface as wrong numbers rather
+than exceptions.
+
+## Step 3 — the generator
+
+Create `scripts/codegen_<vendor>.py` modelled on `scripts/codegen_ascend.py`,
+which has four parts:
+
+- **`OPS`** — `schema op name → (category, vendor-name override)`. **The only
+  hand-maintained data.**
+- **`SKIP`** — ops deliberately hand-written for this backend. A duplicate
+  registration in the same backend slot **crashes at import**, so an op is either
+  generated or hand-written, never both.
+- **`CATEGORIES`** — `category → kernel body template`.
+- **Name reuse** — import `schema_to_cpp_name` from `scripts/codegen_ops.py`.
+  If `XxxFn`/`xxx_dispatcher` names diverge from `csrc/aten/generated/ops.h`, the
+  link fails.
+
+### Declare no dispatchers of your own
+
+This is the most common structural mistake. `csrc/aten/generated/ops.h` already
+has the `XxxFn` typedefs and `DECLARE_DISPATCHER`; `ops.cc` already has
+`ADD_IMPL_TO_DISPATCHER`; `register.inc` already binds the ATen operator to
+`xxx_dispatcher`. Your generator emits **only** the kernel plus:
+
+```cpp
+REGISTER_IMPL_TO_DISPATCHER(XxxFn, xxx_dispatcher,
+                            Backend::k<Vendor>, XxxKernel<Vendor>);
+```
+
+This hangs your kernel in the `k<Vendor>` slot of a dispatcher that already
+exists. Declaring your own typedefs produces either a duplicate-symbol link
+failure or, worse, a second dispatcher nothing routes to — so the kernel compiles,
+registers, and never runs.
+
+Reuse `schema_to_cpp_name` from `scripts/codegen_ops.py` rather than
+reimplementing the name mangling.
+
+## Step 4 — backend slot and routing
+
+Three edits outside the generator:
+
+1. **Backend enum** — add `k<Vendor>` alongside `kAscend` in the `Backend` enum
+   (`csrc/aten/dispatcher.h`), and teach `GetBackendForOp` to resolve it.
+2. **Conf file** — `torch_fl/configs/backends_<vendor>.conf`, with `op = <vendor>`
+   lines. This is what routes an op to your slot **at runtime**; a registered
+   kernel with no conf line never executes. The generator should rewrite a
+   `# --- generated ---` block at the end of this file idempotently.
+3. **CMake** — generated sources under `csrc/aten/backends/<vendor>/` must be
+   excluded from other platforms' builds. Follow the Ascend pattern in
+   `csrc/CMakeLists.txt`: `if(NOT <VENDOR>_KERNEL) EXCLUDE ".*/aten/backends/<vendor>/.*"`.
+
+Registration and routing are **two separate mechanisms**. A kernel that is
+registered but unrouted is the most common "my kernel does nothing" cause; check
+the conf before debugging the kernel.
+
+## Step 5 — verify each operator against CPU
+
+Per-operator CPU comparison is the only trustworthy check — a native kernel that
+returns plausible-looking wrong numbers is the characteristic failure of this path.
+
+```bash
+ACCELERATOR=<vendor> <VENDOR>_KERNEL=1 CUDA_KERNEL=0 FLAGGEMS_KERNEL=0 \
+  pip install -e . --no-build-isolation
+
+FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_<vendor>.conf \
+  pytest tests/integration/ops/ -m "<vendor>" -v
+```
+
+Pass **all** the build env vars explicitly. `setup.py` defaults to
+`ACCELERATOR=cuda`, and omitting them fails at the cmake configure stage with an
+error that does not obviously point back at the missing variable.
+
+Tolerances measured on Ascend, useful as a sanity reference: unary ≤4.4e-5,
+binary ≤4.7e-6, comparison ops exact. A unary op off by 1e-2 is a bug, not
+hardware noise.
+
+Cover per operator: several shapes (including empty and 1-element), every dtype
+you claim, non-contiguous inputs (a wrapper that ignores strides passes contiguous
+tests and fails here), and broadcasting for binaries.
+
+## Growth strategy
+
+1. `unary` category, one operator, end to end until the CPU comparison passes.
+2. Rest of `unary` — should be one `OPS` line each.
+3. `binary` + `binary_scalar` (introduces broadcasting and `at::infer_size`).
+4. `reduce` (introduces int-array marshalling and keepdim shape math).
+5. `gemm` and the rest, by workload need.
+
+After each category: run the suite, update `docs/reference/operator-support.md`
+from **measured** results, commit. Do not accumulate five categories of unverified
+kernels — attributing a failure across them costs more than the incremental runs.
+
+## Done criteria
+
+- Generator runs clean, is idempotent (second run leaves no diff), emits no
+  duplicate `k<Vendor>` registration
+- `SKIP` and the generated set are disjoint — an op is generated **or**
+  hand-written, never both, or import crashes
+- Every generated op has a conf line routing to it
+- Every claimed op has a passing CPU-comparison test at the tolerances above
+- `docs/vendors/<vendor>/` records the five Step-1 answers and the category table
+- `docs/reference/operator-support.md` updated from measured results per CLAUDE.md
+
+## Related
+
+[[runtime-bringup]] (prerequisite) · [[cuda-compat-vendor]] (must be ruled out
+first) · [[torch-version-port]] (supplies `ops.h`/`register.inc`) ·
+[[pre-pr-checks]] (before opening the PR)

--- a/.claude/skills/runtime-bringup/SKILL.md
+++ b/.claude/skills/runtime-bringup/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: runtime-bringup
+description: >
+  Implement the torch_fl device runtime contract for an accelerator that has no
+  backend at all yet — the ~38-function floor (28 C ABI functions +
+  10 allocator virtuals) that must exist before any operator can run. Use this
+  as the FIRST step for any new chip (Kunlun XPU, or any other), regardless of
+  whether it will later use CUDA-compatible boxing or a native operator library.
+  Covers: the exact function inventory and which file each goes in, the
+  USE_<VENDOR> macro wiring across three CMake sites, the allocator backend
+  selection block, and the operator-free smoke test that proves the runtime works.
+---
+
+# Device runtime bringup (torch_fl new accelerator)
+
+## What this achieves and what it deliberately does not
+
+This skill brings a chip from "torch_fl has never heard of it" to "torch_fl can
+allocate a tensor on it, copy H2D/D2H, and synchronize streams and events" —
+**with zero operators registered**. That intermediate state is real, testable,
+and the correct place to stop.
+
+It is a **gate, not a subroutine**. Both operator strategies
+([[cuda-compat-vendor]] for CUDA-compatible chips, [[native-op-backend]] for
+chips with their own operator library) assume this has already passed. Do not
+start either until the smoke test below is green, because an operator failure on
+top of a broken runtime is nearly impossible to attribute.
+
+Nothing here depends on torch version — that axis belongs to
+[[torch-version-port]].
+
+## The contract, counted from the tree
+
+Do not estimate this inventory. It is fixed and enumerable:
+
+| Surface | File | Count |
+|---|---|---|
+| C ABI runtime functions | `csrc/include/flagos.h` (`FLAGOS_EXPORT Error_t`) | **28** |
+| Allocator virtuals | `csrc/runtime/allocator/device_memory_interface.h` (`= 0;`) | **10** |
+| Vendor stream accessor | `GetDefault<Vendor>Stream` (optional, see below) | 0–2 |
+
+Verify the count yourself before starting, since `flagos.h` may have grown:
+
+```bash
+grep -c 'FLAGOS_EXPORT Error_t' csrc/include/flagos.h        # expect 28
+grep -c '= 0;' csrc/runtime/allocator/device_memory_interface.h  # expect 10
+```
+
+Every existing backend implements all 28 — cuda, musa, gcu, ascend, tsingmicro
+and bpu each expose exactly 28. There is no "partial runtime" precedent, and
+`torch.empty` on the device will fault if any are stubbed to return `Success`
+without doing the work.
+
+## Step 1 — read the reference implementation that matches your chip's shape
+
+Pick the closest existing vendor and read all three of its files end to end
+before writing anything. The choice matters more than it looks:
+
+| If the SDK … | Read | Because |
+|---|---|---|
+| ships a `libcudart` shim (`cuda_runtime.h` works) | `accelerator/cuda/*.cc` — and reuse it verbatim via CMake, like `dcu` does | zero new runtime code; DCU adds no `dcu/` directory at all |
+| is CUDA-shaped but renamed (`xxxMalloc`, `xxxStream_t`) | `accelerator/musa/*.cc` | a mechanical 1:1 port of the CUDA sources onto a renamed C API |
+| is a different model entirely (two-stage, context objects) | `accelerator/ascend/*.cc` + `accelerator/gcu/*.cc` | shows how to keep a shared default stream and drain it before host-visible memcpy |
+| has no stream concept | `accelerator/bpu/*.cc` | the degenerate case: streams emulated, `Event*` mostly no-ops |
+
+Kunlun XPU (XRE) is a *renamed-CUDA-shape* SDK (`xpu_malloc` / `XPUStream`), so
+`musa/` is the reference. Confirm that from the headers rather than assuming it.
+
+## Step 2 — the three files, and exactly what goes in each
+
+The 28 functions partition into three files per vendor. Keep the split; the CMake
+glob and every other backend depend on it.
+
+```
+csrc/runtime/accelerator/<vendor>/
+├── device.cc   #  5
+├── memory.cc   #  9
+└── stream.cc   # 14
+```
+
+`device.cc` (5): `GetDeviceCount`, `GetDevice`, `SetDevice`,
+`DeviceGetStreamPriorityRange`, `DeviceSynchronize`
+
+`memory.cc` (9): `Malloc`, `Free`, `MallocHost`, `FreeHost`, `Memcpy`,
+`MemcpyAsync`, `PointerGetAttributes`, `Memset`, `MemsetAsync`
+
+`stream.cc` (14): `StreamCreateWithPriority`, `StreamCreate`,
+`StreamGetPriority`, `StreamDestroy`, `StreamQuery`, `StreamSynchronize`,
+`StreamWaitEvent`, `EventCreateWithFlags`, `EventCreate`, `EventDestroy`,
+`EventRecord`, `EventSynchronize`, `EventQuery`, `EventElapsedTime`
+
+### The error mapping is the part that gets rushed
+
+`Error_t` has exactly five values (`Success`, `ErrorUnknown`,
+`ErrorNotReady`, `ErrorInvalidDevice`, `ErrorMemoryAllocation`). Two mappings are
+load-bearing and silently break things if collapsed into `ErrorUnknown`:
+
+- **`ErrorNotReady`** — `StreamQuery` and `EventQuery` MUST return this (not an
+  error) for "still running". The caching allocator's block-reuse path treats
+  `ErrorNotReady` as "not safe to reuse yet" and anything else as a hard failure,
+  so collapsing it either deadlocks or corrupts.
+- **`ErrorMemoryAllocation`** — OOM must be distinguishable, or torch's
+  retry-after-`empty_cache` path never triggers and users get a crash where they
+  should get a shrunk workspace.
+
+### `PointerGetAttributes` is not optional
+
+It fills `MemoryType` (`Unmanaged`/`Host`/`Device`) plus device index. `copy_`
+uses it to decide whether a pointer needs a device copy or a plain `memcpy`. If
+the SDK has no equivalent query, track allocations in a side table in `memory.cc`
+rather than returning a fixed `MemoryTypeDevice` — a wrong answer here shows up
+much later as a wrong-results bug in `.cpu()`, not as a runtime error.
+
+### The async-dispatch memcpy hazard
+
+If operators on this chip dispatch asynchronously on a shared default stream,
+`Memcpy` (the synchronous one) must **drain that stream first**, or `.cpu()`
+races the kernel that produces the data. Ascend hit this and solved it in
+`accelerator/ascend/acl_stream.h` + a drain at the top of `memory.cc`. Read that
+before writing `Memcpy`; the failure is nondeterministic and looks like a kernel
+bug.
+
+## Step 3 — the allocator backend (10 virtuals)
+
+Create `csrc/runtime/allocator/backends/<vendor>_memory.h` implementing
+`DeviceMemoryInterface`: `device_malloc`, `device_free`, `get_device_index`,
+`set_device`, `get_memory_info`, `event_create`, `event_destroy`, `event_record`,
+`event_query`, `memcpy`.
+
+These mostly forward to the C functions from step 2. Two decisions are real:
+
+**`get_memory_info(free, total)`** — if the SDK cannot report free bytes, do not
+invent a number. Report total and a conservative free; `torch.<device>.mem_get_info`
+and OOM-retry logic read this.
+
+**`provides_caching()`** — the escape hatch. Return `true` only if the platform
+ships a mature caching allocator that does **not** claim the PrivateUse1
+allocator slot torch_fl registers. Getting this wrong is a known trap:
+
+- DCU returns `true` and delegates through the device-generic registry (c10::hip
+  underneath, no c10::cuda symbols) — see `backends/dcu_memory.h`.
+- MUSA deliberately returns `false` even though a `MUSACachingAllocator` exists,
+  because it claims the same PrivateUse1 slot flagos registers — see the comment
+  at `caching_device_allocator.cc:551`.
+
+**Default to `false`** for a new chip. The built-in block pool works, and you can
+delegate later once the vendor allocator's slot behaviour is understood.
+
+## Step 4 — wire the build (three sites, all mandatory)
+
+Missing any one of these produces a confusing failure rather than a clean error.
+
+**Site 1 — `csrc/runtime/accelerator/CMakeLists.txt`.** Two separate blocks:
+the `project()` selector near the top (non-CUDA vendors declare `CXX C` so cmake
+does not demand nvcc), and the per-vendor source/link block below.
+
+```cmake
+elseif(ACCELERATOR STREQUAL "<vendor>")
+  project(FLAGOS_RUNTIME CXX C)
+...
+elseif(ACCELERATOR STREQUAL "<vendor>")
+  file(GLOB SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/<vendor>/*.cc")
+  add_library(${LIBRARY_NAME} SHARED ${SOURCE_FILES})
+  target_include_directories(${LIBRARY_NAME} PUBLIC
+      ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} ${<VENDOR>_HOME}/include)
+  target_link_directories(${LIBRARY_NAME} PRIVATE ${<VENDOR>_HOME}/lib)
+  target_link_libraries(${LIBRARY_NAME} PRIVATE <vendor_runtime_lib>)
+```
+
+Emit a `FATAL_ERROR` when the SDK is not found, naming the env var to set — copy
+the wording style of the bpu/ascend blocks. A link error 40 lines into a build is
+a worse experience than a configure-time message.
+
+**Site 2 — `csrc/CMakeLists.txt`**, define the macro:
+
+```cmake
+target_compile_definitions(${LIBRARY_NAME} PRIVATE USE_<VENDOR>=1)
+```
+
+**Site 3 — `csrc/runtime/allocator/caching_device_allocator.cc`**, two edits.
+The include block at the top, and the selection block in
+`GetCachingAllocator()`. Note the CUDA include is guarded by a **negative**
+condition listing every non-CUDA vendor:
+
+```cpp
+#if !defined(USE_ASCEND) && !defined(USE_TSINGMICRO) && !defined(USE_DCU) && \
+    !defined(USE_GCU) && !defined(USE_MUSA) && !defined(USE_BPU)
+#include "backends/cuda_memory.h"
+#endif
+```
+
+**Add your `USE_<VENDOR>` to that negative list.** Forgetting it is the single
+most likely mistake in this whole skill: both `cuda_memory.h` and your header get
+included, and you get a duplicate-definition or wrong-backend selection that
+points nowhere near the real cause.
+
+Then add the `#elif defined(USE_<VENDOR>)` arm to `GetCachingAllocator()`, with a
+comment saying *why* your `provides_caching()` choice is what it is — every
+existing arm does, and those comments are the reason the DCU/MUSA divergence is
+understandable at all.
+
+**`setup.py`** — add the `ACCELERATOR == "<vendor>"` arm for SDK discovery and
+cmake args. Follow the `musa`/`gcu` arms.
+
+## Step 5 — the operator-free smoke test
+
+Two gates. Symbol completeness first, because it is instant:
+
+```bash
+nm -D torch_fl/lib/libflagos.so | grep -c ' T '   # every one of the 28 exported
+```
+
+Then behaviour. This must pass with **no operators registered** — that is the
+point. Anything that reaches a kernel does not belong in this test:
+
+```python
+import torch, torch_fl
+assert torch.flagos.device_count() > 0
+x = torch.empty(4, 4, device="flagos")          # Malloc
+h = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+d = h.to("flagos")                              # Memcpy H2D
+assert torch.equal(d.cpu(), h)                  # Memcpy D2H
+s = torch.flagos.Stream(); e = torch.flagos.Event(enable_timing=True)
+with torch.flagos.stream(s):
+    y = torch.empty(1 << 20, device="flagos")
+e.record(s); s.synchronize(); e.synchronize()
+assert e.query()
+del x, d, y
+torch.flagos.empty_cache()                      # block pool churn
+print(torch.flagos.memory_allocated(), torch.flagos.max_memory_allocated())
+```
+
+Add it as `tests/integration/test_<vendor>_runtime.py` with a
+`@pytest.mark.<vendor>` marker registered in `pyproject.toml`.
+
+Also exercise the allocator under churn — allocate/free in a loop across two
+streams. Block reuse is where an `ErrorNotReady` mapping mistake surfaces, and a
+single-allocation test will never catch it.
+
+## Done criteria
+
+- `grep -c 'FLAGOS_EXPORT Error_t' csrc/include/flagos.h` functions all
+  implemented, none stubbed to a bare `return Success;`
+- All 10 allocator virtuals implemented; `provides_caching()` decision commented
+- `USE_<VENDOR>` added at all three CMake/allocator sites, **including the
+  negative CUDA-include guard**
+- `ACCELERATOR=<vendor> pip install -e .` builds
+- Smoke test passes with zero operators registered
+- Allocator churn loop across two streams passes
+
+## What to hand off
+
+State explicitly which operator path comes next and on what evidence. If the
+vendor ships a torch wheel containing `libtorch_cuda.so` whose `nm` shows
+`at::add`/`at::mm`, go to [[cuda-compat-vendor]] — it is roughly an order of
+magnitude less work. Otherwise [[native-op-backend]]. Decide from the SDK, not
+from marketing claims about CUDA compatibility.

--- a/.claude/skills/torch-version-port/SKILL.md
+++ b/.claude/skills/torch-version-port/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: torch-version-port
+description: >
+  Port torch_fl to a different PyTorch minor version (e.g. create the 2.9 branch,
+  or bump to 2.11/2.12) — hardware-independent work covering the CPU-only torch
+  pin, ATen codegen regeneration against the new native_functions.yaml, and the
+  per-operator IListRef/ArrayRef signature reconciliation. Use this when creating
+  a new version branch, when `import torch_fl` fails with "Mismatch in kernel C++
+  signatures" after a torch bump, or when csrc/aten/generated/ needs regenerating.
+  Do NOT use this for chip enablement — see runtime-bringup first for that.
+---
+
+# Torch version port (torch_fl, hardware-independent)
+
+## Scope: one axis only
+
+This skill moves torch_fl onto a different `torch==X.Y` line. Everything it
+touches is schema- and ABI-level. **Nothing in it knows or cares which chip will
+run the kernels.**
+
+That separation is the point. Collapsing version work into chip work means every
+torch bump re-derives chip facts and every new chip re-derives version facts.
+Keep them apart:
+
+- version axis → this skill
+- the always-required device runtime → [[runtime-bringup]]
+- operators → [[cuda-compat-vendor]] or [[native-op-backend]]
+
+## Branch model
+
+Branches are **per-torch-minor and are siblings, not descendants**. `main` tracks
+one line (currently 2.10.x, per `docs/reference/compatibility.md`); `2.9`,
+`2.12`, `2.13` are peers. A chip port targets whichever version branch it needs
+and is never the reason a version branch exists.
+
+```bash
+git fetch flagos main
+git switch -c 2.9 flagos/main     # branch from main, not from another version branch
+```
+
+Branching from another version branch inherits that version's signature fixes,
+which are exactly what you are trying to re-derive. Start from `main`.
+
+Note that `main` may not carry codegen infrastructure at all — at time of writing
+`2.13` is the reference implementation for it. If `scripts/codegen_ops.py` is
+absent on your base, port the infra first (see [[cuda-op-integration]] Step 0,
+which lists the precise file set to `git checkout 2.13 --`).
+
+## Step 1 — pin a CPU-only torch, deliberately
+
+```bash
+conda create -n fl29 python=3.11 -y && conda activate fl29
+pip install torch==2.9.0+cpu --index-url https://download.pytorch.org/whl/cpu
+python -c "import torch; print(torch.__version__)"   # must print 2.9.0+cpu
+```
+
+**CPU-only is a requirement, not a convenience.** The CUDA-compatible operator
+path supplies GPU symbols out-of-band through a preloaded external
+`libtorch_cuda.so`; a pip CUDA torch in the same env introduces a second,
+possibly mismatched copy of those symbols and the resulting failures are
+attributed to codegen. `torch.__version__` must keep its `+cpu` suffix through
+the entire port — check it again at the end.
+
+## Step 2 — regenerate ATen codegen
+
+`scripts/codegen_ops.py` reads torchgen's *packaged* `native_functions.yaml`,
+which means its output is a function of the installed torch version. Regenerate
+after the pin, never before:
+
+```bash
+FLAGOS_CODEGEN_ALL=1 python scripts/codegen_ops.py
+```
+
+Emitted into `csrc/aten/generated/`: `ops.h` (typedefs + `DECLARE_DISPATCHER`),
+`ops.cc` (`ADD_IMPL_TO_DISPATCHER`), `cuda_kernels.cc` (boxing kernels), and
+`register.inc` (wrappers + `m.impl()` lines).
+
+Two things to check on the output, both cheap and both catching real problems:
+
+```bash
+# 1. No dropped operators. Any "SKIP <op>" on stderr means an op the previous
+#    version generated is now failing to generate -- investigate, do not accept.
+FLAGOS_CODEGEN_ALL=1 python scripts/codegen_ops.py 2>&1 | grep -E 'SKIP|WARN'
+
+# 2. Idempotency. A second run must produce no diff.
+FLAGOS_CODEGEN_ALL=1 python scripts/codegen_ops.py
+git diff --quiet csrc/aten/generated/ && echo idempotent || echo "NOT idempotent"
+```
+
+A non-idempotent generator (dict ordering, absolute paths, timestamps) makes
+every future rebase a conflict, so fix it here rather than downstream.
+
+## Step 3 — the signature reconciliation, which is the actual work
+
+Steps 1–2 are mechanical. This is where a version port takes its time.
+
+### The failure
+
+```
+RuntimeError: Mismatch in kernel C++ signatures
+  operator: aten::cat
+  kernel 1: ... at::ArrayRef<at::Tensor> ...
+  kernel 2: ... at::IListRef<at::Tensor> ...
+```
+
+A TensorList argument is spelled either `ArrayRef<Tensor>` or `IListRef<Tensor>`
+in the dispatcher signature, and **which one is per-operator, decided by
+torchgen's own rule** — not a global setting. torch_fl mirrors that rule in
+`scripts/codegen_ops.py` (see the comment block around line 56 and
+`use_arrayref`-style logic near line 2065). When PyTorch reclassifies an op
+between minors, the mirrored rule goes stale for that op and registration aborts
+at import.
+
+### How to resolve it
+
+Fix the **rule or its operator list in the generator**, then regenerate. Never
+hand-edit `csrc/aten/generated/*` — the next codegen run reverts it and the bug
+returns wearing a different hat.
+
+```bash
+# Ground truth for one operator, straight from the installed torch:
+python - <<'PY'
+from torchgen.model import NativeFunction
+# read the schema for the failing op out of torchgen's packaged
+# native_functions.yaml and inspect whether it is part of a structured group
+PY
+```
+
+The empirical rule as of the versions checked: an op belonging to a structured
+group takes `IListRef` (e.g. `aten::cat`); a standalone op takes `ArrayRef`. Do
+not port the *list* of exceptions across versions blindly — re-derive it from the
+installed torchgen. Reassuringly, the delta is often empty: 2.13 → 2.12 needed no
+change to the ArrayRef operator set at all, so an empty diff here is a plausible
+correct outcome, not evidence you skipped the step.
+
+### Iterate against the real error, one op at a time
+
+The import aborts on the *first* mismatch, so this is a loop, not a batch fix:
+
+```bash
+python -c "import torch_fl" 2>&1 | head -20   # names one op
+# adjust the generator's rule/list for that op, regenerate, repeat
+```
+
+## Step 4 — build and verify
+
+Build with the CUDA operator path on, since that is what codegen produces:
+
+```bash
+FLAGGEMS_KERNEL=OFF FLAGGEMS_PYTHON=OFF CUDA_KERNEL=ON pip install -e . --no-build-isolation
+```
+
+The build must use **g++ only, no nvcc**, and link only `torch_cpu_library`.
+CUDA symbols resolve at runtime from the preloaded external library. If cmake
+starts looking for nvcc, the version port has picked up a CUDA-torch dependency
+it should not have.
+
+Then, through the preload wrapper:
+
+```bash
+bash scripts/with_cuda_libtorch.sh python -c "import torch_fl; print('ok')"
+bash scripts/with_cuda_libtorch.sh python -m pytest tests/integration/ops/ \
+    -m "not flaggems and not flaggems_python" -q
+```
+
+### Known-benign failures
+
+Under the external-libtorch scheme (CPU pip torch + preload), the two
+`*_out_cuda_override` dispatch-log tests can fail with `Allocator not initialized
+for device` from `CUDACachingAllocator.cpp`. Cause: PyTorch primes the CUDA
+caching allocator inside `torch.cuda._lazy_init()`, which this scheme
+deliberately never calls; a fresh subprocess doing *nothing but* an out-variant op
+allocates into a caller-provided `out` before anything warms the allocator.
+
+This is an environment artifact, not a codegen defect — with a real pip CUDA
+torch installed the same tests pass. Accept or xfail them; do not "fix" it by
+reaching into `torch.cuda` internals, which is precisely what the scheme avoids.
+Ascend-marked tests skipping is also expected.
+
+## Step 5 — record the version in the docs that assert it
+
+A version port that leaves the docs claiming the old range is half-done. Update:
+
+- `docs/reference/compatibility.md` — the PyTorch row of "Project Compatibility"
+  states the supported range (`>=2.10,<2.11` style) and notes that generated ATen
+  bindings are tied to the minor line
+- `README.md` — the PyTorch badge
+- `pyproject.toml` / `setup.py` — any torch version constraint
+
+## Done criteria
+
+- `torch.__version__` still ends in `+cpu`
+- `FLAGOS_CODEGEN_ALL=1 python scripts/codegen_ops.py` runs clean: no `SKIP`, no
+  `WARN`, and a second run leaves no diff
+- Operator count matches what the conf lists (no silent drops vs the base branch)
+- `import torch_fl` is clean through `scripts/with_cuda_libtorch.sh`
+- `tests/integration/ops/` passes modulo the allocator cold-start tests above
+- Version claims in `compatibility.md` / `README.md` match reality
+- `ruff check .` and `ruff format --check .` pass — see [[pre-pr-checks]]
+
+## Pitfalls
+
+**Regenerating before pinning torch.** Codegen output is a function of the
+installed torch. Pin first, or you regenerate against the old schema and the
+diff is noise.
+
+**Hand-editing generated files to clear a signature mismatch.** It works until
+the next codegen run. Fix the generator.
+
+**Porting the ArrayRef exception list from another version branch.** That list
+*is* the version-specific knowledge. Re-derive it.
+
+**Installing CUDA torch to make an error go away.** It will make errors go away,
+including the ones that indicate the external-libtorch path is broken. Keep the
+env CPU-only.
+
+**Treating a green suite on one chip as a green port.** This skill is
+hardware-independent, but its verification runs on whatever chip you have. Other
+platforms are re-validated by their own bringup, and per CLAUDE.md an unvalidated
+platform must be marked **not revalidated** rather than presented as measured.

--- a/docs/development/integration-harness-design.md
+++ b/docs/development/integration-harness-design.md
@@ -1,0 +1,448 @@
+# Integration harness design: four commands for bringing up a new target
+
+> Status: design proposal. 2026-08-13. Motivated by Kunlun P800, which torch-fl
+> currently does not support at all, but written so the harness is reusable for
+> every subsequent target rather than being P800-specific.
+
+## 1. Why four commands and not one
+
+An earlier draft of this proposal modelled new-target bringup as a single
+end-to-end command. That is the wrong decomposition, because the work splits
+along two independent axes that do not co-vary:
+
+- **Which torch version are we building against?** This is hardware-independent.
+  It is about ATen schemas, dispatcher signatures, and which `torch==X+cpu` wheel
+  the build resolves against.
+- **How does this chip execute an operator?** This is hardware-specific and has
+  two fundamentally different answers — reuse a vendor-supplied CUDA-compatible
+  `libtorch_cuda.so`, or call the vendor's own operator library directly.
+
+Collapsing these into one command means every torch bump re-runs chip discovery,
+and every new chip re-derives torch-version facts that are already known. It also
+hides the one piece of work that is *unconditionally* required: the device
+runtime.
+
+The runtime is the honest common denominator. Whether a chip is CUDA-compatible
+or not, torch-fl cannot allocate a tensor on it until the `flagos` runtime
+contract is implemented. So the runtime gets its own command, and it is a
+prerequisite for both operator paths.
+
+```
+                    ┌───────────────────────────┐
+                    │ /torch-version-port       │  hardware-independent
+                    │ (axis: torch version)     │  runs on its own cadence
+                    └───────────────────────────┘
+
+                    ┌───────────────────────────┐
+                    │ /runtime-bringup          │  ALWAYS required
+                    │ (the ~40-function floor)  │  chip-specific, op-agnostic
+                    └─────────────┬─────────────┘
+                                  │ prerequisite
+                    ┌─────────────┴─────────────┐
+                    ▼                           ▼
+        ┌───────────────────────┐   ┌───────────────────────┐
+        │ /cuda-compat-vendor   │   │ /native-op-backend    │
+        │ extract + bundle the  │   │ bind the vendor op    │
+        │ vendor libtorch_cuda  │   │ library per operator  │
+        └───────────────────────┘   └───────────────────────┘
+              CUDA-compatible            not CUDA-compatible
+              (metax, dcu, ppu)          (ascend, gcu, musa)
+```
+
+`/runtime-bringup` is not a subroutine of the other two — it is a gate. Its exit
+criterion (tensors allocate, copy H2D/D2H, streams and events synchronize) is
+checkable without a single operator being registered, and both operator commands
+assume it has already passed.
+
+## 2. The runtime contract, measured
+
+The "basic 40 functions" is close to exact. Counted from the tree rather than
+from memory:
+
+| Surface | File | Count |
+|---|---|---|
+| C ABI runtime functions | `csrc/include/flagos.h` (`FLAGOS_EXPORT Error_t`) | **28** |
+| Caching-allocator virtuals | `csrc/runtime/allocator/device_memory_interface.h` (`= 0;`) | **10** |
+| Vendor stream accessor | `GetDefault<Vendor>Stream` / `GetCurrentStream` | 1–2 |
+| Build wiring | `csrc/runtime/accelerator/CMakeLists.txt` + `setup.py` selector | 2 sites |
+
+So **38 functions plus wiring** — call it 40. The 28 C functions land in exactly
+three files per vendor, and every existing backend implements all 28 (verified:
+cuda, musa, gcu, ascend, tsingmicro, bpu each expose 28):
+
+```
+csrc/runtime/accelerator/<vendor>/
+├── device.cc   #  5  GetDeviceCount, GetDevice, SetDevice,
+│               #     DeviceGetStreamPriorityRange, DeviceSynchronize
+├── memory.cc   #  9  Malloc, Free, MallocHost, FreeHost, Memcpy, MemcpyAsync,
+│               #     PointerGetAttributes, Memset, MemsetAsync
+└── stream.cc   # 14  Stream{CreateWithPriority,Create,GetPriority,Destroy,
+                #     Query,Synchronize,WaitEvent}
+                #     Event{CreateWithFlags,Create,Destroy,Record,
+                #     Synchronize,Query,ElapsedTime}
+```
+
+Plus `csrc/runtime/allocator/backends/<vendor>_memory.h` implementing the 10
+virtuals (`device_malloc`, `device_free`, `get_device_index`, `set_device`,
+`get_memory_info`, `event_create`, `event_destroy`, `event_record`,
+`event_query`, `memcpy`), with the optional `provides_caching()` escape hatch for
+platforms that already ship a mature caching allocator.
+
+This is a **fixed, enumerable, mechanically checkable** contract. That is what
+makes it a good harness target: the agent is not designing anything, it is
+filling in a known table from a vendor SDK header. Completeness is verifiable by
+counting symbols, not by judgement.
+
+---
+
+## 3. Command 1 — `/torch-version-port`
+
+**Axis:** torch version. **Hardware:** none.
+
+### Scope
+
+Adapt torch-fl to a different `torch==X.Y+cpu` line. Everything this command
+touches is schema- and ABI-level; nothing in it knows what chip will eventually
+run the kernels.
+
+```bash
+/torch-version-port 2.9
+```
+
+### What it does
+
+1. **Create/checkout the version branch.** Branches are per-torch-minor in this
+   repo (`main` tracks 2.10.x; `2.9` is a sibling, not a descendant of a chip
+   port). Establish the branch before any other command runs.
+2. **Pin the environment.** `torch==2.9.x+cpu` — CPU-only, deliberately. The
+   CUDA-compatible path supplies GPU symbols out-of-band (command 3), so a CUDA
+   pip torch in the env is a liability, not a help.
+3. **Re-run ATen codegen against the new schema.** `scripts/codegen_ops.py`
+   reads torchgen's packaged `native_functions.yaml`, so a torch bump changes its
+   output. Regenerate `csrc/aten/generated/{ops.h,ops.cc,cuda_kernels.cc,register.inc}`.
+4. **Reconcile per-operator signature splits.** The known failure mode is
+   `Mismatch in kernel C++ signatures` at `import torch_fl`, caused by ops whose
+   dispatcher signature uses `IListRef` vs `ArrayRef` differently between
+   versions. The existing `cuda-op-integration` skill documents this; this
+   command inherits that procedure and its `ARRAYREF_OPS` list.
+5. **Prove codegen idempotency.** A second run must produce no diff. This is a
+   hard gate — a non-idempotent generator makes every future rebase a conflict.
+6. **Update the declared range.** `pyproject.toml`, `docs/reference/compatibility.md`
+   (the `PyTorch` row currently reads `>=2.10,<2.11`), and the README badge.
+
+### Exit criteria
+
+- `python scripts/codegen_ops.py` emits the full conf op count with no WARNINGs
+- second codegen run leaves `git diff` empty
+- `import torch_fl` clean, no signature mismatch
+- `torch.__version__` still ends in `+cpu`
+- existing platform tests for at least one already-supported chip still pass
+
+### Relationship to existing skills
+
+This command is a **generalization of `cuda-op-integration`**, which today is
+written specifically around CUDA boxing on a new torch branch. The version-port
+concerns (codegen, signature splits, idempotency) belong here; the
+CUDA-boxing-specific concerns (external `libtorch_cuda.so`, `LD_PRELOAD`) belong
+in command 3. Splitting them is the main refactor this design implies for the
+existing skill.
+
+---
+
+## 4. Command 2 — `/runtime-bringup`
+
+**Axis:** hardware. **Operator-agnostic.** Required for every target.
+
+### Scope
+
+Implement the 38-function contract in §2 for a new chip and nothing more. No
+operators, no boxing, no kernel library. The deliverable is a build in which a
+`flagos` tensor can be allocated, filled from host memory, copied back, and
+synchronized — with every operator still falling back to CPU.
+
+```bash
+/runtime-bringup kunlun --sdk-path /opt/kunlun/xre
+```
+
+### Naming note
+
+Do not use `xpu` as the `ACCELERATOR` value for Kunlun. `torch.xpu` is PyTorch's
+own Intel GPU namespace, and a `ACCELERATOR=xpu` selector inside a PyTorch
+plugin will be read as Intel by every future reader. Use `kunlun`.
+
+### Phase 2a — SDK reconnaissance (read-only)
+
+Discover, from the vendor SDK, the concrete answer to each of the 38 slots.
+Output is a structured mapping report, committed as
+`docs/vendors/<vendor>/runtime-api-map.md`:
+
+- the runtime shared library and its header set (for Kunlun: XRE — `libxpurt.so`
+  and `xpu/runtime.h`, to be confirmed against the actual SDK, not assumed)
+- device: enumerate / get / set / synchronize entry points
+- memory: device alloc/free, pinned-host alloc/free, sync + async memcpy, memset,
+  pointer attribute query, and free/total memory query
+- stream & event: create-with-priority, query, wait, elapsed-time. Priority range
+  is the slot most often absent; record the clamp behaviour rather than inventing one
+- error enum → `Error_t` mapping (`Success`, `ErrorNotReady`, `ErrorInvalidDevice`,
+  `ErrorMemoryAllocation`, `ErrorUnknown`)
+
+Two findings must be recorded explicitly because they change the generated code
+rather than just filling it in:
+
+1. **Missing slots.** If the SDK has no event-elapsed-time, or no async memset,
+   that is a real capability gap. It must be recorded and surfaced, not silently
+   stubbed with `return Success`. A stub that lies about completion produces
+   silent wrong results downstream.
+2. **Whether the vendor ships a caching allocator.** Determines
+   `provides_caching()`. Getting this wrong costs either performance (redundant
+   double-caching) or correctness of memory stats.
+
+### Phase 2b — Generate the three files plus the allocator
+
+Emit `device.cc` / `memory.cc` / `stream.cc` and
+`allocator/backends/<vendor>_memory.h` from the mapping report, using an existing
+backend as the structural template. Pick the template by shape, not
+alphabetically: `musa` for a CUDA-shaped runtime with renamed symbols, `ascend`
+for a runtime with its own idioms and a self-managed allocator.
+
+### Phase 2c — Build wiring
+
+- `csrc/runtime/accelerator/CMakeLists.txt` — an `elseif(ACCELERATOR STREQUAL
+  "<vendor>")` arm for the source subdirectory and one for include/link paths
+  (both lists exist separately in that file; both need the arm)
+- `setup.py` — the `ACCELERATOR` branch for SDK detection, with a clear
+  actionable error when the SDK is absent, matching the DTK/BPU precedent
+- `torch_fl/configs/backends_<vendor>.conf` — created, and for this command
+  deliberately near-empty: every operator falls back to CPU
+
+### Exit criteria — checkable without any operator
+
+```python
+import torch, torch_fl
+t = torch.empty(4, 4, device="flagos")            # allocator reached
+h = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+d = h.to("flagos"); back = d.cpu()                # H2D + D2H round-trip
+assert torch.equal(h, back)
+torch_fl.synchronize()                            # stream/event path live
+print(torch_fl.device_count(), torch_fl.memory_allocated())
+```
+
+Symbol-count check as a mechanical gate:
+
+```bash
+grep -c 'FLAGOS_EXPORT Error_t' csrc/include/flagos.h     # expect 28
+grep -oE '^Error_t [A-Za-z]+\(' csrc/runtime/accelerator/<vendor>/*.cc | wc -l
+```
+
+The two numbers must agree, and every unimplemented slot must be an explicit
+documented gap rather than a missing symbol found at link time.
+
+---
+
+## 5. Command 3 — `/cuda-compat-vendor`
+
+**Axis:** hardware. **Precondition:** command 2 passed.
+
+### Scope
+
+For a chip whose vendor ships a CUDA-compatible PyTorch build, harvest the
+vendor's own `libtorch_cuda.so` and reuse PyTorch's CUDA kernels through zero-copy
+device-metadata boxing. Zero kernels are written.
+
+```bash
+/cuda-compat-vendor kunlun --vendor-torch /opt/kunlun/torch
+```
+
+### Why this works, and its one hard constraint
+
+`docs/vendors/cuda/external-libtorch-cuda.md` records the measured result: a
+CPU-only pip torch plus an externally supplied `libtorch_cuda.so` registers real
+CUDA implementations for `aten::mm` / `add` / `_softmax` / `bmm` and computes
+correct results (`mm max_err = 9.5e-06`). The hard constraint is **load timing**:
+the library must be loaded before `import torch`, hence `LD_PRELOAD` and
+`scripts/with_cuda_libtorch.sh`.
+
+### Phase 3a — Establish CUDA compatibility (a gate, not an assumption)
+
+This command must not be entered on a hunch. The check is concrete: take the
+vendor's torch install and confirm it registers a **CUDA** dispatch key rather
+than occupying PrivateUse1.
+
+```bash
+python -c "
+import torch
+print(torch.__version__)
+print(torch._C._dispatch_dump('aten::mm'))
+"
+```
+
+- **CUDA key present** → this command applies (the metax / dcu / ppu pattern).
+- **PrivateUse1** → stop and use command 4. torch-fl itself occupies
+  PrivateUse1, so there is no key left to box into. This is not a theory: the
+  Ascend write-up records both `libtorch_npu` fallback and dispatch interception
+  as measured and closed off.
+
+For Kunlun specifically, this gate decides the whole route and its answer is not
+yet known in this repo. It must be measured on a real P800 with the real vendor
+SDK before either operator command is picked. Do not infer it from marketing
+material about CUDA source compatibility — source compatibility of kernel code
+says nothing about which dispatch key the vendor's torch registers.
+
+### Phase 3b — Harvest and bundle
+
+The extraction target is the vendor's torch install (or wheel), not an NVIDIA
+wheel:
+
+1. Locate `libtorch_cuda.so` + `libc10_cuda.so` in the vendor's `torch/lib`.
+2. **Verify the exact version match** against the branch's torch version.
+   Constraint 3 of the CUDA doc: versions must match exactly. A vendor torch
+   built on 2.9.0 pairs only with the `2.9` branch — this is precisely why
+   command 1 exists as a separate axis, and why the branch is chosen first.
+3. Stage into the assets dir and bundle. `setup.py::_bundle_cuda_assets()`
+   already implements this, gated on `ACCELERATOR == "cuda"` and reading
+   `FLAGOS_CUDA_ASSETS_DIR`. Extending that gate to accept a vendor selector is
+   the code change this command needs — the copy logic itself is done, including
+   the size-comparison skip that avoids re-copying ~1GB.
+4. Record the provenance: vendor SDK version, torch version, `.so` sizes and
+   hashes. A bundled 1GB binary of unclear origin is a supply-chain problem, and
+   redistribution terms for a vendor `.so` are a licensing question for a human,
+   not for the agent. The harness stages and documents; it does not decide.
+
+### Phase 3c — Route operators through boxing
+
+Populate `backends_<vendor>.conf` from `backends_cuda.conf`, then narrow it by
+measurement. Vendor CUDA-compatibility is rarely total; the honest output is a
+conf where each entry was tested, and unsupported ops fall back explicitly.
+
+### Exit criteria
+
+- vendor `.so` version matches the branch torch version exactly
+- `import torch_fl` clean through `with_cuda_libtorch.sh`
+- `torch.__version__` still `+cpu` — no vendor CUDA torch installed into the env
+- `tests/integration/ops/` passing for routed ops, with failures either fixed or
+  removed from the conf, never left silently routed
+- provenance recorded in `docs/vendors/<vendor>/installation.md`
+
+### Known cold-start artifact
+
+The first CUDA op in a fresh process can hit `Allocator not initialized for
+device`, because this scheme deliberately never calls
+`torch.cuda._lazy_init()`. It surfaces on out-variants (`mm.out`, `bmm.out`) run
+as the very first op. It is an artifact of the external-libtorch scheme, not a
+defect in the port; do not "fix" it by reaching into `torch.cuda` internals,
+which is exactly what the scheme avoids.
+
+---
+
+## 6. Command 4 — `/native-op-backend`
+
+**Axis:** hardware. **Precondition:** command 2 passed and command 3's gate
+returned "not CUDA-compatible".
+
+### Scope
+
+Bind the vendor's own operator library per operator. Each kernel marshals its
+arguments, allocates and shape-infers its own output, and invokes the vendor
+call. This is the Ascend/GCU/MUSA route.
+
+```bash
+/native-op-backend kunlun --op-lib libxdnn.so --category unary
+```
+
+### Reuse what already exists
+
+The Ascend aclnn codegen is a working precedent and its architecture transfers
+directly. Three properties matter:
+
+- **Dispatcher declarations are reused, not re-declared.** `generated/ops.h`
+  already has the `XxxFn` typedefs and `DECLARE_DISPATCHER`; `ops.cc` has
+  `ADD_IMPL_TO_DISPATCHER`; `register.inc` binds the ATen op. A native backend
+  emits only `REGISTER_IMPL_TO_DISPATCHER(XxxFn, xxx_dispatcher,
+  Backend::k<Vendor>, XxxKernel<Vendor>)`.
+- **Symbol names must agree with the ATen codegen.** Reuse
+  `codegen_ops.py:schema_to_cpp_name()` or the link fails.
+- **Category-driven, not operator-driven.** The vendor calling convention is
+  uniform; the real variation is argument marshalling and output allocation,
+  which is consistent *within* a category. Ascend reached 63 categories covering
+  138 operators this way. Expand category by category, verifying each against
+  CPU on real hardware before starting the next.
+
+### Phase 4a — Recon the operator library
+
+The critical asymmetry versus command 3: **the ATen schema does not carry the
+vendor API name or the marshalling rules.** A native backend therefore needs a
+hand-maintained mapping table, and the agent's job is to propose entries and
+verify them, not to guess them. Record: the two-stage vs single-call convention,
+the tensor/scalar/int-array wrapper types, the dtype enum mapping, and how
+workspace is requested.
+
+### Phase 4b — Emit kernels by category
+
+Generate into `csrc/aten/backends/<vendor>/generated/<vendor>_kernels.cc`.
+Hand-written and generated registrations are **mutually exclusive** — a duplicate
+registration for the same backend slot is a hard error at import — so the
+generator reads a skip list. The Ascend principle applies: anything a category
+can express goes through codegen; hand-writing is reserved for what codegen
+cannot express.
+
+### Phase 4c — Route and verify per operator
+
+Add `op = <vendor>` lines to `backends_<vendor>.conf` only for operators that
+have passed a CPU-comparison test on real hardware. Unrouted operators reach
+`cpu_fallback`.
+
+### Exit criteria
+
+- each claimed operator has a recorded max-error against CPU on real hardware
+  (the Ascend bar: unary ≤4.4e-5, binary ≤4.7e-6, comparisons exact)
+- no duplicate backend-slot registration
+- conf regeneration idempotent
+- `docs/reference/operator-support.md` updated from **measured** results, per
+  CLAUDE.md's operator-support rule — routing configuration is not evidence
+
+---
+
+## 7. Applying this to Kunlun P800
+
+The sequence is fixed by the dependency graph, and the branching decision sits in
+the middle where it can be made from evidence:
+
+1. `/torch-version-port 2.9` — create the `2.9` branch, pin `torch==2.9.x+cpu`,
+   regenerate ATen bindings. No P800 needed; can start immediately.
+2. `/runtime-bringup kunlun --sdk-path <XRE>` — the 38-function floor. Needs the
+   SDK; needs a P800 only for the final round-trip check.
+3. **Run command 3's Phase 3a gate on real hardware.** Dump the dispatch table of
+   the vendor's torch. This is the one unknown that determines everything after
+   it, and it is cheap to answer once hardware is in hand.
+4. Then either `/cuda-compat-vendor kunlun` or `/native-op-backend kunlun`.
+
+Two things block on access rather than on design: the XRE/XDNN SDK, and a P800
+for the gate in step 3. Steps 1 and 2a can proceed without either — the
+reconnaissance phase is read-only over headers.
+
+## 8. What changes in the existing skills
+
+- `cuda-op-integration` splits: version-port concerns move to command 1, the
+  external-libtorch and boxing concerns become command 3. The skill as written
+  conflates them, which is why it reads as CUDA-only despite most of its content
+  being version-generic.
+- `pre-pr-checks` is unchanged and remains the final step of all four commands.
+- The four commands share the reconnaissance-report convention
+  (`docs/vendors/<vendor>/*-api-map.md`): a committed, human-reviewable artifact
+  produced before any code is generated. It is the review surface — reviewing a
+  mapping table is tractable, reviewing 138 generated kernels is not.
+
+## 9. Design principles carried across all four
+
+1. **Recon is read-only and its output is committed.** Generation never happens
+   in the same step as discovery.
+2. **Gaps are recorded, never stubbed.** A missing SDK slot is documented as a
+   capability gap. A stub returning `Success` for an operation that did not
+   happen is worse than a link error.
+3. **Support claims come from measurement.** Every "supported" entry traces to a
+   test run on real hardware, per CLAUDE.md. Routing config is not evidence.
+4. **Idempotency is a gate, not a nicety.** Every generator's second run must
+   produce no diff.
+5. **The agent stages, humans decide.** Redistributing a vendor `.so`, promoting
+   a platform's status, merging a branch — the harness prepares these with
+   provenance and stops.


### PR DESCRIPTION
## AI Agent Information

- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @zhaoyinglia
- **Session Summary**: The user requested a reusable AI harness for bringing unsupported accelerators into torch_fl, starting with Kunlun P800. The design was refined from one end-to-end command into four independently reusable skills: torch version porting, mandatory runtime bringup, CUDA-compatible vendor integration, and native operator backend integration.

## Summary

This PR adds four Claude Code skills and one design document for bringing new accelerator targets into torch_fl. The decomposition separates hardware-independent PyTorch version work from hardware-specific runtime and operator work, while making runtime bringup an explicit prerequisite for both operator strategies. The change is documentation and agent instructions only; it does not modify runtime behavior, build configuration, operator routing, or platform support claims.

## Change Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [ ] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected

- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [x] Platform-agnostic (all platforms)

## Problem Analysis

### What was broken/missing?

The repository had focused skills for CUDA operator regeneration and pre-PR checks, but no reusable harness for a chip that torch_fl did not support at all. The initial proposal also combined four distinct concerns into one command: PyTorch version adaptation, runtime integration, CUDA-compatible operator reuse, and native operator integration.

### Why did it happen?

The current skills evolved around existing backends and concrete maintenance tasks. A full new-chip integration crosses two independent axes that do not change together:

- PyTorch version compatibility is hardware-independent and concerns ATen schemas, torchgen output, and dispatcher signatures.
- Operator execution is hardware-specific and must choose either CUDA-compatible boxing or a direct vendor operator API.

Combining these axes would rerun hardware discovery on every PyTorch bump and rerun version work for every chip. It would also obscure the one unconditional prerequisite: the device runtime contract required before any operator can allocate, copy, or synchronize a flagos tensor.

### Investigation process:

1. Counted the runtime contract directly from `csrc/include/flagos.h` and `csrc/runtime/allocator/device_memory_interface.h`: 28 exported C ABI functions and 10 required allocator virtuals.
2. Verified that CUDA, MUSA, GCU, Ascend, TsingMicro, and BPU each implement all 28 C ABI functions, and mapped the 5 device, 9 memory, and 14 stream/event functions to their existing source files.
3. Inspected `csrc/runtime/accelerator/CMakeLists.txt`, `csrc/CMakeLists.txt`, and `csrc/runtime/allocator/caching_device_allocator.cc` to identify every required `USE_<VENDOR>` and backend-selection wiring site.
4. Inspected `setup.py::_bundle_cuda_assets()`, `scripts/with_cuda_libtorch.sh`, and `docs/vendors/cuda/external-libtorch-cuda.md` for the measured external-`libtorch_cuda.so` constraints.
5. Inspected `scripts/codegen_ascend.py`, `csrc/aten/dispatcher.h`, and `docs/vendors/ascend/aclnn-codegen.md` for the category-based native backend pattern and existing measured dead ends.

## Solution Design

### Implementation approach:

Add four independent, composable skills:

1. `/torch-version-port`: create or update a PyTorch minor-version branch using CPU-only PyTorch, regenerate ATen bindings, and reconcile per-operator `IListRef`/`ArrayRef` signature changes.
2. `/runtime-bringup`: implement the 28-function C ABI and 10-function allocator contract, wire CMake and allocator selection, and stop at an operator-free allocation/copy/stream smoke test.
3. `/cuda-compat-vendor`: prove that a vendor torch registers CUDA dispatch entries, extract and bundle the vendor `libtorch_cuda.so` set, enforce exact version matching, and preload before importing torch.
4. `/native-op-backend`: after CUDA compatibility is measured and ruled out, bind the vendor operator library through category-based code generation and verify each routed operator against CPU on hardware.

### Key design decisions:

- **Runtime is a gate, not a hidden sub-step.** It has an independently testable exit condition with zero operators registered, making subsequent operator failures attributable.
- **CUDA compatibility is measured before choosing the expensive native path.** Marketing claims about source compatibility do not prove CUDA dispatch-key registration.
- **Discovery and generation are separated.** SDK mapping reports are human-reviewable inputs; generated kernel files are not treated as the primary review surface.
- **Support claims require hardware evidence.** The skills inherit the repository rule that backend routing is not operator-support evidence.
- **Kunlun P800 remains route-neutral.** The design records the dispatcher probe that selects CUDA-compatible or native integration rather than guessing without the SDK.

### Code changes by file:

- `.claude/skills/torch-version-port/SKILL.md`: Defines the hardware-independent PyTorch minor-version port workflow, codegen idempotency gate, and signature reconciliation loop.
- `.claude/skills/runtime-bringup/SKILL.md`: Defines the complete runtime contract, file ownership, error semantics, allocator integration, build wiring, and operator-free smoke tests.
- `.claude/skills/cuda-compat-vendor/SKILL.md`: Defines compatibility proof, vendor shared-library extraction, exact version matching, preload timing, bundling, and boxing verification.
- `.claude/skills/native-op-backend/SKILL.md`: Defines native SDK reconnaissance, vendor wrappers, category-based codegen, backend routing, and per-operator CPU comparison.
- `docs/development/integration-harness-design.md`: Records the four-command dependency graph, measured runtime inventory, per-command contracts, P800 decision gate, and shared design principles.

### Changes by commit:

1. `f16f639` - `docs: add four-command integration harness skills`: Adds all four skills and the design document as one coherent documentation change.

## Verification

### Pre-submission Checklist

- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (not applicable: no typed executable code changed)
- [ ] **All tests pass** (the Python 3.11 unit suite cannot collect extension-dependent tests because `torch_fl._C` is not built in this documentation-only checkout; the two extension-independent tests are platform-skipped)
- [x] **Manual testing completed** (all referenced files and wiring sites were checked, skill frontmatter was parsed, truncation markers were checked, and the diff passed whitespace validation)
- [x] **No debug/temporary code** (no executable code changed)
- [x] **Documentation updated** (the design document is part of this PR)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results

```bash
$ python3 -m ruff check .
All checks passed!

$ python3 -m ruff format --check .
170 files already formatted

$ git diff --check flagos/main...HEAD
# No output; exit status 0
```

### Test Results

```bash
$ /public-flash/lvyufeng/miniconda3/envs/torchfl-pr/bin/python -m pytest tests/unit/ -v
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
collecting ... collected 33 items / 4 errors / 6 skipped
...
E   ModuleNotFoundError: No module named 'torch_fl._C'
!!!!!!!!!!!!!!!!!!! Interrupted: 4 errors during collection !!!!!!!!!!!!!!!!!!!!
========================= 6 skipped, 4 errors in 4.15s =========================
```

The isolated Python 3.11 environment contains NumPy and CPU-only PyTorch 2.10.0, so dependency collection progressed to the project extension boundary. The full unit suite still cannot execute because this documentation-only checkout has not built `torch_fl._C`; four directly imported tests stop collection, and additional BPU tests have the same dependency. This is a missing build artifact rather than a failing assertion from the Markdown changes.

After excluding all 12 test files that directly import `torch_fl`, the only remaining tests are platform-skipped:

```bash
$ /public-flash/lvyufeng/miniconda3/envs/torchfl-pr/bin/python -m pytest tests/unit/ -v \
    --ignore=<12 extension-dependent test files>
collecting ... collected 0 items / 2 skipped
============================== 2 skipped in 1.45s ==============================
```

### Manual Verification

```bash
# Count the fixed runtime surfaces used by the runtime-bringup skill.
$ grep -c 'FLAGOS_EXPORT Error_t' csrc/include/flagos.h
28
$ grep -c '= 0;' csrc/runtime/allocator/device_memory_interface.h
10

# Verify every existing backend implements all 28 C ABI functions.
$ for v in cuda musa gcu ascend tsingmicro bpu; do
>   n=$(grep -h -oE '^[A-Za-z_]+ (Malloc|Free|MallocHost|FreeHost|Memcpy|MemcpyAsync|PointerGetAttributes|Memset|MemsetAsync|GetDeviceCount|SetDevice|GetDevice|DeviceGetStreamPriorityRange|DeviceSynchronize|Stream[A-Za-z]*|Event[A-Za-z]*)\(' csrc/runtime/accelerator/$v/*.cc | wc -l)
>   echo "$v: $n"
> done
cuda: 28
musa: 28
gcu: 28
ascend: 28
tsingmicro: 28
bpu: 28

# Check for accidental output truncation in every skill.
$ grep -c 'truncated' .claude/skills/*/SKILL.md
.claude/skills/cuda-compat-vendor/SKILL.md:0
.claude/skills/native-op-backend/SKILL.md:0
.claude/skills/runtime-bringup/SKILL.md:0
.claude/skills/torch-version-port/SKILL.md:0
```

## Code Quality Verification

### Style Consistency

- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (no reinventing)

### Edge Cases Considered

1. A vendor that ships a true `libcudart` shim should reuse `accelerator/cuda/*.cc` like DCU rather than receive a redundant runtime port.
2. A vendor may claim CUDA compatibility without registering the CUDA dispatch key; the skill requires a dispatcher dump before selecting the boxing path.
3. Missing runtime capabilities must be documented rather than implemented as false `Success` stubs, especially `ErrorNotReady`, OOM mapping, pointer attributes, and synchronous-copy stream draining.
4. A vendor caching allocator may conflict with torch_fl's PrivateUse1 allocator slot, as MUSA demonstrates; delegation defaults to off until slot behavior is understood.
5. Generated and hand-written native kernels cannot register the same backend slot; the native skill requires disjoint generated and `SKIP` sets.

### Potential Risks

1. Vendor SDK APIs vary enough that the skills cannot guarantee a zero-intervention port; they define gates and reviewable mappings rather than claiming universal automatic code generation.
2. P800's operator strategy remains unresolved until the vendor torch and SDK are inspected on hardware. Choosing a path before that measurement could add unnecessary work.
3. Repository architecture may evolve; because skills reference concrete files and contracts, they must be updated when those contracts change.

### Rollback Plan

Revert commit `f16f639`. The PR adds only Markdown skill and design files, so rollback has no runtime, ABI, packaging, or user-data impact.

## Related Work

- Related to existing skill `.claude/skills/cuda-op-integration/SKILL.md`
- Related to existing skill `.claude/skills/pre-pr-checks/SKILL.md`
- Related to `docs/vendors/cuda/external-libtorch-cuda.md`
- Related to `docs/vendors/ascend/aclnn-codegen.md`
- No issue is closed by this documentation-only PR.

## Explicitly Not Included

- No `2.9` branch or PyTorch 2.9 port is created; `/torch-version-port` defines that subsequent work.
- No Kunlun runtime or XDNN operator code is implemented.
- No claim is made about whether P800 is CUDA-dispatch compatible.
- No shared vendor binaries are downloaded, bundled, or redistributed.
- No platform compatibility or operator-support status is changed.

## Human Review Notes

### Areas needing special attention:

1. Whether the four-command boundary matches the maintainers' preferred ownership boundaries for future backend work.
2. Whether the 28 C ABI plus 10 allocator virtuals accurately represent the intended minimum runtime contract.
3. Whether P800 route selection should remain a measured gate or whether maintainers already have vendor evidence that selects one path.

### Questions for reviewer:

1. Should the existing `cuda-op-integration` skill eventually be split or redirected so that version-specific content points to `/torch-version-port` and vendor boxing content points to `/cuda-compat-vendor`?
2. Should future vendor integrations commit SDK API mapping reports under `docs/vendors/<vendor>/` before generated code, as proposed here?

## Additional Context

The design was motivated by Kunlun P800, but no skill is P800-specific. The intended sequence is:

```text
/torch-version-port <version>       # independent version axis
/runtime-bringup <vendor>           # mandatory hardware floor
               |
               +-- /cuda-compat-vendor <vendor>
               +-- /native-op-backend <vendor>
```

The operator branch is selected by measured dispatch-key evidence, not by product positioning.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
