### PR TITLE
fix: restore PPU profiler device activities

### DIFF
--- a/csrc/profiler/cupti_device_tracer.cc
+++ b/csrc/profiler/cupti_device_tracer.cc
@@ -36,6 +36,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <time.h>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -583,6 +584,14 @@ std::string demangleName(const char* mangled) {
 class CuptiDeviceTracer;
 
 namespace {
+void bufferRequested(uint8_t** buffer, size_t* size, size_t* maxNumRecords);
+void bufferCompleted(
+    CUcontext context,
+    uint32_t streamId,
+    uint8_t* buffer,
+    size_t size,
+    size_t validSize);
+
 // Global tracer pointer for the buffer callbacks (CUPTI callbacks are C-style
 // and cannot capture context).
 CuptiDeviceTracer* g_active_tracer = nullptr;
@@ -610,6 +619,12 @@ class CuptiDeviceTracer : public DeviceTracer {
       return;
     }
 
+    // CUPTI activity timestamps are in the clock domain returned by
+    // cuptiGetTimestamp. Kineto's capture window uses CLOCK_REALTIME. Sample both
+    // domains at each end of the session: PPU's compatibility clock differs in
+    // both epoch and observed rate under load, so a single offset is insufficient.
+    start_clock_sample_ = sampleClocks(shim);
+
     // Publish this tracer and reset its buffers under the lock, then RELEASE the
     // lock before touching CUPTI. cuptiActivityFlushAll() invokes bufferCompleted
     // synchronously on this same thread, and bufferCompleted also locks
@@ -624,15 +639,30 @@ class CuptiDeviceTracer : public DeviceTracer {
 
     FLAGOS_CUPTI_LOG("[flagos] CuptiDeviceTracer::start() called\n");
 
-    // Callbacks are registered globally at init time; just enable activities here
+    // PyTorch's kineto owns the process-global CUPTI activity callbacks on
+    // CUDA-enabled builds, so reclaim them for the FlagOS session. Registering at
+    // module initialization alone is insufficient: kineto may replace them after
+    // torch_fl is imported, which makes HGPTI reject our buffer at flush as
+    // "unknown" and leaves the PrivateUse1 trace empty.
+    CUptiResult res_cb =
+        shim.ActivityRegisterCallbacks(bufferRequested, bufferCompleted);
+
+    // KERNEL and CONCURRENT_KERNEL are mutually exclusive in PPU's CUPTI
+    // compatibility layer: whichever is enabled first succeeds and the second
+    // returns HGPTI_ERROR_NOT_COMPATIBLE. Enable both so NVIDIA gets concurrent
+    // records while PPU accepts the already-armed mode; the parser handles either
+    // record kind.
     CUptiResult res1 = shim.ActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
+    CUptiResult res_k = shim.ActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL);
     CUptiResult res2 = shim.ActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY);
     CUptiResult res_ms = shim.ActivityEnable(CUPTI_ACTIVITY_KIND_MEMSET);
     CUptiResult res_rt = shim.ActivityEnable(CUPTI_ACTIVITY_KIND_RUNTIME);
     CUptiResult res_ec =
         shim.ActivityEnable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION);
