### PR TITLE
[CICD] Ci watch 2.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, devops, dev-hygon]
+    branches: [main, dev, devops, dev-hygon, "2.9"]
     paths:
       - "cmake/**"
       - "csrc/**"
@@ -31,7 +31,7 @@ on:
       - ".github/scripts/**"
       - ".github/workflows/**"
   pull_request:
-    branches: [main, dev, devops, dev-hygon]
+    branches: [main, dev, devops, dev-hygon, "2.9"]
     paths:
       - "cmake/**"
       - "csrc/**"
@@ -106,7 +106,7 @@ jobs:
   ascend-pipeline:
     name: Platform pipeline (ascend)
     needs: discover-platforms
-    if: needs.discover-platforms.outputs.has_ascend == 'true'
+    if: needs.discover-platforms.outputs.has_ascend == 'true' && github.ref_name != '2.9' && github.base_ref != '2.9'
     uses: ./.github/workflows/integration-test-ascend.yml
 
   cuda-pipeline:
@@ -118,11 +118,11 @@ jobs:
   dcu-pipeline:
     name: Platform pipeline (dcu)
     needs: discover-platforms
-    if: needs.discover-platforms.outputs.has_dcu == 'true'
+    if: needs.discover-platforms.outputs.has_dcu == 'true' && github.ref_name != '2.9' && github.base_ref != '2.9'
     uses: ./.github/workflows/integration-test-dcu.yml
 
   metax-pipeline:
     name: Platform pipeline (metax)
     needs: discover-platforms
-    if: needs.discover-platforms.outputs.has_metax == 'true'
+    if: needs.discover-platforms.outputs.has_metax == 'true' && github.ref_name != '2.9' && github.base_ref != '2.9'
     uses: ./.github/workflows/integration-test-metax.yml

--- a/docs/architecture/torch-compile-integration.md
+++ b/docs/architecture/torch-compile-integration.md
@@ -313,7 +313,8 @@ tests live alongside it:
 3. **Dynamic shapes**: Some models with dynamic shapes may not compile
 4. **CUDA graphs off**: `torch.cuda.CUDAGraph` is a dummy class in the CPU torch
    wheel, so `triton.cudagraphs` is forced off even under `mode="max-autotune"`
-5. **FlagTree maturity**: Backend support varies by hardware (NVIDIA most mature)
+5. **FlagTree maturity**: Backend support varies by hardware; Hygon HCU is
+   validated on `gfx936`, while other vendor backends remain untested here
 
 ## Roadmap
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -26,7 +26,7 @@
 | MetaX | `ACCELERATOR=metax` | CUDA-boxing reuse via `cu-bridge`/mxcc, or native MetaX kernels | Stable | Not validated | Experimental (NCCL-shaped `mccl` fallback; not CI-covered) | Not validated on this vendor's tracer | Experimental (Python dispatch; not CI-tested on MetaX) | Stable |
 | Ascend | `ACCELERATOR=ascend` | Native ACLNN operator backend, optional FlagGems via triton-ascend | Stable (CI-covered ops, RNG suite) | Not validated | Experimental (HCCL fallback; architectural routing only, no collective-level CI) | Runtime only (device/runtime events not emitted; profiler parity suite excluded from CI) | Experimental (Python dispatch; not CI-tested on Ascend) | Beta |
 | PPU | `ACCELERATOR=cuda` + `PPU_SDK`/`PPU_HOME` detection | Same CUDA-boxing path as NVIDIA CUDA, against the PPU's CUDA-13-compatible SDK | Experimental | Not validated | Experimental (NCCL fallback via vendor-adapted `libnccl.so.2`; not CI-covered) | Not validated on this vendor's tracer | Experimental (vendor-index Triton required) | Experimental |
-| Hygon DCU | `ACCELERATOR=dcu` | CUDA boxing over the hipified DTK torch build (HIP kernels under the CUDA dispatch key) | Beta (including FP16/BF16 autocast and GradScaler) | Not validated | Experimental (RCCL via DTK; all_reduce/DDP measured on 2 cards, not in CI) | Beta (parity suite runs in CI) | Beta (Python dispatch only) | Beta |
+| Hygon DCU | `ACCELERATOR=dcu` | CUDA boxing over the hipified DTK torch build (HIP kernels under the CUDA dispatch key) | Beta (including FP16/BF16 autocast and GradScaler) | Experimental (FlagTree HCU validated on `gfx936`; not in CI) | Experimental (RCCL via DTK; all_reduce/DDP measured on 2 cards, not in CI) | Beta (parity suite runs in CI) | Beta (Python dispatch only) | Beta |
 | Enflame GCU | `ACCELERATOR=gcu` | Native `libtopsaten.so` operator backend, with CPU fallback for unrouted/int64 ops | Experimental | Not validated | Not validated | Not validated | Experimental (Python dispatch, requires vendor Triton) | Experimental |
 | Moore Threads MUSA | `ACCELERATOR=musa` | Native `mudnn` operator backend, with CPU fallback for unrouted ops | Experimental | Not validated | Not validated | Not validated | Experimental (Python dispatch, requires vendor Triton) | Experimental |
 | D-Robotics BPU | `ACCELERATOR=bpu` | No eager kernel sets are built; eager ops run on CPU | Runtime only (CPU fallback for eager) | Experimental (`torch.compile(backend="bpu")` graph path via hbdk4) | Not applicable | Not validated | Not applicable (no per-op kernel build) | Runtime only |
