### PR TITLE
docs: allow upstream torch minor stable branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,32 +93,48 @@ Use standard templates:
 
 See `CONTRIBUTING.md` for detailed contribution guidelines.
 
-### Strict upstream branch policy
+### Upstream branch policy
 
-**Never create, push, update, or delete a feature branch on an upstream repository.**
-Upstream remotes are read-only for feature development, including when the current
-account happens to have write access.
+The upstream repository may contain stable branches for supported PyTorch minor
+lines, such as `2.9`. These stable branches are part of the release/support
+contract and may be created or maintained on the upstream remote when explicitly
+requested by the project maintainer. A stable branch must be named for a PyTorch
+minor line and must not be used as a general-purpose development branch.
 
-Before pushing any feature branch:
+All ordinary development branches remain fork-only. This includes `docs/*`,
+`feat/*`, `fix/*`, `perf/*`, `refactor/*`, `test/*`, `ci/*`, and experimental
+work, even when the change is intended to land on a stable branch. The required
+flow is:
 
-1. Inspect `git remote -v` and identify the contributor fork and the upstream repository.
-2. Push the feature branch only to the contributor fork (normally `origin`):
+```text
+<contributor-fork>:<development-branch>
+        -> PR -> <upstream>:main or <upstream>:<torch-minor-stable-branch>
+```
+
+Before pushing a branch:
+
+1. Inspect `git remote -v` and classify the target as either an upstream stable
+   branch or a contributor development branch.
+2. For ordinary development, push only to the contributor fork (normally `origin`):
    ```bash
-   git push origin <feature-branch>
+   git push origin <development-branch>
    ```
-3. Create the pull request from `<fork-owner>:<feature-branch>` into the upstream
-   repository's `main` branch:
+3. Create the pull request from `<fork-owner>:<development-branch>` into the
+   intended upstream target, either `main` or an existing stable PyTorch minor
+   branch:
    ```bash
    gh pr create \
      --repo <upstream-owner>/<upstream-repo> \
-     --head <fork-owner>:<feature-branch> \
-     --base main
+     --head <fork-owner>:<development-branch> \
+     --base <main-or-torch-minor-stable-branch>
    ```
-4. If a feature branch was accidentally created on the upstream repository, stop,
-   report it, and clean it up only as part of an explicitly authorized correction.
+4. Creating or updating an upstream stable branch requires explicit maintainer
+   authorization and must be limited to stable-branch setup or maintenance. Do not
+   push ordinary commits directly to that branch; submit them through a fork PR.
 
-Do **not** run `git push <upstream> <feature-branch>` for ordinary development. A
-successful push is not evidence that the push was appropriate.
+Do **not** run `git push <upstream> <development-branch>` for ordinary development.
+A successful push is not evidence that the push was appropriate. If a branch is
+ambiguous, treat it as a development branch and use the contributor fork.
 
 ## Commit Message Format
 


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code
- **Model**: Claude Opus 5
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Updated the repository branch policy after the PyTorch 2.9 version port so that explicitly authorized PyTorch minor stable branches may exist upstream while ordinary development remains fork-only.

## Summary
This documentation change replaces the blanket upstream branch prohibition with a scoped policy. Explicitly authorized stable branches named for supported PyTorch minor lines, such as `2.9`, may be created or maintained upstream. Ordinary `docs/*`, `feat/*`, `fix/*`, `perf/*`, `refactor/*`, `test/*`, `ci/*`, and experimental branches must still be pushed to the contributor fork and merged through a pull request targeting upstream `main` or the appropriate stable branch.

## Change Type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [ ] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [x] Platform-agnostic (all platforms)

## Problem Analysis
### What was broken/missing?
The branch policy treated every upstream branch as a feature branch and prohibited upstream stable branches. That prevented the project from maintaining dedicated PyTorch minor-line integration targets such as `2.9`, even though those branches have a different release and support role from ordinary development branches.

### Why did it happen?
The previous policy intentionally protected the upstream repository from direct feature-branch pushes, but it did not distinguish release/support branches from change-specific development branches.

