### PR TITLE
docs: record Hygon FlagTree compile validation

### DIFF
--- a/docs/architecture/torch-compile-integration.md
+++ b/docs/architecture/torch-compile-integration.md
@@ -313,7 +313,8 @@ tests live alongside it:
 3. **Dynamic shapes**: Some models with dynamic shapes may not compile
 4. **CUDA graphs off**: `torch.cuda.CUDAGraph` is a dummy class in the CPU torch
    wheel, so `triton.cudagraphs` is forced off even under `mode="max-autotune"`
-5. **FlagTree maturity**: Backend support varies by hardware (NVIDIA most mature)
+5. **FlagTree maturity**: Backend support varies by hardware; Hygon HCU is
+   validated on `gfx936`, while other vendor backends remain untested here
 
 ## Roadmap
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -26,7 +26,7 @@
 | MetaX | `ACCELERATOR=metax` | CUDA-boxing reuse via `cu-bridge`/mxcc, or native MetaX kernels | Stable | Not validated | Experimental (NCCL-shaped `mccl` fallback; not CI-covered) | Not validated on this vendor's tracer | Experimental (Python dispatch; not CI-tested on MetaX) | Stable |
 | Ascend | `ACCELERATOR=ascend` | Native ACLNN operator backend, optional FlagGems via triton-ascend | Stable (CI-covered ops, RNG suite) | Not validated | Experimental (HCCL fallback; architectural routing only, no collective-level CI) | Runtime only (device/runtime events not emitted; profiler parity suite excluded from CI) | Experimental (Python dispatch; not CI-tested on Ascend) | Beta |
 | PPU | `ACCELERATOR=cuda` + `PPU_SDK`/`PPU_HOME` detection | Same CUDA-boxing path as NVIDIA CUDA, against the PPU's CUDA-13-compatible SDK | Experimental | Not validated | Experimental (NCCL fallback via vendor-adapted `libnccl.so.2`; not CI-covered) | Not validated on this vendor's tracer | Experimental (vendor-index Triton required) | Experimental |
-| Hygon DCU | `ACCELERATOR=dcu` | CUDA boxing over the hipified DTK torch build (HIP kernels under the CUDA dispatch key) | Beta (including FP16/BF16 autocast and GradScaler) | Not validated | Experimental (RCCL via DTK; all_reduce/DDP measured on 2 cards, not in CI) | Beta (parity suite runs in CI) | Beta (Python dispatch only) | Beta |
+| Hygon DCU | `ACCELERATOR=dcu` | CUDA boxing over the hipified DTK torch build (HIP kernels under the CUDA dispatch key) | Beta (including FP16/BF16 autocast and GradScaler) | Experimental (FlagTree HCU validated on `gfx936`; not in CI) | Experimental (RCCL via DTK; all_reduce/DDP measured on 2 cards, not in CI) | Beta (parity suite runs in CI) | Beta (Python dispatch only) | Beta |
 | Enflame GCU | `ACCELERATOR=gcu` | Native `libtopsaten.so` operator backend, with CPU fallback for unrouted/int64 ops | Experimental | Not validated | Not validated | Not validated | Experimental (Python dispatch, requires vendor Triton) | Experimental |
 | Moore Threads MUSA | `ACCELERATOR=musa` | Native `mudnn` operator backend, with CPU fallback for unrouted ops | Experimental | Not validated | Not validated | Not validated | Experimental (Python dispatch, requires vendor Triton) | Experimental |
 | D-Robotics BPU | `ACCELERATOR=bpu` | No eager kernel sets are built; eager ops run on CPU | Runtime only (CPU fallback for eager) | Experimental (`torch.compile(backend="bpu")` graph path via hbdk4) | Not applicable | Not validated | Not applicable (no per-op kernel build) | Runtime only |
@@ -111,6 +111,14 @@ FP16 and BF16 autocast policies, nested autocast state, finite and overflowing G
 and forward/backward optimizer execution. CPU-to-DCU copies and representative elementwise,
 reduction, matrix multiplication, and backward operations preserve all tested PyTorch dtypes from
 bool through complex128, including float64.
+
+`torch.compile(backend="flagos")` is experimentally validated on Hygon with a
+FlagTree 0.6.0 HCU build and PyTorch 2.10.0. The full compile integration suite
+passes on the `gfx936` target, including forward and backward execution, FP32
+and FP16 inputs, max-autotune, recompilation, FakeTensor tracing, and the
+FlagTree-specific result/device checks. The FlagTree wheel must replace the
+active `triton` installation before Python starts; the current DCU CI image
+uses DTK Triton and does not exercise this path.
 
 ### Enflame GCU
 