-    FLAGOS_CUPTI_LOG("[flagos] ActivityEnable results: KERNEL=" << res1
-              << ", MEMCPY=" << res2 << ", MEMSET=" << res_ms
+    FLAGOS_CUPTI_LOG("[flagos] Activity setup results: CALLBACKS=" << res_cb
+              << ", CONCURRENT_KERNEL=" << res1
+              << ", KERNEL=" << res_k << ", MEMCPY=" << res2
+              << ", MEMSET=" << res_ms
               << ", RUNTIME=" << res_rt
               << ", EXTERNAL_CORRELATION=" << res_ec << "\n");
 
@@ -649,17 +679,21 @@ class CuptiDeviceTracer : public DeviceTracer {
 
     FLAGOS_CUPTI_LOG("[flagos] CuptiDeviceTracer::stop() called\n");
 
+    end_clock_sample_ = sampleClocks(shim);
+
+    // Flush while activities and the active tracer are still live. PPU's HGPTI
+    // backend follows the documented forced-termination ordering and may deliver
+    // the completion callback synchronously from this call.
+    FLAGOS_CUPTI_LOG("[flagos] Flushing CUPTI activities...\n");
+    CUptiResult flush_res = shim.ActivityFlushAll(1);
+    FLAGOS_CUPTI_LOG("[flagos] ActivityFlushAll result: " << flush_res << "\n");
+
     shim.ActivityDisable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
     shim.ActivityDisable(CUPTI_ACTIVITY_KIND_KERNEL);
     shim.ActivityDisable(CUPTI_ACTIVITY_KIND_MEMCPY);
     shim.ActivityDisable(CUPTI_ACTIVITY_KIND_MEMSET);
     shim.ActivityDisable(CUPTI_ACTIVITY_KIND_RUNTIME);
     shim.ActivityDisable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION);
-
-    // Flush all pending activity records - force flag=0 means wait for completion
-    FLAGOS_CUPTI_LOG("[flagos] Flushing CUPTI activities...\n");
-    CUptiResult flush_res = shim.ActivityFlushAll(0);
-    FLAGOS_CUPTI_LOG("[flagos] ActivityFlushAll result: " << flush_res << "\n");
 
     std::lock_guard<std::mutex> lock(g_tracer_mutex);
     g_active_tracer = nullptr;
@@ -677,6 +711,8 @@ class CuptiDeviceTracer : public DeviceTracer {
   std::vector<DeviceEvent> drain() override {
     std::lock_guard<std::mutex> lock(g_tracer_mutex);
     for (auto& ev : events_) {
+      ev.start_ns = toRealtime(ev.start_ns);
+      ev.end_ns = toRealtime(ev.end_ns);
       ev.external_correlation_id = lookupExternalCorrelation(ev.correlation_id);
     }
     return std::move(events_);
@@ -724,9 +760,6 @@ class CuptiDeviceTracer : public DeviceTracer {
     CUpti_Activity* record = nullptr;
     while (true) {
       CUptiResult status = shim.ActivityGetNextRecord(buffer, validSize, &record);
-      if (status == CUPTI_ERROR_MAX_LIMIT_REACHED) {
-        break;  // No more records
-      }
       if (status != CUPTI_SUCCESS || !record) {
         break;
       }
@@ -944,11 +977,63 @@ class CuptiDeviceTracer : public DeviceTracer {
     return static_cast<int32_t>(it->second);
   }
 
+  struct ClockSample {
+    uint64_t vendor_ns = 0;
+    uint64_t realtime_ns = 0;
+    bool valid = false;
+  };
+
+  static ClockSample sampleClocks(CuptiShim& shim) {
+    ClockSample sample;
+    if (!shim.GetTimestamp) {
+      return sample;
+    }
+
+    timespec before{};
+    timespec after{};
+    clock_gettime(CLOCK_REALTIME, &before);
+    CUptiResult result = shim.GetTimestamp(&sample.vendor_ns);
+    clock_gettime(CLOCK_REALTIME, &after);
+    const uint64_t before_ns = static_cast<uint64_t>(before.tv_sec) * 1000000000ULL +
+        static_cast<uint64_t>(before.tv_nsec);
+    const uint64_t after_ns = static_cast<uint64_t>(after.tv_sec) * 1000000000ULL +
+        static_cast<uint64_t>(after.tv_nsec);
+    sample.realtime_ns = before_ns + (after_ns - before_ns) / 2;
+    sample.valid = result == CUPTI_SUCCESS && sample.vendor_ns != 0;
+    FLAGOS_CUPTI_LOG("[flagos] clock sample result=" << result
+                     << " vendor=" << sample.vendor_ns
+                     << " realtime=" << sample.realtime_ns << "\n");
+    return sample;
+  }
+
+  uint64_t toRealtime(uint64_t vendor_ns) const {
+    if (!start_clock_sample_.valid) {
+      return vendor_ns;
+    }
+    if (!end_clock_sample_.valid ||
+        end_clock_sample_.vendor_ns <= start_clock_sample_.vendor_ns) {
+      return start_clock_sample_.realtime_ns +
+          (vendor_ns - start_clock_sample_.vendor_ns);
+    }
+
+    const long double vendor_delta = static_cast<long double>(
+        end_clock_sample_.vendor_ns - start_clock_sample_.vendor_ns);
+    const long double realtime_delta = static_cast<long double>(
+        end_clock_sample_.realtime_ns - start_clock_sample_.realtime_ns);
+    const long double elapsed = static_cast<long double>(vendor_ns) -
+        static_cast<long double>(start_clock_sample_.vendor_ns);
+    return static_cast<uint64_t>(
+        static_cast<long double>(start_clock_sample_.realtime_ns) +
+        elapsed * realtime_delta / vendor_delta);
+  }
+
   std::vector<DeviceEvent> events_;
   // cupti correlationId -> externalId (torch correlation id), populated from
   // EXTERNAL_CORRELATION records. Guarded by g_tracer_mutex (processBuffer
   // writes it; drain reads it after stop()).
   std::unordered_map<uint32_t, uint64_t> external_correlation_;
+  ClockSample start_clock_sample_;
+  ClockSample end_clock_sample_;
 };
 
 namespace {
@@ -1032,11 +1117,14 @@ struct CuptiTracerInit {
     CUptiResult res =
         shim.ActivityRegisterCallbacks(bufferRequested, bufferCompleted);
     FLAGOS_CUPTI_LOG("[flagos] ActivityRegisterCallbacks result: " << res << "\n");
-    CUptiResult en_k = shim.ActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
+    CUptiResult en_ck =
+        shim.ActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
+    CUptiResult en_k = shim.ActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL);
     CUptiResult en_m = shim.ActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY);
     CUptiResult en_s = shim.ActivityEnable(CUPTI_ACTIVITY_KIND_MEMSET);
-    FLAGOS_CUPTI_LOG("[flagos] init ActivityEnable KERNEL=" << en_k
-              << " MEMCPY=" << en_m << " MEMSET=" << en_s
+    FLAGOS_CUPTI_LOG("[flagos] init ActivityEnable CONCURRENT_KERNEL=" << en_ck
+              << " KERNEL=" << en_k << " MEMCPY=" << en_m
+              << " MEMSET=" << en_s
               << " (RUNTIME/EXTERNAL_CORRELATION deferred to start())\n");
   }
 };

--- a/csrc/profiler/cupti_shim.h
+++ b/csrc/profiler/cupti_shim.h
@@ -31,9 +31,11 @@ typedef struct CUctx_st* CUcontext;
 typedef enum {
   CUPTI_SUCCESS = 0,
   CUPTI_ERROR_INVALID_PARAMETER = 1,
-  CUPTI_ERROR_NOT_INITIALIZED = 15,
-  CUPTI_ERROR_MAX_LIMIT_REACHED = 28,
-  CUPTI_ERROR_INVALID_KIND = 32
+  // PPU's CUPTI compatibility layer forwards HGPTI result values, whose
+  // MAX_LIMIT_REACHED and INVALID_KIND differ from NVIDIA CUPTI. Avoid using
+  // either vendor's numeric result here; ActivityGetNextRecord returns a null
+  // record when iteration is complete, which is the portable termination signal.
+  CUPTI_ERROR_NOT_INITIALIZED = 15
 } CUptiResult;
 
 // Activity kinds (subset). Values MUST match the cu12 runtime's
@@ -158,6 +160,7 @@ struct CuptiShim {
       CUpti_ExternalCorrelationKind, uint64_t) = nullptr;
   CUptiResult (*ActivityPopExternalCorrelationId)(
       CUpti_ExternalCorrelationKind, uint64_t*) = nullptr;
+  CUptiResult (*GetTimestamp)(uint64_t*) = nullptr;
   // Optional: only used for diagnostics, so a failure to resolve it is not fatal.
   CUptiResult (*GetVersion)(uint32_t*) = nullptr;
 
@@ -254,6 +257,7 @@ struct CuptiShim {
              "cuptiActivityPushExternalCorrelationId");
     LOAD_SYM(ActivityPopExternalCorrelationId,
              "cuptiActivityPopExternalCorrelationId");
+    LOAD_SYM(GetTimestamp, "cuptiGetTimestamp");
     LOAD_SYM(GetVersion, "cuptiGetVersion");
 
 #undef LOAD_SYM

--- a/csrc/profiler/flagos_kineto_profiler.cc
+++ b/csrc/profiler/flagos_kineto_profiler.cc
@@ -298,6 +298,7 @@ void FlagosKinetoProfilerSession::processTrace(
   // fell outside the window -- leaves a dangling arrow, which is not what
   // torch+cuda produces.
   std::set<uint32_t> device_correlations;
+  std::set<uint32_t> runtime_correlations;
   int device_in_window = 0;
   int device_total = 0;
   for (const auto& ev : events_) {
@@ -312,9 +313,21 @@ void FlagosKinetoProfilerSession::processTrace(
         device_correlations.insert(ev.correlation_id);
         ++device_in_window;
       }
+    } else if (in_window(ev) && ev.correlation_id != 0) {
+      runtime_correlations.insert(ev.correlation_id);
     }
   }
   FLAGOS_KINETO_LOG("[flagos] Found " << device_in_window << "/" << device_total << " device events in window\n");
+
+  // A renderable flow requires one runtime and one device activity with the same
+  // vendor correlation id. Device records without a runtime counterpart occur
+  // for work submitted by an internal vendor thread and must not emit a lone
+  // finish half.
+  std::set<uint32_t> paired_correlations;
+  std::set_intersection(
+      device_correlations.begin(), device_correlations.end(),
+      runtime_correlations.begin(), runtime_correlations.end(),
+      std::inserter(paired_correlations, paired_correlations.end()));
 
   // Whether kineto actually handed us a resolver. An EMPTY callback is a total
   // loss of linking: every activity is then emitted with linked == nullptr,
@@ -408,7 +421,7 @@ void FlagosKinetoProfilerSession::processTrace(
     // is the vendor correlation id (shared by a launch's runtime event and the
     // kernel/memcpy event it produced). Using the torch correlation id here
     // instead would emit only unpaired 'f' halves that no viewer renders.
-    if (ev.correlation_id != 0 && device_correlations.count(ev.correlation_id)) {
+    if (ev.correlation_id != 0 && paired_correlations.count(ev.correlation_id)) {
       activity.flow.id = ev.correlation_id;
       activity.flow.type = libkineto::kLinkAsyncCpuGpu;
       activity.flow.start = (ev.kind == profiler::EventKind::Runtime) ? 1 : 0;


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @zhaoyinglia
- **Session Summary**: Investigated issue #92 on PPU hardware, compared the CUPTI compatibility layer with native HGPTI, fixed callback ownership and timestamp-domain handling, and verified full profiler parity without synthetic activities or fallbacks.

## Summary

Restore real PPU device activities in `torch.profiler` traces. The fix reclaims process-global CUPTI callbacks for each FlagOS profiler session, flushes activity buffers before disabling collection, supports both mutually exclusive PPU kernel activity modes, and maps vendor timestamps into Kineto's realtime clock domain. PPU traces now contain real kernel, memcpy, memset, runtime, CPU/device correlation, device-time attribution, and paired `ac2g` flows.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [x] CUDA
- [x] MetaX
- [ ] Ascend
- [x] PPU
- [ ] Platform-agnostic (all platforms)

The changed CUPTI tracer is shared by CUDA-compatible backends. PPU exercises the new compatibility behavior; ordinary NVIDIA CUDA remains the primary behavior, and MetaX uses CUDA boxing. No Ascend or DCU tracer code is changed.

## Problem Analysis
### What was broken/missing?

On PPU, `tests/integration/test_profiler_parity.py` exported only `Trace` and `cpu_op`. Real kernel, memcpy, memset, runtime, flow, and device-time information was absent. Flushes could report `bufferCompleted called with unknown buffer`, and all seven parity checks failed.

### Why did it happen?

There were three interacting root causes:

1. CUPTI activity callbacks are process-global. PyTorch Kineto could replace the callbacks registered during `torch_fl` initialization, so HGPTI later completed a buffer that FlagOS had not allocated through its active callback set.
2. PPU's CUPTI compatibility layer exposes activity timestamps in a different epoch and observed rate from Kineto's `CLOCK_REALTIME` capture window. Although 112 real activities reached `processTrace`, the window predicate rejected all of them.
3. PPU treats `KERNEL` and `CONCURRENT_KERNEL` as mutually exclusive. The first kind enabled succeeds and the second returns `HGPTI_ERROR_NOT_COMPATIBLE`; assuming one fixed kernel kind is portable loses activities. PPU also forwards HGPTI result values, so end-of-record result codes differ from NVIDIA CUPTI.

After device activities became visible, device records submitted without an in-window runtime counterpart produced unpaired flow finish events. Flow generation therefore also needed to require both endpoints.

### Investigation process:
1. Read the CUPTI shim, device tracer, Kineto session adapter, profiler parity test, and PPU SDK HGPTI headers.
2. Built an out-of-tree ctypes A/B probe and ran CUPTI-wrapper and native-HGPTI modes in separate fresh processes. Both produced the same real stream: 16 kernels, 4 memcpys, 1 memset, 399 runtime records, and external-correlation records with no unknown or duplicate completions.
3. Rebuilt the plugin with callback and buffer diagnostics. This showed 112 real activities were drained, but their timestamps were around `4.86e15` while Kineto's window was around `1.786e18`.
4. Measured `cuptiGetTimestamp` against `CLOCK_REALTIME`, implemented two-point session calibration, and reran the unchanged parity suite.
5. Inspected exported flow IDs and restricted flow generation to correlation IDs present on both runtime and device sides.

## Solution Design
### Implementation approach:

- Re-register FlagOS activity callbacks at every profiler session start.
- Force-flush while activities and the active tracer are still live, then disable activities.
- Enable and parse both kernel activity kinds, allowing each vendor to accept its supported/active mode.
- Stop comparing `ActivityGetNextRecord` against vendor-specific numeric terminal codes.
- Resolve `cuptiGetTimestamp` dynamically and take paired vendor/realtime samples at session start and stop.
- Convert activity timestamps with an affine mapping in `drain()`, after all buffers have arrived but before Kineto applies its capture window.
- Emit `ac2g` flow metadata only for correlation IDs with both an in-window runtime event and an in-window device event.

### Key design decisions:

- **Keep the CUPTI compatibility path:** Direct HGPTI and the PPU CUPTI wrapper produced identical complete records, so a separate PPU-native tracer would duplicate code without fixing the actual callback-ownership issue.
- **Use two-point calibration:** A single epoch offset still drifted under the profiled load. Start/stop sampling corrects both epoch and observed clock-rate differences while preserving event ordering and duration ratios.
- **Preserve strict parity:** No categories are synthesized, no CPU fallback is used, and the existing parity assertions remain unchanged.
- **Generate only renderable flows:** Requiring both endpoints prevents lone `f` events while preserving vendor correlation IDs for valid arrows.

### Code changes by file:
- `csrc/profiler/cupti_device_tracer.cc`: Reclaim callbacks per session, flush before disable, support both kernel kinds, calibrate timestamps, and avoid vendor-specific record-iteration termination.
- `csrc/profiler/cupti_shim.h`: Resolve `cuptiGetTimestamp` and remove hardcoded NVIDIA-only result values from iteration logic.
- `csrc/profiler/flagos_kineto_profiler.cc`: Emit flow arrows only for runtime/device correlation IDs present on both sides of the capture window.

### Changes by commit:
1. `3bec396` - `fix: restore PPU profiler device activities`: Restore real PPU activities, timestamp containment, correlation, and paired flows.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (not applicable; C++ changes compile in the PPU editable build)
- [x] **All tests pass** (unit + affected integration)
- [x] **Manual testing completed** (original profiler workload and repeated captures)
- [x] **No debug/temporary code** (diagnostics remain behind existing debug environment variables)
- [x] **Documentation updated** (not needed; no user-facing API or build procedure changed)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ ruff --version
ruff 0.15.12

$ ruff check .
All checks passed!

$ ruff format --check .
156 files already formatted

$ git diff --check
# no output
```

### Test Results
```bash
$ pytest tests/unit/ -v
================== 85 passed, 28 skipped, 1 warning in 17.38s ==================

$ FLAGOS_DISABLE_CUDA_ASSETS=1 \
    pytest tests/integration/test_profiler_parity.py -v -m main_ops
========================= 7 passed, 1 warning in 1.08s =========================
```

PPU environment:
- Hardware: PPU-ZW810E
- PyTorch: 2.10.0 vendor PPU build
- Build selector: `ACCELERATOR=cuda`
- SDK layout: PPU SDK with CUDA-compatible toolkit and HGPTI-backed CUPTI compatibility library

Editable build command:
```bash
ACCELERATOR=cuda \
CUDA_HOME=/usr/local/PPU_SDK/CUDA_SDK \
CUDA_KERNEL=ON \
FLAGGEMS_KERNEL=OFF \
FLAGGEMS_PYTHON=OFF \
FLAGOS_SKIP_CUDA_ASSETS=1 \
pip install --no-build-isolation -e .
```

### Manual Verification
```bash
# Original issue workload after the fix:
$ FLAGOS_DISABLE_CUDA_ASSETS=1 python <repeated-capture-check>
capture 1: categories=['Trace', 'cpu_op', 'gpu_memcpy', 'gpu_memset', 'kernel', 'privateuse1_runtime'], flows=26, paired=True
capture 2: categories=['Trace', 'cpu_op', 'gpu_memcpy', 'gpu_memset', 'kernel', 'privateuse1_runtime'], flows=26, paired=True
```

Before the fix, debug output showed real activities being discarded:
```text
Captured 112 GPU activities
processTrace(4-arg) called with 112 events
Found 0/21 device events in window
linked 0/0 link candidates, dropped 112 outside window
```

After the fix:
```text
Captured 112 GPU activities
Found 18/21 device events in window
linked 108/108 link candidates
```

The exported traces contain real PPU device records; no fake or synthetic activities are added.

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (no reinventing)

### Edge Cases Considered
1. A second profiler capture in the same process, where another CUPTI consumer may have replaced process-global callbacks.
2. Either `KERNEL` or `CONCURRENT_KERNEL` being accepted first, with the second mode returning a vendor incompatibility code.
3. PPU/HGPTI terminal result values differing from NVIDIA CUPTI values.
4. Vendor timestamps differing from Kineto in both epoch and observed rate.
5. Device activities with no runtime counterpart, which must not create dangling flow halves.
6. Missing `cuptiGetTimestamp`, where the tracer retains the original timestamps rather than fabricating a conversion.

### Potential Risks
1. Timestamp interpolation assumes the vendor clock progresses monotonically between the two session samples; malformed or non-monotonic samples fall back to offset-only/original behavior.
2. The CUPTI activity callback API is process-global, so simultaneous independent CUPTI activity consumers remain inherently unable to own distinct callback sets.
3. CUDA and MetaX hardware were not available in this PPU environment; their shared CUPTI code paths rely on the same symbols and retain NVIDIA's preferred concurrent-kernel mode.

### Rollback Plan

Revert commit `3bec396`. This restores the previous CUPTI lifecycle and timestamp behavior; PPU profiler parity would again remain unavailable, but operator execution is unaffected.

## Related Work
- Fixes #92
- Related to the existing CUDA profiler parity implementation and the Ascend profiler follow-up documented in `.github/configs/ascend.yml`

## Explicitly Not Included
- Re-adding `.github/configs/ppu.yml`: that manifest is not present in the current repository or fetched history, so this PR does not invent a new CI configuration source.
- A separate native HGPTI tracer: the A/B probe showed the CUPTI compatibility layer delivers the same complete activity stream.
- Relaxed tests, skipped assertions, CPU fallback, or synthesized trace activities.

## Human Review Notes
### Areas needing special attention:
1. The start/stop clock sampling and affine conversion in `CuptiDeviceTracer::drain()`.
2. Callback ownership and flush-before-disable ordering for NVIDIA CUPTI as well as PPU/HGPTI.
3. Flow pairing based on the intersection of in-window runtime and device correlation IDs.

### Questions for reviewer:
1. Should the external PPU CI manifest be updated in a separate repository after this PR lands?
2. Is additional NVIDIA CUDA hardware validation desired before merge, given that PPU validation covers the changed CUPTI interface but not an NVIDIA driver?

## Additional Context

Issue #92 originally classified the failure as a vendor CUPTI defect. The fresh-process A/B probe showed that both native HGPTI and the compatibility wrapper emit complete real activity streams. The repository-side defects were callback ownership, lifecycle ordering, vendor-specific result assumptions, and clock-domain conversion.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
