### PR TITLE
fix: correct FlagTree install-time integration

### DIFF
--- a/docs/architecture/torch-compile-integration.md
+++ b/docs/architecture/torch-compile-integration.md
@@ -21,7 +21,8 @@ output = compiled_model(input)
 - Automatic kernel fusion (no manual optimization needed), cutting per-op dispatch overhead
 - Graph stays on flagos: no cuda round trip, no copy at the graph boundary
 - Compatible with existing flagos dispatch (FlagGems Python/C++, CUDA boxing)
-- Optional FlagTree integration for multi-backend compilation
+- Optional FlagTree compilation for multi-backend kernel generation (drop-in: it
+  replaces `triton` at install time, so no code change is needed)
 
 ## Quick Start
 
@@ -64,20 +65,76 @@ compile. Note that CUDA graphs are always forced off (see Limitations), so
 `mode="reduce-overhead"` -- whose main lever is cudagraphs -- has little effect
 here.
 
-### FlagTree Integration (Phase 2)
+### FlagTree Integration
 
-Use FlagTree for multi-backend kernel compilation:
+[FlagTree](https://github.com/flagos-ai/FlagTree) is a Triton fork whose kernel
+compiler targets many vendor backends. It integrates by **substitution at install
+time**, which is the whole thing to understand about it:
+
+- Its wheel is named `flagtree`, but the module it installs is **`triton`**.
+- Installing it **uninstalls the official `triton`** and takes its place.
+- So `import flagtree` never works, and inductor's own `import triton` already
+  resolves to FlagTree once installed. Nothing in `torch_fl` patches `sys.modules`.
+
+There is no `flagtree` package on PyPI; build it from source. On a machine whose
+`triton` is in use by FlagGems, build into a separate virtualenv, since the
+install removes the existing `triton`:
 
 ```bash
-# Install FlagTree
-pip install flagtree
+# System deps (nlohmann-json must match cmake/json-version.txt)
+apt install zlib1g-dev libxml2-dev nlohmann-json3-dev
 
-# Enable FlagTree backend
-export FLAGOS_USE_FLAGTREE=1
-python your_script.py
+git clone https://github.com/flagos-ai/FlagTree.git
+cd FlagTree
+pip install -r python/requirements.txt
+
+# Pick the vendor backend. Do NOT set this for nvidia or amd.
+# export FLAGTREE_BACKEND=metax
+
+# Repo root for Triton 3.4+ (branch main); use `cd python` first on 3.1-3.3.
+MAX_JOBS=64 pip install . --no-build-isolation -v
 ```
 
-FlagTree replaces OpenAI Triton with a multi-backend compiler supporting NVIDIA, Ascend, Cambricon, and MetaX hardware.
+LLVM arrives as a prebuilt tarball (~4.5 GB unpacked), so this does not build
+LLVM from source. Verify, from any directory other than `FlagTree/python`:
+
+```bash
+pip show flagtree                                  # wheel name
+python -c 'import triton; print(triton.__path__)'  # module name
+```
+
+Branch selects the Triton base version, which must match what your torch
+expects: `main` is Triton 3.6 (correct for torch 2.10), `triton_v3.5.x` is 3.5
+and carries the Ascend backend.
+
+#### Using a FlagTree build without replacing your triton
+
+Since FlagTree's install removes the existing `triton`, the cheapest way to test
+against it is to build into a separate virtualenv and shadow `triton` by path,
+keeping torch and `torch_fl` from your main environment. Triton does not link
+against torch, so the two mix freely as long as the Python versions match:
+
+```bash
+PYTHONPATH=/path/to/flagtree-venv/lib/python3.12/site-packages \
+  FLAGOS_USE_FLAGTREE=1 pytest tests/integration/test_compile.py
+```
+
+This avoids rebuilding `torch_fl` inside the FlagTree venv, and leaves the
+FlagGems-facing `triton` in the main environment untouched.
+
+Once built, compilation goes through FlagTree with no further configuration.
+Setting `FLAGOS_USE_FLAGTREE=1` **asserts** that the active `triton` is FlagTree
+and errors out if it is stock Triton — it cannot switch FlagTree on, because that
+was decided when the environment was built:
+
+```bash
+FLAGOS_USE_FLAGTREE=1 python your_script.py
+```
+
+Detection uses the FlagTree-only module `triton._flagtree_spec`. Note that
+`triton._flagtree_backend.FLAGTREE_BACKEND` is *not* a usable signal: it is the
+empty string on nvidia/amd builds, since upstream directs you not to set
+`FLAGTREE_BACKEND` for those.
 
 ## Architecture
 
@@ -126,15 +183,19 @@ device type equals the accelerator, so a cuda-rewritten graph produces
 stream-less autograd nodes and AOT autograd's backward trace trips
 `opt_ready_stream && opt_parent_stream` (engine.cpp:1085).
 
-### Phase 2: FlagTree Integration
+### FlagTree Compilation
 
 **Components**:
-1. **Triton import patcher** (`torch_fl/compile/flagtree_shim.py`)
-   - Replaces `import triton` with `import flagtree`
-   - Activated via `FLAGOS_USE_FLAGTREE=1`
+1. **Detection only** (`torch_fl/compile/flagtree_shim.py`)
+   - No import patching: FlagTree *is* the `triton` module once installed, so
+     inductor picks it up with no interception
+   - `is_flagtree_active()` tests for the FlagTree-only `triton._flagtree_spec`
+   - `FLAGOS_USE_FLAGTREE=1` calls `require_flagtree()`, which errors if the
+     active Triton is stock
 
 2. **Backend selection**
-   - FlagTree backend configured via `GEMS_VENDOR` env var
+   - Chosen at FlagTree build time via `FLAGTREE_BACKEND` (unset for nvidia/amd),
+     not at runtime
    - Same Triton kernel code, different backend compiler
 
 **Benefits**:
@@ -166,7 +227,7 @@ FLAGOS_USE_FLAGTREE=1 python tests/perf/bench_compile.py
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `FLAGOS_USE_FLAGTREE` | `0` | Use FlagTree instead of OpenAI Triton |
+| `FLAGOS_USE_FLAGTREE` | `0` | Require the active triton to be FlagTree (assert, not switch) |
 | `FLAGOS_COMPILE_FALLBACK_EAGER` | `0` | Fall back to eager on compile errors |
 
 Existing dispatch variables (`FLAGOS_USE_FLAGGEMS`, `FLAGOS_BACKEND_CONFIG`) still apply to compiled kernels.
@@ -193,14 +254,22 @@ Existing dispatch variables (`FLAGOS_USE_FLAGGEMS`, `FLAGOS_BACKEND_CONFIG`) sti
 
 **Debug**: Run with `TORCH_LOGS="+inductor"` to see fusion decisions.
 
-### FlagTree Not Loading
+### FlagTree Not Active
 
-**Symptom**: `FLAGOS_USE_FLAGTREE=1` but warning says "falling back to OpenAI Triton".
+**Symptom**: `FLAGOS_USE_FLAGTREE=1` raises "the active 'triton' module is stock
+Triton, not FlagTree".
 
-**Solutions**:
-1. Install FlagTree: `pip install flagtree`
-2. Verify import works: `python -c "import flagtree"`
-3. Check FlagTree supports your hardware (`GEMS_VENDOR` setting)
+The env's `triton` is the official one. FlagTree is selected when the environment
+is built, so this cannot be fixed at runtime — build FlagTree per the section
+above, into this interpreter. Check what you have with:
+
+```bash
+python -c 'import triton; print(triton.__path__)'
+python -c 'import importlib.util as u; print(u.find_spec("triton._flagtree_spec") is not None)'
+```
+
+Do not reach for `import flagtree` when debugging this; that module does not
+exist at any point, whether or not FlagTree is installed.
 
 ## Testing
 
@@ -216,8 +285,8 @@ pytest tests/integration/test_compile.py::test_compile_backward
 pytest tests/integration/test_compile.py -k fake_tensor
 pytest tests/integration/ops/test_clamp_dispatch.py -v
 
-# Test FlagTree integration (requires flagtree installed)
-FLAGOS_USE_FLAGTREE=1 pytest tests/integration/test_compile.py::test_flagtree_integration
+# Test FlagTree compilation (requires a FlagTree-built env)
+FLAGOS_USE_FLAGTREE=1 pytest tests/integration/test_compile.py::test_flagtree_compiles_correct_results
 ```
 
 ### Codegen fixes this integration required
@@ -249,7 +318,12 @@ tests live alongside it:
 ## Roadmap
 
 - [x] Phase 1: Inductor integration (flagos as a first-class GPU device)
-- [ ] Phase 2: FlagTree integration — shim exists, not yet exercised end-to-end
+- [x] Phase 2: FlagTree integration — needs no shim; FlagTree substitutes for
+      triton at install time, so inductor picks it up unaided. Built from source
+      on H800 (`flagtree-0.6.0`, Triton 3.6, nvidia backend).
+- [x] `torch.compile(backend="flagos")` end-to-end on FlagTree — forward and
+      backward compile and match eager, with inductor's fused kernels built to
+      PTX/cubin by FlagTree. Full `test_compile.py` passes 15/15 there.
 - [ ] Benchmark fusion gains vs. stock inductor+triton on cuda
 - [ ] Phase 3: FlagGems-aware fusion (recognize pre-optimized patterns)
 - [ ] Phase 4: Custom fusion patterns for flagos-specific ops

--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -15,7 +15,7 @@
 """
 Integration tests for torch.compile on flagos device.
 
-Tests basic compilation, fusion gains, and FlagTree integration (Phase 2).
+Tests basic compilation, fusion gains, and FlagTree detection.
 """
 
 import os
@@ -264,34 +264,56 @@ def test_fake_tensor_linear(device):
         assert out.device.type == x.device.type
 
 
+def test_flagtree_requires_flagtree_install():
+    """FLAGOS_USE_FLAGTREE=1 must not silently no-op on a stock-Triton env.
+
+    FlagTree replaces triton at install time, so the flag can only assert; it
+    cannot switch anything on. Whichever Triton this env has, exactly one of the
+    two branches below is the correct behaviour.
+    """
+    from torch_fl.compile.flagtree_shim import is_flagtree_active, require_flagtree
+
+    if is_flagtree_active():
+        require_flagtree()  # must not raise
+    else:
+        with pytest.raises(RuntimeError, match="not FlagTree"):
+            require_flagtree()
+
+
+def test_flagtree_is_never_importable_as_flagtree():
+    """Guard the packaging trap: the wheel is 'flagtree', the module is 'triton'.
+
+    A future contributor reaching for `import flagtree` would write code that can
+    only ever raise, which is exactly the bug this test pins down.
+    """
+    import importlib.util
+
+    assert importlib.util.find_spec("flagtree") is None
+
+
 @pytest.mark.skipif(
     os.environ.get("FLAGOS_USE_FLAGTREE", "0") != "1",
-    reason="FlagTree integration not enabled (set FLAGOS_USE_FLAGTREE=1)",
+    reason="FlagTree compilation not requested (set FLAGOS_USE_FLAGTREE=1)",
 )
-def test_flagtree_integration(device):
-    """
-    Test FlagTree integration (Phase 2).
+def test_flagtree_compiles_correct_results(device):
+    """Compiling through FlagTree must match eager.
 
-    Requires: pip install flagtree + FLAGOS_USE_FLAGTREE=1
+    Requires a FlagTree-built env; see docs/architecture/torch-compile-integration.md.
     """
+    from torch_fl.compile.flagtree_shim import is_flagtree_active
+
+    if not is_flagtree_active():
+        pytest.skip("active triton is stock Triton, not FlagTree")
+
     model = SimpleModel().to(device)
     x = torch.randn(32, 128, device=device)
 
-    # Compile should use FlagTree instead of OpenAI Triton
+    eager_output = model(x)
     compiled_model = torch.compile(model, backend="flagos")
     output = compiled_model(x)
 
-    eager_output = model(x)
+    assert_on_flagos(output)
     torch.testing.assert_close(output, eager_output, rtol=1e-4, atol=1e-4)
-
-    # Verify FlagTree was actually used (check sys.modules)
-    import sys
-
-    if "flagtree" in sys.modules:
-        # FlagTree loaded successfully
-        pass
-    else:
-        pytest.skip("FlagTree not loaded (may have fallen back to OpenAI Triton)")
 
 
 def test_compile_fallback_eager():

--- a/tests/perf/bench_compile.py
+++ b/tests/perf/bench_compile.py
@@ -21,7 +21,7 @@ parity with inductor+triton performance gains.
 Usage:
     python tests/perf/bench_compile.py
     python tests/perf/bench_compile.py --model=mlp --batch-size=128
-    FLAGOS_USE_FLAGTREE=1 python tests/perf/bench_compile.py  # Phase 2
+    FLAGOS_USE_FLAGTREE=1 python tests/perf/bench_compile.py  # require FlagTree
 """
 
 import argparse

--- a/torch_fl/compile/README.md
+++ b/torch_fl/compile/README.md
@@ -82,16 +82,19 @@ Event/Stream shims that inductor's autotuner needs.
 
 ## Environment Variables
 
-- `FLAGOS_USE_FLAGTREE=1` - Reserved for FlagTree integration (Phase 2)
+- `FLAGOS_USE_FLAGTREE=1` - Assert that the active `triton` is FlagTree, erroring
+  out if it is stock Triton. FlagTree replaces `triton` at install time, so this
+  can only check; it cannot switch anything on. See
+  [`docs/architecture/torch-compile-integration.md`](../../docs/architecture/torch-compile-integration.md).
 - `FLAGOS_COMPILE_FALLBACK_EAGER=1` - Fall back to eager mode on compile errors
 
 ## Limitations
 
 1. Single device - multi-GPU compilation not yet exercised
-2. FlagTree integration is a stub (Phase 2)
+2. FlagTree verified on nvidia/sm90 only; other vendor backends untested here
 
 ## Future Work
 
-- [ ] FlagTree integration to replace OpenAI Triton
+- [ ] Exercise `torch.compile(backend="flagos")` on a FlagTree-built env
 - [ ] Benchmark fusion gains against stock inductor+triton on cuda
 - [ ] Multi-GPU compilation support

--- a/torch_fl/compile/__init__.py
+++ b/torch_fl/compile/__init__.py
@@ -23,9 +23,9 @@ fusion, with device context patched to target the flagos device. Generated
 Triton kernels dispatch through the existing flagos routing infrastructure
 (kFlagOsPython/kFlagOs/cuda boxing).
 
-Optional FlagTree integration (Phase 2):
-    FLAGOS_USE_FLAGTREE=1 model = torch.compile(model, backend="flagos")
-This replaces OpenAI Triton with FlagTree for multi-backend kernel compilation.
+FlagTree compiles these kernels instead of OpenAI Triton when it is installed,
+which requires no change here: FlagTree replaces the `triton` module at install
+time. FLAGOS_USE_FLAGTREE=1 asserts that it really is the active Triton.
 """
 
 from torch_fl.compile.inductor_backend import flagos_compile_backend

--- a/torch_fl/compile/flagtree_shim.py
+++ b/torch_fl/compile/flagtree_shim.py
@@ -13,74 +13,71 @@
 # limitations under the License.
 
 """
-FlagTree integration for torch.compile (Phase 2).
+FlagTree detection for torch.compile.
 
-Patches inductor's Triton imports to use FlagTree instead of OpenAI Triton,
-enabling multi-backend kernel compilation (NVIDIA/Ascend/Cambricon/MetaX).
+FlagTree is a Triton fork that substitutes itself for Triton *at install time*:
+its wheel is named ``flagtree``, but the module it installs is ``triton``, and
+installing it uninstalls the official ``triton``. So inductor's own
+``import triton`` already resolves to FlagTree once it is installed, and nothing
+here needs to patch ``sys.modules`` -- there is no ``flagtree`` module to import.
 
-Activated via FLAGOS_USE_FLAGTREE=1 environment variable.
+This module therefore only *reports* which Triton is active, so that
+FLAGOS_USE_FLAGTREE=1 can assert FlagTree is really in use instead of silently
+compiling with stock Triton.
 """
 
-import sys
+import importlib.util
+from typing import Optional
 
 
-_original_triton = None
-_patched = False
+# FlagTree-only module. Present regardless of which vendor backend was built,
+# unlike triton._flagtree_backend.FLAGTREE_BACKEND, which is the empty string on
+# nvidia/amd because upstream tells you not to set FLAGTREE_BACKEND for those.
+_FLAGTREE_MARKER = "triton._flagtree_spec"
 
 
-def patch_inductor_triton():
-    """
-    Replace inductor's triton imports with flagtree.
-
-    FlagTree is API-compatible with OpenAI Triton (it's a fork), so this is
-    a drop-in replacement. Inductor generates Triton kernel code; we just
-    swap which compiler JITs it.
-
-    This must be called before inductor imports triton (i.e., before the
-    first torch.compile call that uses inductor).
-    """
-    global _patched, _original_triton
-
-    if _patched:
-        return
-
+def is_flagtree_active() -> bool:
+    """Whether the importable ``triton`` is FlagTree rather than stock Triton."""
     try:
-        import flagtree as triton
+        return importlib.util.find_spec(_FLAGTREE_MARKER) is not None
+    except (ImportError, ValueError):
+        # No triton at all, or a triton too broken to introspect.
+        return False
+
+
+def flagtree_backend() -> Optional[str]:
+    """The vendor backend FlagTree was built for, if it recorded one.
+
+    Empty on nvidia/amd (upstream builds those without FLAGTREE_BACKEND set), so
+    an empty result means "FlagTree, vendor unrecorded", not "not FlagTree".
+    Returns None when FlagTree is not active.
+    """
+    if not is_flagtree_active():
+        return None
+    try:
+        from triton._flagtree_backend import FLAGTREE_BACKEND
+
+        return FLAGTREE_BACKEND
     except ImportError:
-        raise ImportError(
-            "FLAGOS_USE_FLAGTREE=1 but 'flagtree' package not installed. "
-            "Install with: pip install flagtree"
-        )
-
-    # Save original triton if already imported
-    if "triton" in sys.modules:
-        _original_triton = sys.modules["triton"]
-
-    # Replace triton in sys.modules with flagtree
-    sys.modules["triton"] = triton
-
-    # Also replace triton.language (inductor imports this)
-    if hasattr(triton, "language"):
-        sys.modules["triton.language"] = triton.language
-
-    _patched = True
+        return ""
 
 
-def unpatch_inductor_triton():
+def require_flagtree() -> None:
+    """Fail unless the active Triton is FlagTree.
+
+    Called for FLAGOS_USE_FLAGTREE=1. FlagTree cannot be enabled from here -- it
+    is chosen when the environment is built -- so the only useful thing this can
+    do is refuse to pretend.
     """
-    Restore original OpenAI Triton (for testing/cleanup).
-    """
-    global _patched, _original_triton
-
-    if not _patched:
+    if is_flagtree_active():
         return
 
-    if _original_triton is not None:
-        sys.modules["triton"] = _original_triton
-        if hasattr(_original_triton, "language"):
-            sys.modules["triton.language"] = _original_triton.language
-    else:
-        sys.modules.pop("triton", None)
-        sys.modules.pop("triton.language", None)
-
-    _patched = False
+    raise RuntimeError(
+        "FLAGOS_USE_FLAGTREE=1 but the active 'triton' module is stock Triton, "
+        "not FlagTree. FlagTree replaces triton at install time; it is not "
+        "something this process can switch on. Build it from source "
+        "(https://github.com/flagos-ai/FlagTree) -- there is no 'flagtree' "
+        "package on PyPI, and 'import flagtree' never works because the module "
+        "it installs is named 'triton'. Unset FLAGOS_USE_FLAGTREE to compile "
+        "with stock Triton instead."
+    )

--- a/torch_fl/compile/inductor_backend.py
+++ b/torch_fl/compile/inductor_backend.py
@@ -127,7 +127,7 @@ def flagos_compile_backend(
         model = torch.compile(model, backend="flagos", mode="max-autotune")
 
     Environment:
-        FLAGOS_USE_FLAGTREE=1 : Use FlagTree instead of OpenAI Triton (Phase 2)
+        FLAGOS_USE_FLAGTREE=1 : Require that the active triton be FlagTree
         FLAGOS_COMPILE_FALLBACK_EAGER=1 : Fall back to eager on compile errors
     """
     # Import inductor lazily (not all torch builds have it)
@@ -143,20 +143,13 @@ def flagos_compile_backend(
 
     config_patches = _resolve_config_patches(mode, options, dynamic)
 
-    # Phase 2 hook: FlagTree integration
-    use_flagtree = os.environ.get("FLAGOS_USE_FLAGTREE", "0") == "1"
-    if use_flagtree:
-        try:
-            from torch_fl.compile.flagtree_shim import patch_inductor_triton
+    # FlagTree substitutes itself for triton at install time, so if it is
+    # installed inductor already compiles with it and there is nothing to switch
+    # on here. This only asserts that, so the flag cannot silently no-op.
+    if os.environ.get("FLAGOS_USE_FLAGTREE", "0") == "1":
+        from torch_fl.compile.flagtree_shim import require_flagtree
 
-            patch_inductor_triton()
-        except ImportError:
-            import warnings
-
-            warnings.warn(
-                "FLAGOS_USE_FLAGTREE=1 but flagtree_shim not available. "
-                "Falling back to OpenAI Triton."
-            )
+        require_flagtree()
 
     # Make inductor treat flagos as a GPU device. Order matters: is_gpu() must
     # answer True and the device interface must be resolvable before the


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Investigated the existing FlagTree shim against the real upstream FlagTree repository, built FlagTree from source on H800, corrected the integration model, and verified `torch.compile` end to end.

## Summary

FlagTree's distribution is named `flagtree`, but it installs the Python module `triton` and replaces stock Triton at installation time. The previous shim attempted `import flagtree as triton`, so it could never activate FlagTree and silently continued with stock Triton. This PR replaces that dead runtime patch with explicit detection/assertion, adds regression coverage, and documents the correct source-build and isolated testing workflow.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [x] Refactoring
- [x] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [x] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)

The detection logic is platform-independent, but end-to-end execution was measured only on NVIDIA H800/sm90. Other FlagTree vendor backends were not revalidated.

## Problem Analysis

### What was broken/missing?

`FLAGOS_USE_FLAGTREE=1` did not enable FlagTree. `patch_inductor_triton()` attempted `import flagtree as triton`; that import always fails because FlagTree installs only a module named `triton`. The backend caught the resulting `ImportError`, emitted a warning, and compiled with stock Triton. The integration test then checked `"flagtree" in sys.modules`, which is also impossible, and skipped instead of detecting the failure.

### Why did it happen?

The original integration assumed FlagTree was a side-by-side Python package that could replace Triton at runtime. Upstream actually implements install-time substitution: the wheel/distribution is called `flagtree`, while its package and extension module are called `triton`, and installing it removes official Triton.

### Investigation process:
1. Cloned `https://github.com/flagos-ai/FlagTree` through the configured proxy and inspected `setup.py`, `python/triton`, and upstream installation guidance.
2. Built `flagtree-0.6.0+git11e9e341` from source in an isolated Python 3.12 environment and confirmed `pip show flagtree` succeeds, `import flagtree` fails, and `import triton` loads FlagTree 3.6.0.
3. Verified `triton._flagtree_spec` is a stable FlagTree-only marker; rejected `FLAGTREE_BACKEND` as the marker because it is intentionally empty for NVIDIA/AMD builds.
4. Exercised stock-Triton and FlagTree environments separately, then ran `torch.compile(backend="flagos")` forward and backward on H800.
5. Used fresh Triton cache directories to verify FlagTree emitted PTX/cubin for inductor-generated fused kernels.

## Solution Design

### Implementation approach:

Remove runtime import substitution. `is_flagtree_active()` detects the FlagTree-only `triton._flagtree_spec`; `require_flagtree()` gives `FLAGOS_USE_FLAGTREE=1` an honest assertion semantic. When FlagTree is installed, inductor's normal `import triton` already uses it without intervention. When stock Triton is active, the flag now fails loudly instead of silently doing nothing.

### Key design decisions:

- Detect a FlagTree-only module rather than distribution metadata, so editable/source installs and renamed wheel distributions remain supported.
- Do not use `FLAGTREE_BACKEND` as presence detection because upstream leaves it empty on NVIDIA/AMD.
- Preserve the environment variable for compatibility, but define it as an assertion rather than a runtime switch that cannot be implemented.
- Test FlagTree in isolation through `PYTHONPATH`, avoiding replacement of the main environment's Triton and avoiding a second torch/torch_fl build.

### Code changes by file:
- `torch_fl/compile/flagtree_shim.py`: replace the impossible import/sys.modules patch with detection, backend reporting, and a clear assertion error.
- `torch_fl/compile/inductor_backend.py`: call `require_flagtree()` when requested instead of warning and silently falling back.
- `torch_fl/compile/__init__.py`: describe FlagTree's actual install-time integration.
- `tests/integration/test_compile.py`: cover stock/FlagTree detection branches, pin the packaging trap, and execute compiled correctness when FlagTree is active.
- `tests/perf/bench_compile.py`: update the environment-variable description.
- `torch_fl/compile/README.md`: document assertion semantics and the tested platform boundary.
- `docs/architecture/torch-compile-integration.md`: replace incorrect PyPI/runtime-patching instructions with the measured source-build, verification, and isolated-PYTHONPATH workflow.

### Changes by commit:
1. `bced0fe` - `fix: correct FlagTree integration for install-time substitution`: fixes detection, tests, and documentation as one atomic change.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (not separately configured; Python imports and integration tests exercised all added functions)
- [x] **Relevant tests pass** (stock Triton and real FlagTree compile suites)
- [x] **Manual testing completed** (including original failure mode and generated PTX/cubin evidence)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [x] **Documentation updated** (compile README and architecture guide)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ ruff --version
ruff 0.15.12

$ ruff check .
All checks passed!

$ ruff format --check .
170 files already formatted
```

### Test Results
```bash
$ python -m pytest tests/integration/test_compile.py -v
...
14 passed, 1 skipped, 14 warnings in 2.89s
```

The one skip is the expected FlagTree-only execution test in the stock-Triton environment.

```bash
$ PYTHONPATH=/public-flash/lvyufeng/venvs/flagtree-build/lib/python3.12/site-packages \
    FLAGOS_USE_FLAGTREE=1 python -m pytest tests/integration/test_compile.py -v
...
15 passed, 14 warnings in 3.43s
```

```bash
$ python -m pytest tests/unit/ -v
...
1 failed, 91 passed, 28 skipped, 1 warning in 9.29s
```

The unrelated pre-existing profiler test `tests/unit/test_profiler_privateuse1.py::test_stage_b_chrome_trace_has_gpu_kernels` fails on current `flagos/main` with CUPTI reporting `bufferCompleted called with unknown buffer` and no GPU trace events. An isolated rerun reproduced the same failure. This PR does not touch profiler code; all other unit tests passed.

### Manual Verification
```bash
# Before fix: the module assumed by the shim does not exist, even after FlagTree is installed.
$ /public-flash/lvyufeng/venvs/flagtree-build/bin/python -c \
    'import importlib.util as u; print(u.find_spec("flagtree"))'
None

# FlagTree is actually installed as triton.
$ /public-flash/lvyufeng/venvs/flagtree-build/bin/python -c \
    'import triton, importlib.util as u; print(triton.__version__); print(u.find_spec("triton._flagtree_spec") is not None)'
3.6.0
True

# After fix: stock Triton is rejected instead of silently accepted.
$ FLAGOS_USE_FLAGTREE=1 python <compile-smoke-test>
correctly refused: True

# After fix: real FlagTree compiles and executes the flagos model.
$ PYTHONPATH=/public-flash/lvyufeng/venvs/flagtree-build/lib/python3.12/site-packages \
    FLAGOS_USE_FLAGTREE=1 python <compile-smoke-test>
PASS: compiled matches eager; out device = flagos:0

# Fresh cache proves FlagTree compiled inductor's generated kernels.
$ find /tmp/ft_tcache -name '*.ptx' -o -name '*.cubin'
/tmp/ft_tcache/.../triton_poi_fused_addmm_relu_threshold_backward_0.ptx
/tmp/ft_tcache/.../triton_poi_fused_addmm_relu_threshold_backward_0.cubin
```

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked neighboring compile integration helpers)
- [x] Comment density matches surrounding code
- [x] Used standard importlib detection rather than adding a new dependency

### Edge Cases Considered
1. Stock Triton active: assertion raises a precise error and normal compilation remains unchanged when the assertion flag is unset.
2. FlagTree active with no recorded vendor backend: detection still succeeds on NVIDIA/AMD where `FLAGTREE_BACKEND` is intentionally empty.
3. Triton absent or broken during introspection: detection returns false instead of leaking an incidental import exception.
4. FlagTree editable/source installation: detection relies on the installed module rather than wheel metadata.
5. Forward and backward compilation: both were executed and their generated binary artifacts inspected.

### Potential Risks
1. A future FlagTree release could rename/remove `triton._flagtree_spec`; the assertion would then fail clearly rather than silently use stock Triton.
2. Only NVIDIA H800/sm90 was available for end-to-end validation; other FlagTree vendor backends remain unverified.
3. The unrelated CUPTI unit test is currently red on this machine/current main, as documented above.

### Rollback Plan

Revert commit `bced0fe`. Normal stock-Triton compilation is already covered and unchanged when `FLAGOS_USE_FLAGTREE` is unset.

## Related Work
- FlagTree upstream: https://github.com/flagos-ai/FlagTree
- No linked issue.

## Explicitly Not Included
- Changes to FlagTree upstream or vendor-specific compiler backends.
- Validation on MetaX, Ascend, PPU, or other non-NVIDIA hardware.
- FlagTree or Triton dependency changes in torch_fl packaging; FlagTree remains an explicit environment choice.
- Changes to the unrelated CUPTI profiler failure observed in the full unit suite.

## Human Review Notes

### Areas needing special attention:
1. Whether `FLAGOS_USE_FLAGTREE=1` should remain as an assertion or be deprecated entirely.
2. Whether `triton._flagtree_spec` is the preferred long-term upstream marker.
3. Accuracy of the source-build instructions across the supported FlagTree branches.

### Questions for reviewer:
1. Should follow-up work add CI coverage using a prebuilt FlagTree environment?
2. Are additional vendor maintainers needed to validate their FlagTree backends?

## Additional Context

The source build used FlagTree main commit `11e9e341`, wheel `flagtree-0.6.0+git11e9e341`, Triton 3.6.0, Python 3.12, and NVIDIA H800/sm90.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