@@ -111,6 +111,14 @@ FP16 and BF16 autocast policies, nested autocast state, finite and overflowing G
 and forward/backward optimizer execution. CPU-to-DCU copies and representative elementwise,
 reduction, matrix multiplication, and backward operations preserve all tested PyTorch dtypes from
 bool through complex128, including float64.
+
+`torch.compile(backend="flagos")` is experimentally validated on Hygon with a
+FlagTree 0.6.0 HCU build and PyTorch 2.10.0. The full compile integration suite
+passes on the `gfx936` target, including forward and backward execution, FP32
+and FP16 inputs, max-autotune, recompilation, FakeTensor tracing, and the
+FlagTree-specific result/device checks. The FlagTree wheel must replace the
+active `triton` installation before Python starts; the current DCU CI image
+uses DTK Triton and does not exercise this path.
 
 ### Enflame GCU
 

--- a/docs/vendors/dcu/installation.md
+++ b/docs/vendors/dcu/installation.md
@@ -91,6 +91,41 @@ Run the DCU AMP coverage, including both autocast dtypes and finite/non-finite G
 pytest tests/integration/test_amp.py -v
 ```
 
+### `torch.compile` with FlagTree
+
+DCU `torch.compile` is validated with FlagTree's HCU backend on the Hygon
+`gfx936` target. FlagTree replaces the active `triton` module at installation
+time, so build it in a separate environment or install location rather than
+trying to import a `flagtree` module at runtime:
+
+```bash
+git clone https://github.com/flagos-ai/FlagTree.git
+cd FlagTree
+export FLAGTREE_BACKEND=hcu
+MAX_JOBS=16 python -m pip install . --no-build-isolation -v
+```
+
+Use the resulting FlagTree environment together with the PyTorch 2.10 and
+torch-fl installation. These variables select the HCU backend and assert that
+the active Triton is FlagTree:
+
+```bash
+export FLAGTREE_BACKEND=hcu
+export FLAGOS_USE_FLAGTREE=1
+export TRITON_BACKENDS_IN_TREE=1
+export GEMS_VENDOR=hygon
+
+python -c 'import triton; from triton._flagtree_backend import FLAGTREE_BACKEND; print(triton.__version__, FLAGTREE_BACKEND)'
+pytest tests/integration/test_compile.py -v
+```
+
+The measured Hygon run used FlagTree 0.6.0, PyTorch 2.10.0, and produced
+`GPUTarget(backend='hip', arch='gfx936', warp_size=64)`. All 15 compile tests
+passed. Compiled outputs and backward gradients remained on `flagos`; eager
+and compiled results matched. The DCU CI manifest does not include this check
+because its pinned image currently supplies DTK Triton rather than a FlagTree
+HCU build.
+
 ### Operator Tests (Vendor Backend)
 
 Run the main operator suite against the DCU boxing backend:

--- a/torch_fl/compile/README.md
+++ b/torch_fl/compile/README.md
@@ -91,10 +91,12 @@ Event/Stream shims that inductor's autotuner needs.
 ## Limitations
 
 1. Single device - multi-GPU compilation not yet exercised
-2. FlagTree verified on nvidia/sm90 only; other vendor backends untested here
+2. FlagTree is validated on NVIDIA `sm90` and Hygon `gfx936` with the HCU
+   backend; other vendor backends remain untested here
 
 ## Future Work
 
-- [ ] Exercise `torch.compile(backend="flagos")` on a FlagTree-built env
+- [x] Exercise `torch.compile(backend="flagos")` on FlagTree-built NVIDIA and
+      Hygon HCU environments
 - [ ] Benchmark fusion gains against stock inductor+triton on cuda
 - [ ] Multi-GPU compilation support


### PR DESCRIPTION
  ## Summary
  - add `2.9` to CI push and pull_request branch filters
  - keep CUDA coverage enabled for `2.9`
  - skip Ascend, DCU, and MetaX pipelines on `2.9`

  ## Validation
  - parsed `.github/workflows/ci.yml` with Python YAML loader
  - ran `git diff --check`

