### PR TITLE
fix: reject incompatible flagos generators in CUDA boxing

### DIFF
--- a/csrc/aten/generated/cuda_kernels.cc
+++ b/csrc/aten/generated/cuda_kernels.cc
@@ -832,6 +832,15 @@
 namespace at::native::flagos {
 namespace {
 
+void ValidateGeneratorForCudaBoxing(
+    const ::std::optional<at::Generator>& generator) {
+  TORCH_CHECK(
+      !generator.has_value() || !generator->defined() ||
+          generator->device().type() != c10::DeviceType::PrivateUse1,
+      "Expected a 'cuda' device type for generator but found '",
+      generator->device().type(), "'");
+}
+
 at::Tensor PrivAdaptiveAvgPool2dKernelCuda(const at::Tensor & self, at::IntArrayRef output_size) {
   DeviceBoxingGuard guard(self);
   auto result = at::_adaptive_avg_pool2d(self, output_size);
@@ -3939,6 +3948,7 @@ void PrivFusedAdamwInplaceTensorLrKernelCuda(at::TensorList self, at::TensorList
 
 ::std::tuple<at::Tensor,at::Tensor> PrivFusedDropoutKernelCuda(const at::Tensor & self, double p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::_fused_dropout(self, p, generator);
   UnboxToFlagos(std::get<0>(result));
@@ -3948,6 +3958,7 @@ void PrivFusedAdamwInplaceTensorLrKernelCuda(at::TensorList self, at::TensorList
 
 ::std::tuple<at::Tensor &,at::Tensor &> PrivFusedDropoutOutKernelCuda(const at::Tensor & self, double p, ::std::optional<at::Generator> generator, at::Tensor & out0, at::Tensor & out1) {
   DeviceBoxingGuard guard(self, out0, out1);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out0.get_device());
   auto _ret = at::_fused_dropout_outf(self, p, generator, out0, out1);
   UnboxToFlagos(out0);
@@ -4775,6 +4786,7 @@ at::Tensor PrivSafeSoftmaxKernelCuda(const at::Tensor & self, int64_t dim, ::std
 
 at::Tensor PrivSampleDirichletKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::_sample_dirichlet(self, generator);
   UnboxToFlagos(result);
@@ -4783,6 +4795,7 @@ at::Tensor PrivSampleDirichletKernelCuda(const at::Tensor & self, ::std::optiona
 
 at::Tensor & PrivSampleDirichletOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::_sample_dirichlet_outf(self, generator, out);
   UnboxToFlagos(out);
@@ -5185,6 +5198,7 @@ at::Tensor & PrivStackOutKernelCuda(at::TensorList tensors, int64_t dim, at::Ten
 
 at::Tensor PrivStandardGammaKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::_standard_gamma(self, generator);
   UnboxToFlagos(result);
@@ -5193,6 +5207,7 @@ at::Tensor PrivStandardGammaKernelCuda(const at::Tensor & self, ::std::optional<
 
 at::Tensor & PrivStandardGammaOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::_standard_gamma_outf(self, generator, out);
   UnboxToFlagos(out);
@@ -6742,6 +6757,7 @@ at::Tensor & BatchNormElemtOutKernelCuda(const at::Tensor & input, const ::std::
 
 at::Tensor BernoulliKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::bernoulli(self, generator);
   UnboxToFlagos(result);
@@ -6750,6 +6766,7 @@ at::Tensor BernoulliKernelCuda(const at::Tensor & self, ::std::optional<at::Gene
 
 at::Tensor BernoulliTensorKernelCuda(const at::Tensor & self, const at::Tensor & p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self, p);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::bernoulli(self, p, generator);
   UnboxToFlagos(result);
@@ -6758,6 +6775,7 @@ at::Tensor BernoulliTensorKernelCuda(const at::Tensor & self, const at::Tensor &
 
 at::Tensor & BernoulliTensorOutKernelCuda(const at::Tensor & self, const at::Tensor & p, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, p, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::bernoulli_outf(self, p, generator, out);
   UnboxToFlagos(out);
@@ -6766,6 +6784,7 @@ at::Tensor & BernoulliTensorOutKernelCuda(const at::Tensor & self, const at::Ten
 
 at::Tensor & BernoulliFloatOutKernelCuda(const at::Tensor & self, double p, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::bernoulli_outf(self, p, generator, out);
   UnboxToFlagos(out);
@@ -6774,6 +6793,7 @@ at::Tensor & BernoulliFloatOutKernelCuda(const at::Tensor & self, double p, ::st
 
 at::Tensor & BernoulliOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::bernoulli_outf(self, generator, out);
   UnboxToFlagos(out);
@@ -6782,6 +6802,7 @@ at::Tensor & BernoulliOutKernelCuda(const at::Tensor & self, ::std::optional<at:
 
 at::Tensor & BernoulliInplaceTensorKernelCuda(at::Tensor & self, const at::Tensor & p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self, p);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.bernoulli_(p, generator);
   return self;
@@ -6789,6 +6810,7 @@ at::Tensor & BernoulliInplaceTensorKernelCuda(at::Tensor & self, const at::Tenso
 
 at::Tensor & BernoulliInplaceFloatKernelCuda(at::Tensor & self, double p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.bernoulli_(p, generator);
   return self;
@@ -6862,6 +6884,7 @@ at::Tensor & BincountOutKernelCuda(const at::Tensor & self, const ::std::optiona
 
 at::Tensor BinomialKernelCuda(const at::Tensor & count, const at::Tensor & prob, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(count, prob);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(count.get_device());
   auto result = at::binomial(count, prob, generator);
   UnboxToFlagos(result);
@@ -6870,6 +6893,7 @@ at::Tensor BinomialKernelCuda(const at::Tensor & count, const at::Tensor & prob,
 
 at::Tensor & BinomialOutKernelCuda(const at::Tensor & count, const at::Tensor & prob, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(count, prob, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::binomial_outf(count, prob, generator, out);
   UnboxToFlagos(out);
@@ -7302,6 +7326,7 @@ at::Tensor & CatOutKernelCuda(const at::ITensorListRef & tensors, int64_t dim, a
 
 at::Tensor CauchyKernelCuda(const at::Tensor & self, double median, double sigma, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::cauchy(self, median, sigma, generator);
   UnboxToFlagos(result);
@@ -7310,6 +7335,7 @@ at::Tensor CauchyKernelCuda(const at::Tensor & self, double median, double sigma
 
 at::Tensor & CauchyOutKernelCuda(const at::Tensor & self, double median, double sigma, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::cauchy_outf(self, median, sigma, generator, out);
   UnboxToFlagos(out);
@@ -7318,6 +7344,7 @@ at::Tensor & CauchyOutKernelCuda(const at::Tensor & self, double median, double 
 
 at::Tensor & CauchyInplaceKernelCuda(at::Tensor & self, double median, double sigma, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.cauchy_(median, sigma, generator);
   return self;
@@ -8639,6 +8666,7 @@ at::Tensor & Expm1InplaceKernelCuda(at::Tensor & self) {
 
 at::Tensor ExponentialKernelCuda(const at::Tensor & self, double lambd, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::exponential(self, lambd, generator);
   UnboxToFlagos(result);
@@ -8647,6 +8675,7 @@ at::Tensor ExponentialKernelCuda(const at::Tensor & self, double lambd, ::std::o
 
 at::Tensor & ExponentialOutKernelCuda(const at::Tensor & self, double lambd, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::exponential_outf(self, lambd, generator, out);
   UnboxToFlagos(out);
@@ -8655,6 +8684,7 @@ at::Tensor & ExponentialOutKernelCuda(const at::Tensor & self, double lambd, ::s
 
 at::Tensor & ExponentialInplaceKernelCuda(at::Tensor & self, double lambd, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.exponential_(lambd, generator);
   return self;
@@ -9221,6 +9251,7 @@ at::Tensor & GeluBackwardGradInputKernelCuda(const at::Tensor & grad_output, con
 
 at::Tensor GeometricKernelCuda(const at::Tensor & self, double p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::geometric(self, p, generator);
   UnboxToFlagos(result);
@@ -9229,6 +9260,7 @@ at::Tensor GeometricKernelCuda(const at::Tensor & self, double p, ::std::optiona
 
 at::Tensor & GeometricOutKernelCuda(const at::Tensor & self, double p, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::geometric_outf(self, p, generator, out);
   UnboxToFlagos(out);
@@ -9237,6 +9269,7 @@ at::Tensor & GeometricOutKernelCuda(const at::Tensor & self, double p, ::std::op
 
 at::Tensor & GeometricInplaceKernelCuda(at::Tensor & self, double p, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.geometric_(p, generator);
   return self;
@@ -10755,6 +10788,7 @@ at::Tensor & LogInplaceKernelCuda(at::Tensor & self) {
 
 at::Tensor LogNormalKernelCuda(const at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::log_normal(self, mean, std, generator);
   UnboxToFlagos(result);
@@ -10763,6 +10797,7 @@ at::Tensor LogNormalKernelCuda(const at::Tensor & self, double mean, double std,
 
 at::Tensor & LogNormalOutKernelCuda(const at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::log_normal_outf(self, mean, std, generator, out);
   UnboxToFlagos(out);
@@ -10771,6 +10806,7 @@ at::Tensor & LogNormalOutKernelCuda(const at::Tensor & self, double mean, double
 
 at::Tensor & LogNormalInplaceKernelCuda(at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.log_normal_(mean, std, generator);
   return self;
@@ -11920,6 +11956,7 @@ at::Tensor & MultilabelMarginLossBackwardGradInputKernelCuda(const at::Tensor & 
 
 at::Tensor MultinomialKernelCuda(const at::Tensor & self, int64_t num_samples, bool replacement, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::multinomial(self, num_samples, replacement, generator);
   UnboxToFlagos(result);
@@ -11928,6 +11965,7 @@ at::Tensor MultinomialKernelCuda(const at::Tensor & self, int64_t num_samples, b
 
 at::Tensor & MultinomialOutKernelCuda(const at::Tensor & self, int64_t num_samples, bool replacement, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::multinomial_outf(self, num_samples, replacement, generator, out);
   UnboxToFlagos(out);
@@ -12462,6 +12500,7 @@ at::Tensor & NormOutKernelCuda(const at::Tensor & self, const ::std::optional<at
 
 at::Tensor NormalTensorTensorKernelCuda(const at::Tensor & mean, const at::Tensor & std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(mean, std);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(mean.get_device());
   auto result = at::normal(mean, std, generator);
   UnboxToFlagos(result);
@@ -12470,6 +12509,7 @@ at::Tensor NormalTensorTensorKernelCuda(const at::Tensor & mean, const at::Tenso
 
 at::Tensor & NormalTensorTensorOutKernelCuda(const at::Tensor & mean, const at::Tensor & std, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(mean, std, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::normal_outf(mean, std, generator, out);
   UnboxToFlagos(out);
@@ -12478,6 +12518,7 @@ at::Tensor & NormalTensorTensorOutKernelCuda(const at::Tensor & mean, const at::
 
 at::Tensor NormalTensorFloatKernelCuda(const at::Tensor & mean, double std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(mean);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(mean.get_device());
   auto result = at::normal(mean, std, generator);
   UnboxToFlagos(result);
@@ -12486,6 +12527,7 @@ at::Tensor NormalTensorFloatKernelCuda(const at::Tensor & mean, double std, ::st
 
 at::Tensor & NormalTensorFloatOutKernelCuda(const at::Tensor & mean, double std, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(mean, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::normal_outf(mean, std, generator, out);
   UnboxToFlagos(out);
@@ -12494,6 +12536,7 @@ at::Tensor & NormalTensorFloatOutKernelCuda(const at::Tensor & mean, double std,
 
 at::Tensor NormalFloatTensorKernelCuda(double mean, const at::Tensor & std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(std);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(std.get_device());
   auto result = at::normal(mean, std, generator);
   UnboxToFlagos(result);
@@ -12502,6 +12545,7 @@ at::Tensor NormalFloatTensorKernelCuda(double mean, const at::Tensor & std, ::st
 
 at::Tensor & NormalFloatTensorOutKernelCuda(double mean, const at::Tensor & std, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(std, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::normal_outf(mean, std, generator, out);
   UnboxToFlagos(out);
@@ -12517,6 +12561,7 @@ at::Tensor NormalFloatFloatKernelCuda(double mean, double std, at::IntArrayRef s
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::normal(mean, std, size, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
@@ -12525,6 +12570,7 @@ at::Tensor NormalFloatFloatKernelCuda(double mean, double std, at::IntArrayRef s
 
 at::Tensor & NormalFloatFloatOutKernelCuda(double mean, double std, at::IntArrayRef size, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::normal_outf(mean, std, size, generator, out);
   UnboxToFlagos(out);
@@ -12533,6 +12579,7 @@ at::Tensor & NormalFloatFloatOutKernelCuda(double mean, double std, at::IntArray
 
 at::Tensor & NormalOutKernelCuda(const at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::normal_outf(self, mean, std, generator, out);
   UnboxToFlagos(out);
@@ -12541,6 +12588,7 @@ at::Tensor & NormalOutKernelCuda(const at::Tensor & self, double mean, double st
 
 at::Tensor & NormalInplaceKernelCuda(at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.normal_(mean, std, generator);
   return self;
@@ -12548,6 +12596,7 @@ at::Tensor & NormalInplaceKernelCuda(at::Tensor & self, double mean, double std,
 
 at::Tensor NormalFunctionalKernelCuda(const at::Tensor & self, double mean, double std, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::normal_functional(self, mean, std, generator);
   UnboxToFlagos(result);
@@ -12648,6 +12697,7 @@ at::Tensor & PixelUnshuffleOutKernelCuda(const at::Tensor & self, int64_t downsc
 
 at::Tensor PoissonKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::poisson(self, generator);
   UnboxToFlagos(result);
@@ -12656,6 +12706,7 @@ at::Tensor PoissonKernelCuda(const at::Tensor & self, ::std::optional<at::Genera
 
 at::Tensor & PoissonOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::poisson_outf(self, generator, out);
   UnboxToFlagos(out);
@@ -12942,6 +12993,7 @@ at::Tensor RandGeneratorKernelCuda(at::IntArrayRef size, ::std::optional<at::Gen
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::rand(size, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
@@ -12957,6 +13009,7 @@ at::Tensor RandGeneratorWithNamesKernelCuda(at::IntArrayRef size, ::std::optiona
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::rand(size, generator, names, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
@@ -12965,6 +13018,7 @@ at::Tensor RandGeneratorWithNamesKernelCuda(at::IntArrayRef size, ::std::optiona
 
 at::Tensor & RandGeneratorWithNamesOutKernelCuda(at::IntArrayRef size, ::std::optional<at::Generator> generator, ::std::optional<at::DimnameList> names, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::rand_outf(size, generator, names, out);
   UnboxToFlagos(out);
@@ -13012,6 +13066,7 @@ at::Tensor RandLikeKernelCuda(const at::Tensor & self, ::std::optional<at::Scala
 
 at::Tensor RandLikeGeneratorKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::rand_like(self, generator, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
@@ -13020,6 +13075,7 @@ at::Tensor RandLikeGeneratorKernelCuda(const at::Tensor & self, ::std::optional<
 
 at::Tensor & RandLikeGeneratorOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::rand_like_outf(self, generator, memory_format, out);
   UnboxToFlagos(out);
@@ -13058,6 +13114,7 @@ at::Tensor RandintGeneratorKernelCuda(int64_t high, at::IntArrayRef size, ::std:
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::randint(high, size, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
@@ -13066,6 +13123,7 @@ at::Tensor RandintGeneratorKernelCuda(int64_t high, at::IntArrayRef size, ::std:
 
 at::Tensor & RandintGeneratorOutKernelCuda(int64_t high, at::IntArrayRef size, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randint_outf(high, size, generator, out);
   UnboxToFlagos(out);
@@ -13096,6 +13154,7 @@ at::Tensor RandintLowGeneratorKernelCuda(int64_t low, int64_t high, at::IntArray
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::randint(low, high, size, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
@@ -13104,6 +13163,7 @@ at::Tensor RandintLowGeneratorKernelCuda(int64_t low, int64_t high, at::IntArray
 
 at::Tensor & RandintLowGeneratorOutKernelCuda(int64_t low, int64_t high, at::IntArrayRef size, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randint_outf(low, high, size, generator, out);
   UnboxToFlagos(out);
@@ -13144,6 +13204,7 @@ at::Tensor RandintLikeTensorKernelCuda(const at::Tensor & self, const at::Tensor
 
 at::Tensor RandintLikeTensorGeneratorKernelCuda(const at::Tensor & self, const at::Tensor & high, ::std::optional<at::Generator> generator, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self, high);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::randint_like(self, high, generator, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
@@ -13152,6 +13213,7 @@ at::Tensor RandintLikeTensorGeneratorKernelCuda(const at::Tensor & self, const a
 
 at::Tensor & RandintLikeTensorGeneratorOutKernelCuda(const at::Tensor & self, const at::Tensor & high, ::std::optional<at::Generator> generator, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, high, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randint_like_outf(self, high, generator, memory_format, out);
   UnboxToFlagos(out);
@@ -13168,6 +13230,7 @@ at::Tensor & RandintLikeTensorOutKernelCuda(const at::Tensor & self, const at::T
 
 at::Tensor RandintLikeGeneratorKernelCuda(const at::Tensor & self, int64_t high, ::std::optional<at::Generator> generator, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::randint_like(self, high, generator, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
@@ -13176,6 +13239,7 @@ at::Tensor RandintLikeGeneratorKernelCuda(const at::Tensor & self, int64_t high,
 
 at::Tensor & RandintLikeGeneratorOutKernelCuda(const at::Tensor & self, int64_t high, ::std::optional<at::Generator> generator, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randint_like_outf(self, high, generator, memory_format, out);
   UnboxToFlagos(out);
@@ -13200,6 +13264,7 @@ at::Tensor & RandintLikeLowDtypeOutKernelCuda(const at::Tensor & self, int64_t l
 
 at::Tensor RandintLikeLowGeneratorDtypeKernelCuda(const at::Tensor & self, int64_t low, int64_t high, ::std::optional<at::Generator> generator, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::randint_like(self, low, high, generator, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
@@ -13208,6 +13273,7 @@ at::Tensor RandintLikeLowGeneratorDtypeKernelCuda(const at::Tensor & self, int64
 
 at::Tensor & RandintLikeLowGeneratorDtypeOutKernelCuda(const at::Tensor & self, int64_t low, int64_t high, ::std::optional<at::Generator> generator, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randint_like_outf(self, low, high, generator, memory_format, out);
   UnboxToFlagos(out);
@@ -13246,6 +13312,7 @@ at::Tensor RandnGeneratorKernelCuda(at::IntArrayRef size, ::std::optional<at::Ge
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::randn(size, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
@@ -13261,6 +13328,7 @@ at::Tensor RandnGeneratorWithNamesKernelCuda(at::IntArrayRef size, ::std::option
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::randn(size, generator, names, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
@@ -13269,6 +13337,7 @@ at::Tensor RandnGeneratorWithNamesKernelCuda(at::IntArrayRef size, ::std::option
 
 at::Tensor & RandnGeneratorWithNamesOutKernelCuda(at::IntArrayRef size, ::std::optional<at::Generator> generator, ::std::optional<at::DimnameList> names, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randn_outf(size, generator, names, out);
   UnboxToFlagos(out);
@@ -13308,6 +13377,7 @@ at::Tensor RandnLikeKernelCuda(const at::Tensor & self, ::std::optional<at::Scal
 
 at::Tensor RandnLikeGeneratorKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, ::std::optional<at::ScalarType> dtype, ::std::optional<at::Layout> layout, ::std::optional<at::Device> device, ::std::optional<bool> pin_memory, ::std::optional<at::MemoryFormat> memory_format) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::randn_like(self, generator, dtype, layout, device, pin_memory, memory_format);
   UnboxToFlagos(result);
@@ -13316,6 +13386,7 @@ at::Tensor RandnLikeGeneratorKernelCuda(const at::Tensor & self, ::std::optional
 
 at::Tensor & RandnLikeGeneratorOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, ::std::optional<at::MemoryFormat> memory_format, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randn_like_outf(self, generator, memory_format, out);
   UnboxToFlagos(out);
@@ -13332,6 +13403,7 @@ at::Tensor & RandnLikeOutKernelCuda(const at::Tensor & self, ::std::optional<at:
 
 at::Tensor RandomKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::random(self, generator);
   UnboxToFlagos(result);
@@ -13340,6 +13412,7 @@ at::Tensor RandomKernelCuda(const at::Tensor & self, ::std::optional<at::Generat
 
 at::Tensor RandomFromKernelCuda(const at::Tensor & self, int64_t from, ::std::optional<int64_t> to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::random(self, from, to, generator);
   UnboxToFlagos(result);
@@ -13348,6 +13421,7 @@ at::Tensor RandomFromKernelCuda(const at::Tensor & self, int64_t from, ::std::op
 
 at::Tensor & RandomFromOutKernelCuda(const at::Tensor & self, int64_t from, ::std::optional<int64_t> to, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::random_outf(self, from, to, generator, out);
   UnboxToFlagos(out);
@@ -13356,6 +13430,7 @@ at::Tensor & RandomFromOutKernelCuda(const at::Tensor & self, int64_t from, ::st
 
 at::Tensor & RandomOutKernelCuda(const at::Tensor & self, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::random_outf(self, generator, out);
   UnboxToFlagos(out);
@@ -13364,6 +13439,7 @@ at::Tensor & RandomOutKernelCuda(const at::Tensor & self, ::std::optional<at::Ge
 
 at::Tensor RandomToKernelCuda(const at::Tensor & self, int64_t to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::random(self, to, generator);
   UnboxToFlagos(result);
@@ -13372,6 +13448,7 @@ at::Tensor RandomToKernelCuda(const at::Tensor & self, int64_t to, ::std::option
 
 at::Tensor & RandomToOutKernelCuda(const at::Tensor & self, int64_t to, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::random_outf(self, to, generator, out);
   UnboxToFlagos(out);
@@ -13380,6 +13457,7 @@ at::Tensor & RandomToOutKernelCuda(const at::Tensor & self, int64_t to, ::std::o
 
 at::Tensor & RandomInplaceKernelCuda(at::Tensor & self, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.random_(generator);
   return self;
@@ -13387,6 +13465,7 @@ at::Tensor & RandomInplaceKernelCuda(at::Tensor & self, ::std::optional<at::Gene
 
 at::Tensor & RandomInplaceFromKernelCuda(at::Tensor & self, int64_t from, ::std::optional<int64_t> to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.random_(from, to, generator);
   return self;
@@ -13394,6 +13473,7 @@ at::Tensor & RandomInplaceFromKernelCuda(at::Tensor & self, int64_t from, ::std:
 
 at::Tensor & RandomInplaceToKernelCuda(at::Tensor & self, int64_t to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.random_(to, generator);
   return self;
@@ -13423,6 +13503,7 @@ at::Tensor RandpermGeneratorKernelCuda(int64_t n, ::std::optional<at::Generator>
   at::Device _req_dev = device.has_value() ? *device : at::Device(at::kPrivateUse1, 0);
   at::Device _cuda_dev = _req_dev.type() == at::kPrivateUse1
       ? at::Device(at::kCUDA, _req_dev.index()) : _req_dev;
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(_cuda_dev.index());
   auto result = at::randperm(n, generator, dtype, layout, ::std::optional<at::Device>(_cuda_dev), pin_memory);
   if (result.device().type() == at::kCUDA) UnboxToFlagos(result);
@@ -13431,6 +13512,7 @@ at::Tensor RandpermGeneratorKernelCuda(int64_t n, ::std::optional<at::Generator>
 
 at::Tensor & RandpermGeneratorOutKernelCuda(int64_t n, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::randperm_outf(n, generator, out);
   UnboxToFlagos(out);
@@ -13887,6 +13969,7 @@ at::Tensor & RowIndicesCopyOutKernelCuda(const at::Tensor & self, at::Tensor & o
 
 at::Tensor RreluWithNoiseKernelCuda(const at::Tensor & self, at::Tensor & noise, const at::Scalar & lower, const at::Scalar & upper, bool training, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self, noise);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::rrelu_with_noise(self, noise, lower, upper, training, generator);
   UnboxToFlagos(result);
@@ -13895,6 +13978,7 @@ at::Tensor RreluWithNoiseKernelCuda(const at::Tensor & self, at::Tensor & noise,
 
 at::Tensor & RreluWithNoiseOutKernelCuda(const at::Tensor & self, at::Tensor & noise, const at::Scalar & lower, const at::Scalar & upper, bool training, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, noise, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(noise.get_device());
   at::rrelu_with_noise_outf(self, noise, lower, upper, training, generator, out);
   UnboxToFlagos(noise);
@@ -13904,6 +13988,7 @@ at::Tensor & RreluWithNoiseOutKernelCuda(const at::Tensor & self, at::Tensor & n
 
 at::Tensor & RreluWithNoiseInplaceKernelCuda(at::Tensor & self, at::Tensor & noise, const at::Scalar & lower, const at::Scalar & upper, bool training, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self, noise);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   at::rrelu_with_noise_(self, noise, lower, upper, training, generator);
   return self;
@@ -13925,6 +14010,7 @@ at::Tensor & RreluWithNoiseBackwardOutKernelCuda(const at::Tensor & grad_output,
 
 ::std::tuple<at::Tensor,at::Tensor> RreluWithNoiseFunctionalKernelCuda(const at::Tensor & self, const at::Tensor & noise, const at::Scalar & lower, const at::Scalar & upper, bool training, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self, noise);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::rrelu_with_noise_functional(self, noise, lower, upper, training, generator);
   UnboxToFlagos(std::get<0>(result));
@@ -16170,6 +16256,7 @@ at::Tensor & UnfoldCopyOutKernelCuda(const at::Tensor & self, int64_t dimension,
 
 at::Tensor UniformKernelCuda(const at::Tensor & self, double from, double to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   auto result = at::uniform(self, from, to, generator);
   UnboxToFlagos(result);
@@ -16178,6 +16265,7 @@ at::Tensor UniformKernelCuda(const at::Tensor & self, double from, double to, ::
 
 at::Tensor & UniformOutKernelCuda(const at::Tensor & self, double from, double to, ::std::optional<at::Generator> generator, at::Tensor & out) {
   DeviceBoxingGuard guard(self, out);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(out.get_device());
   at::uniform_outf(self, from, to, generator, out);
   UnboxToFlagos(out);
@@ -16186,6 +16274,7 @@ at::Tensor & UniformOutKernelCuda(const at::Tensor & self, double from, double t
 
 at::Tensor & UniformInplaceKernelCuda(at::Tensor & self, double from, double to, ::std::optional<at::Generator> generator) {
   DeviceBoxingGuard guard(self);
+  ValidateGeneratorForCudaBoxing(generator);
   if (!generator.has_value()) generator = at::native::flagos::GetFlagosDefaultCudaGenerator(self.get_device());
   self.uniform_(from, to, generator);
   return self;

--- a/scripts/codegen_ops.py
+++ b/scripts/codegen_ops.py
@@ -1310,16 +1310,25 @@ def optional_tensor_names(args: List[Tuple[str, str]]) -> List[str]:
 
 
 def _generator_inject_line(args, device_expr):
-    """If this op's schema carries a trailing `Generator?`, emit a line that
-    fills an absent generator with the flagos shared CUDA generator (the one
-    FlagGems reads), so torch.manual_seed unifies native + flaggems RNG.
-    Returns '' for non-RNG ops. `device_expr` is a C++ expr yielding int64
-    device index in the kernel body scope."""
+    """Emit the CUDA-boxing prelude for a schema carrying `Generator?`.
+
+    Reject a caller-supplied flagos generator before the inner ATen redispatch:
+    its PrivateUse1 key otherwise routes back to this same kernel after every
+    tensor has been boxed to CUDA, recursing until stack overflow. Its mt19937
+    state is not convertible to CUDA's philox state, so failing cleanly matches
+    native PyTorch's handling of incompatible generator devices. If no generator
+    was supplied, inject the shared CUDA generator so torch.manual_seed unifies
+    native and FlagGems RNG.
+
+    Returns '' for non-RNG ops. `device_expr` is a C++ expression yielding the
+    device index in the kernel body scope.
+    """
     has_gen = any("Generator" in t for t, _ in args)
     if not has_gen:
         return ""
     # The generator parameter is always named `generator` in the faithful sig.
     return (
+        "  ValidateGeneratorForCudaBoxing(generator);\n"
         f"  if (!generator.has_value()) generator = "
         f"at::native::flagos::GetFlagosDefaultCudaGenerator({device_expr});\n"
     )
@@ -2168,6 +2177,15 @@ def main():
         "",
         "namespace at::native::flagos {",
         "namespace {",
+        "",
+        "void ValidateGeneratorForCudaBoxing(",
+        "    const ::std::optional<at::Generator>& generator) {",
+        "  TORCH_CHECK(",
+        "      !generator.has_value() || !generator->defined() ||",
+        "          generator->device().type() != c10::DeviceType::PrivateUse1,",
+        "      \"Expected a 'cuda' device type for generator but found '\",",
+        '      generator->device().type(), "\'");',
+        "}",
         "",
     ]
     for op in sorted(op_info):

--- a/tests/integration/ops/test_rng_dispatch.py
+++ b/tests/integration/ops/test_rng_dispatch.py
@@ -90,6 +90,11 @@ def _explicit_generator(seed):
     rejected outright ("Expected a 'cpu' device type for generator"), because the
     aclnn kernels seed themselves from the default *CPU* generator.
 
+    A `flagos` generator is not a portable fallback: it carries an mt19937
+    state, while CUDA boxing needs a philox generator and aclnn consumes seeds
+    from a CPU generator. Passing the incompatible device type must raise, just
+    like native CPU/CUDA generator mismatches (and is covered below).
+
     So try CUDA first and fall back to CPU. What the two tests below assert --
     that an explicit generator is honoured and stays isolated from
     `torch.manual_seed` -- is a property of the injection logic, not of the
@@ -289,6 +294,40 @@ class TestRngSeedSource:
             warnings.simplefilter("always")
             torch.manual_seed(SEED)
         assert not [w for w in caught if "does not take effect" in str(w.message)]
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_flagos_generator_device_mismatch_raises(self):
+        # A Generator contributes its dispatch key to operator selection. After
+        # the boxed kernel changed its tensor to CUDA, a flagos generator used
+        # to select the same flagos kernel again: infinite redispatch ending in
+        # SIGSEGV. Like native device mismatches, this unsupported generator
+        # combination must fail cleanly instead.
+        gen = torch.Generator(device="flagos")
+        with pytest.raises(RuntimeError, match="device type for generator"):
+            _empty(8).normal_(generator=gen)
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_flagos_generator_factory_mismatch_raises(self):
+        # Factory RNG has no Tensor key to override the generator's PrivateUse1
+        # key, so it is a distinct recursion entry point. Only CUDA-shaped
+        # boxing backends expose this overload; aclnn uses its own factory path.
+        if len(torch.cuda.default_generators) == 0:
+            pytest.skip("factory generator overload requires CUDA boxing")
+        gen = torch.Generator(device="flagos")
+        with pytest.raises(RuntimeError, match="device type for generator"):
+            torch.rand(8, device=DEVICE, generator=gen)
+
+    @pytest.mark.anyplatform
+    @pytest.mark.main_ops
+    def test_flagos_generator_does_not_reroute_cpu_op(self):
+        # The tensor is CPU, so a PrivateUse1 redispatch here can only have come
+        # from the generator. This covers the dispatch-key root cause directly,
+        # independently of CUDA boxing.
+        gen = torch.Generator(device="flagos")
+        with pytest.raises(RuntimeError, match="device type for generator"):
+            torch.empty(8).normal_(generator=gen)
 
     @pytest.mark.anyplatform
     @pytest.mark.main_ops


### PR DESCRIPTION
<!--
⚠️ AI-GENERATED PR TEMPLATE ⚠️
This pull request was prepared with Claude Code.
-->

## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5
- **Human Reviewer**: @zhaoyinglia
- **Session Summary**: Investigated a reproducible SIGSEGV when a caller supplied `torch.Generator(device="flagos")` to CUDA-boxed RNG operators on MetaX C550 hardware. The fix was implemented in the CUDA schema code generator and validated against vendor and FlagGems paths.

## Summary
CUDA-boxed RNG kernels accepted a caller-supplied flagos generator whose `PrivateUse1` dispatch key caused the kernel to redispatch to itself after tensor boxing, resulting in infinite recursion and a segmentation fault. This change validates incompatible flagos generators before the inner ATen redispatch and raises the native-style device mismatch error instead. It also adds regression coverage for factory, in-place, and CPU-tensor entry points while preserving generator-less shared CUDA generator injection.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [x] CUDA
- [x] MetaX
- [ ] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)

## Problem Analysis
### What was broken/missing?

Passing a flagos generator to a CUDA-boxed RNG operation could crash the process:

```python
generator = torch.Generator(device="flagos")
torch.rand(8, device="flagos", generator=generator)
```

The call ended with SIGSEGV instead of a clear generator-device mismatch error.

### Why did it happen?

`GeneratorImpl` advertises the `PrivateUse1` dispatch key. CUDA boxing changes tensor metadata from `PrivateUse1` to CUDA, but the caller-supplied generator remains associated with `PrivateUse1`. PyTorch includes generator keys during dispatch-key extraction, so the inner redispatch selected the same flagos kernel again. Repeated calls recursed until the native stack overflowed.

The flagos generator uses an MT19937 state, while CUDA boxing requires a CUDA/Philox generator. There is no lossless state conversion, so accepting the flagos generator in the CUDA path is not valid; it must fail cleanly.

### Investigation process:
1. Reproduced the SIGSEGV on 8x MetaX C550 hardware and confirmed the same failure on the prior verified tree.
2. Captured a native backtrace showing repeated `uniform_` frames and identified `Generator` dispatch-key extraction as the recursion source.
3. Compared CPU, CUDA, and flagos generator combinations; CUDA generators continued to work, CPU generators raised normally, and only flagos generators recursed.
4. Audited all generated CUDA kernels and found 80 `Generator?` signatures sharing the same redispatch pattern.
5. Regenerated the CUDA artifacts twice and confirmed the second generation was idempotent.

## Solution Design
### Implementation approach:

The generator prelude emitted by `scripts/codegen_ops.py` now calls `ValidateGeneratorForCudaBoxing(generator)` before the inner ATen call. The generated validator rejects a defined `PrivateUse1` generator with the same message shape used by native PyTorch for incompatible generator devices. Generator-less calls retain the existing `GetFlagosDefaultCudaGenerator()` injection, so unified `torch.manual_seed()` behavior is unchanged.

### Key design decisions:

- Reject rather than convert flagos generators because MT19937 and CUDA Philox states have different layouts and semantics.
- Validate in the shared codegen helper so all CUDA generator-bearing templates receive the same behavior.
- Keep `GeneratorImpl`'s `PrivateUse1` identity intact; changing it would make the generator's device and dispatch identity inconsistent.
- Keep the fix limited to CUDA boxing. Ascend's native RNG path has separate generator handling and is not changed.

### Code changes by file:
- `scripts/codegen_ops.py:1312-1335`: emit the generator validation prelude for all CUDA generator-bearing kernels.
- `scripts/codegen_ops.py:2178-2190`: generate the shared `ValidateGeneratorForCudaBoxing` helper.
- `csrc/aten/generated/cuda_kernels.cc:835-843`: regenerated validator and 80 validation call sites.
- `tests/integration/ops/test_rng_dispatch.py:300-339`: add factory, in-place, and CPU-tensor regression tests.

### Changes by commit:
1. `9eaa814` - `fix: reject incompatible flagos generators in CUDA boxing`: validate incompatible generators before CUDA redispatch and add regression coverage.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [ ] **Type checking passed** (not applicable)
- [x] **All tests pass** (relevant unit + integration tests)
- [x] **Manual testing completed** (original SIGSEGV reproduced before the fix and converted to RuntimeError after the fix)
- [x] **No debug/temporary code** (no debug code in the submitted diff)
- [ ] **Documentation updated** (not required for this internal bug fix)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ ruff --version
ruff 0.15.12

$ ruff check .
All checks passed!

$ ruff format --check .
170 files already formatted
```

### Test Results
```bash
# MetaX C550, vendor boxing RNG suite
$ python -m pytest tests/integration/ops/test_rng_dispatch.py -q -p no:cacheprovider
107 passed, 2 skipped, 1 xfailed in 0.49s

# MetaX C550, FlagGems RNG suite
$ FLAGOS_USE_FLAGGEMS=1 python -m pytest tests/integration/ops/test_rng_dispatch.py -q -p no:cacheprovider
109 passed, 1 xpassed in 2.80s

# MetaX C550, full main_ops regression
$ python -m pytest tests/integration/ops/ -m main_ops -q -p no:cacheprovider
120 passed, 15 skipped, 729 deselected, 1 xfailed in 226.99s

# New targeted regression tests
$ python -m pytest tests/integration/ops/test_rng_dispatch.py -q -p no:cacheprovider -k 'flagos_generator_device_mismatch or flagos_generator_factory_mismatch or flagos_generator_does_not_reroute_cpu_op'
3 passed, 107 deselected in 0.13s
```

### Manual Verification
```bash
# Original reproduction before the fix
$ torch.rand(8, device="flagos", generator=torch.Generator(device="flagos"))
Fatal Python error: Segmentation fault
exit=139

# After the fix, MetaX C550 vendor boxing
$ torch.rand(8, device="flagos", generator=torch.Generator(device="flagos"))
RuntimeError: Expected a 'cuda' device type for generator but found 'flagos'

# CUDA generator remains supported
$ torch.rand(8, device="flagos", generator=torch.Generator(device="cuda"))
# succeeds; reseeding the generator reproduces the same output
```

## Code Quality Verification
### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used the project's existing code-generation and dispatch utilities

### Edge Cases Considered
1. Factory RNG with no tensor dispatch key.
2. In-place RNG with a boxed flagos tensor.
3. CPU tensor plus a flagos generator, isolating generator-key redispatch from CUDA boxing.
4. Generator-less RNG calls that depend on the shared CUDA generator.
5. Explicit CUDA generator calls, including reseeding and reproducibility.
6. FlagGems and vendor boxing configurations.

### Potential Risks
1. A caller that previously triggered a process crash with a flagos generator now receives a deliberate RuntimeError; this is the intended behavior because the generator state cannot be converted to CUDA Philox state.
2. The generated helper is emitted for all 80 CUDA generator-bearing kernels, so a codegen or schema change could require regenerating the generated artifact.

### Rollback Plan
Revert commit `9eaa814`. The generated artifact and regression tests are self-contained with the codegen change.

## Related Work
- Fixes the explicit flagos-generator SIGSEGV discovered during MetaX C550 RNG verification.
- Related to the unified RNG injection work merged in PR #42/#49.
- Related to the iterable `default_generators` fix merged in PR #52.

## Explicitly Not Included
- Converting MT19937 flagos generator state into CUDA Philox state.
- Changing FlagGems' existing `uniform_` explicit-generator behavior, which intentionally drops the generator in its Python path due to a documented cold-kernel compilation limitation.
- Adding the MetaX RNG suite to MetaX CI; that is a separate CI follow-up.
- Changing Ascend native RNG implementations.

## Human Review Notes
### Areas needing special attention:
1. Confirm that rejecting `PrivateUse1` generators is preferable to attempting an MT19937-to-Philox conversion.
2. Review that the generated validator is placed before every CUDA ATen redispatch carrying `Generator?`.
3. Confirm the generated artifact remains synchronized with `scripts/codegen_ops.py`.

### Questions for reviewer:
1. Should the MetaX CI RNG coverage be added in a follow-up PR?
2. Should the existing FlagGems `uniform_` generator handling be addressed separately?

## Additional Context
The fix was developed and verified on MetaX C550 hardware. The original crash was confirmed on both the current tree and the previously verified pre-fix tree, establishing that this PR fixes an existing latent crash rather than a regression introduced by the latest upstream synchronization.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