--- a/docs/vendors/dcu/installation.md
+++ b/docs/vendors/dcu/installation.md
@@ -91,6 +91,41 @@ Run the DCU AMP coverage, including both autocast dtypes and finite/non-finite G
 pytest tests/integration/test_amp.py -v
 ```
 
+### `torch.compile` with FlagTree
+
+DCU `torch.compile` is validated with FlagTree's HCU backend on the Hygon
+`gfx936` target. FlagTree replaces the active `triton` module at installation
+time, so build it in a separate environment or install location rather than
+trying to import a `flagtree` module at runtime:
+
+```bash
+git clone https://github.com/flagos-ai/FlagTree.git
+cd FlagTree
+export FLAGTREE_BACKEND=hcu
+MAX_JOBS=16 python -m pip install . --no-build-isolation -v
+```
+
+Use the resulting FlagTree environment together with the PyTorch 2.10 and
+torch-fl installation. These variables select the HCU backend and assert that
+the active Triton is FlagTree:
+
+```bash
+export FLAGTREE_BACKEND=hcu
+export FLAGOS_USE_FLAGTREE=1
+export TRITON_BACKENDS_IN_TREE=1
+export GEMS_VENDOR=hygon
+
+python -c 'import triton; from triton._flagtree_backend import FLAGTREE_BACKEND; print(triton.__version__, FLAGTREE_BACKEND)'
+pytest tests/integration/test_compile.py -v
+```
+
+The measured Hygon run used FlagTree 0.6.0, PyTorch 2.10.0, and produced
+`GPUTarget(backend='hip', arch='gfx936', warp_size=64)`. All 15 compile tests
+passed. Compiled outputs and backward gradients remained on `flagos`; eager
+and compiled results matched. The DCU CI manifest does not include this check
+because its pinned image currently supplies DTK Triton rather than a FlagTree
+HCU build.
+
 ### Operator Tests (Vendor Backend)
 
 Run the main operator suite against the DCU boxing backend:

--- a/torch_fl/compile/README.md
+++ b/torch_fl/compile/README.md
@@ -91,10 +91,12 @@ Event/Stream shims that inductor's autotuner needs.
 ## Limitations
 
 1. Single device - multi-GPU compilation not yet exercised
-2. FlagTree verified on nvidia/sm90 only; other vendor backends untested here
+2. FlagTree is validated on NVIDIA `sm90` and Hygon `gfx936` with the HCU
+   backend; other vendor backends remain untested here
 
 ## Future Work
 
-- [ ] Exercise `torch.compile(backend="flagos")` on a FlagTree-built env
+- [x] Exercise `torch.compile(backend="flagos")` on FlagTree-built NVIDIA and
+      Hygon HCU environments
 - [ ] Benchmark fusion gains against stock inductor+triton on cuda
 - [ ] Multi-GPU compilation support


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Validated the existing torch.compile integration against a source-built FlagTree HCU backend on real Hygon DCU hardware, then recorded the measured result in the compatibility and installation documentation.

## Summary
This change documents experimental Hygon DCU support for `torch.compile(backend="flagos")` through a FlagTree HCU build. Validation used PyTorch 2.10.0, DTK 6.3, and the Hygon `gfx936` target; all 15 compile integration tests passed, including forward, backward, FP16, max-autotune, recompilation, FakeTensor tracing, and FlagTree identity checks. The DCU CI manifest is intentionally unchanged because its pinned image currently provides DTK Triton rather than a FlagTree HCU build.

## Change Type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)
- Hygon DCU

## Problem Analysis
### What was broken/missing?
The implementation already supported the FlagOS Inductor backend, but the documentation still described FlagTree as validated only on NVIDIA and marked Hygon `torch.compile` as not validated. Users had no Hygon-specific instructions for building and activating the FlagTree HCU backend.

### Why did it happen?
FlagTree replaces the importable `triton` module at installation time, and the Hygon DTK environment normally supplies a separate stock Triton/HCU installation. The existing DCU CI image does not contain a FlagTree HCU build, so the path was not represented by the CI manifest or compatibility matrix.

### Investigation process:
1. Rebased the working branch onto the current local `flagos/main` at `a81d69a` and inspected the existing compile backend, FlagTree detection shim, integration tests, and DCU installation/compatibility documentation.
2. Built FlagTree 0.6.0 from source with `FLAGTREE_BACKEND=hcu` and verified that `triton._flagtree_spec` was importable, `FLAGTREE_BACKEND` was `hcu`, and the driver selected `GPUTarget(backend='hip', arch='gfx936', warp_size=64)`.
3. Ran the dedicated and full compile suites on Hygon hardware. The full suite passed 15/15, with compiled outputs and gradients remaining on `flagos` and matching eager results.
4. During the source build, an automatically ordered TLE generation dependency was missing; explicitly running the `TleTableGen` Ninja target generated the required headers and allowed the unchanged FlagTree source build to complete. No torch-fl implementation change was required.

## Solution Design
### Implementation approach:
Record the measured Hygon result in the compatibility matrix, architecture documentation, compile README, and DCU installation guide. The guide explains that FlagTree must replace `triton` at install time and that `FLAGOS_USE_FLAGTREE=1` only asserts the active installation; it does not switch Triton at runtime.

### Key design decisions:
- Mark Hygon compile support as Experimental rather than Stable because the result is a hardware measurement and is not yet exercised by CI.
- Keep the DCU CI manifest unchanged because adding a test that requires a FlagTree wheel to an image that only supplies DTK Triton would produce a misleading or skipped check.
- Document the exact Hygon target and software versions so the claim is reproducible and does not imply support for untested vendor backends.

### Code changes by file:
- `docs/reference/compatibility.md`: Mark Hygon FlagTree HCU compile support as Experimental and record the measured `gfx936` validation and CI limitation.
- `docs/vendors/dcu/installation.md`: Add FlagTree HCU build, environment, identity-check, and compile-test instructions for DCU.
- `docs/architecture/torch-compile-integration.md`: Update FlagTree maturity and Hygon validation status.
- `torch_fl/compile/README.md`: Mark NVIDIA and Hygon FlagTree environments as exercised and retain the multi-GPU limitation.

### Changes by commit:
1. `<pending>` - `docs: record Hygon FlagTree compile validation`: Document the measured Hygon HCU FlagTree torch.compile path.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (not applicable; documentation-only change)
- [x] **All tests pass** (full compile integration suite on Hygon hardware)
- [x] **Manual testing completed** (FlagTree identity, Hygon target, and device-preserving output checks)
- [x] **No debug/temporary code** (temporary FlagTree build artifacts remain outside the repository)
- [x] **Documentation updated** (compatibility, architecture, vendor guide, and compile README)
- [x] **Commit messages follow conventions**
- [x] **All text in English**

### Linting Results
```bash
$ ruff check
All checks passed!