### Investigation process:
1. Read the existing branch policy in `CLAUDE.md` and identified the blanket prohibition on upstream branch creation and maintenance.
2. Confirmed the repository remotes: `flagos` is the upstream repository and `origin` is the contributor fork.
3. Reviewed the `torch-version-port` workflow, which models supported PyTorch minor versions as sibling branches such as `2.9`.
4. Ran `git diff --check`, `ruff check .`, and `ruff format --check .` on the documentation change.

## Solution Design
### Implementation approach:
Document a narrow exception for explicitly authorized upstream stable branches named for supported PyTorch minor lines. Keep all ordinary development branches fork-only and document the pull-request targets and remote checks for both paths.

### Key design decisions:
- Stable branch names must identify a PyTorch minor line, for example `2.9`, and must not become scratch branches.
- Creating or updating an upstream stable branch requires explicit maintainer authorization.
- Ordinary commits must not be pushed directly to a stable branch; they must use a contributor-fork branch and a pull request.
- Ambiguous branch names are treated as ordinary development branches and therefore use the contributor fork.

### Code changes by file:
- `CLAUDE.md`: Replaced the blanket upstream branch prohibition with the stable-branch exception, fork-only development rules, remote checks, and PR examples.

### Changes by commit:
1. `5a1155a` - `docs: allow upstream torch minor stable branches`: Document the scoped upstream stable-branch policy.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (not applicable to documentation-only change)
- [ ] **All tests pass** (not applicable; no code changed)
- [x] **Manual testing completed** (reviewed the resulting policy diff and checked whitespace)
- [x] **No debug/temporary code** (no print statements, TODOs, or temporary repository files)
- [x] **Documentation updated** (CLAUDE.md)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ git diff --check
# Output: no output; passed

$ ruff check .
All checks passed!

$ ruff format --check .
172 files already formatted
```

### Test Results
No unit or integration tests were run because this PR changes only repository workflow documentation and no executable code or generated artifact.

### Manual Verification
```bash
$ git diff --check
# Output: no output; passed

$ git diff -- CLAUDE.md
# Confirmed the policy distinguishes explicitly authorized PyTorch minor stable
# branches from fork-only ordinary development branches and allows PR targets
# of upstream main or an appropriate stable branch.
```

## Code Quality Verification
### Style Consistency
- [x] Matched existing documentation style in `CLAUDE.md`
- [x] Followed existing branch and remote naming conventions
- [x] Comment density matches surrounding documentation
- [x] Used the repository's existing workflow terminology

### Edge Cases Considered
1. Ordinary `docs/*`, `feat/*`, `fix/*`, `perf/*`, `refactor/*`, `test/*`, and `ci/*` branches remain fork-only.
2. Experimental or ambiguous branch names default to the fork-only development path.
3. Stable branch maintenance is authorization-gated and does not permit direct ordinary commits.

### Potential Risks
1. A maintainer could misclassify a scratch branch as a stable branch; the policy limits stable names to supported PyTorch minor lines and requires explicit authorization.
2. Existing local clones may still contain the old policy until they update from this PR.

### Rollback Plan
Revert commit `5a1155a` to restore the previous upstream branch policy if the project decides not to maintain upstream PyTorch minor stable branches.

## Related Work
- Related to the merged integration harness PR #114.
- Related to the PyTorch 2.9 port on the contributor fork.
- This PR must land before the separately requested upstream `2.9` stable branch creation.

## Explicitly Not Included
- Creating or updating the upstream `flagos/2.9` branch.
- Porting code, generated artifacts, or operator support.
- Changing the existing `2.9` version-port commit or its contributor-fork branch.

## Human Review Notes
### Areas needing special attention:
1. Whether the stable-branch exception is narrow enough to protect upstream from ordinary direct development pushes.
2. Whether `2.9` is the desired naming convention for PyTorch minor stable branches.
3. Whether the documented PR flow correctly covers both `main` and stable branch targets.

### Questions for reviewer:
1. Should additional release-branch naming constraints be documented before creating `flagos/2.9`?
2. Should stable branch creation remain limited to explicit maintainer requests, as documented here?

## Additional Context
The policy is intentionally independent of any specific hardware backend. It supports the repository's sibling-per-PyTorch-minor branch model while preserving fork-based review for normal development.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