$ ruff format --check
481 files already formatted
```

The documentation-only paths have no Python files for Ruff to lint; the Python formatting check was also run on the affected compile integration files:

```bash
$ ruff check docs/reference/compatibility.md docs/vendors/dcu/installation.md docs/architecture/torch-compile-integration.md torch_fl/compile/README.md
warning: No Python files found under the given path(s)
All checks passed!

$ ruff format --check torch_fl/compile/flagtree_shim.py tests/integration/test_compile.py
2 files already formatted
```

### Test Results
```bash
# Dedicated FlagTree test on Hygon DCU
FLAGOS_USE_FLAGTREE=1 pytest tests/integration/test_compile.py::test_flagtree_compiles_correct_results -v

# Result
1 passed, 14 warnings in 37.63s

# Full compile integration suite on Hygon DCU
FLAGOS_USE_FLAGTREE=1 pytest tests/integration/test_compile.py -v

# Result
15 passed, 14 warnings in 26.15s
```

### Manual Verification
```bash
# FlagTree identity and target
triton 3.6.0
flagtree_marker True
flagtree_backend hcu
target GPUTarget(backend='hip', arch='gfx936', warp_size=64)

# Compile behavior
compiled output device: flagos:0
gradient device: flagos:0
eager and compiled results: match
```

## Code Quality Verification
### Style Consistency
- [x] Matched existing documentation style in modified files
- [x] Followed existing naming conventions
- [x] Comment density matches surrounding documentation
- [x] Used the project's existing FlagTree detection and environment conventions

### Edge Cases Considered
1. Stock Triton must not be mistaken for FlagTree; `FLAGOS_USE_FLAGTREE=1` asserts the FlagTree marker.
2. FlagTree's wheel name differs from its importable module; the guide explicitly avoids recommending `import flagtree`.
3. Compiled forward outputs and backward gradients must remain on `flagos`, proving that the graph was not rewritten to CUDA or CPU.
4. FP16, max-autotune, recompilation, and FakeTensor tracing are included in the full suite.

### Potential Risks
1. FlagTree backend behavior may change across source revisions or Hygon/DTK versions; this is why the matrix entry is Experimental.
2. The documented build is not currently part of DCU CI and requires a separately built FlagTree HCU environment.

### Rollback Plan
Revert this documentation-only commit. No runtime or generated-code behavior changes are included.

## Related Work
- Related to #116 (FlagTree install-time substitution)
- Related to #117 (DCU AMP validation and current DCU documentation)
- Depends on the existing `torch.compile(backend="flagos")` integration

## Explicitly Not Included
- No changes to torch-fl runtime, Inductor registration, code generation, or operator routing.
- No FlagTree wheel or build artifact is bundled or published.
- No change to the DCU CI image or test manifest, because the current image does not provide FlagTree HCU.
- No performance claim or benchmark result; compile performance remains unmeasured.

## Human Review Notes
### Areas needing special attention:
1. Confirm that the Experimental compatibility status accurately reflects a real Hygon `gfx936` measurement without implying CI coverage.
2. Check that the FlagTree install-time substitution and `FLAGOS_USE_FLAGTREE=1` semantics are clear.
3. Review whether the DCU CI image should gain a separately managed FlagTree HCU job in a follow-up change.

### Questions for reviewer:
1. Should the Hygon FlagTree environment be added to CI after a reproducible FlagTree-enabled image is available?
2. Should the measured FlagTree version and Hygon target be pinned in a future vendor CI image?

## Additional Context
The FlagTree source build initially required an explicit TLE table-generation Ninja target because the generated dialect header was not available when the dependent compile target started. This was an environment/build-order issue in the external FlagTree source tree; the torch-fl repository required no source fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
