### PR TITLE
feat: complete PPU AMP integration

### DIFF
--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -25,7 +25,7 @@
 | NVIDIA CUDA | `ACCELERATOR=cuda` (default) | CUDA boxing over an external `libtorch_cuda.so` | Stable | Experimental (inductor GPU device registered; no CI test step) | Beta (FlagCX + NCCL fallback, DDP live-verified) | Stable (CUPTI parity) | Beta (Python + C++ dispatch paths) | Stable |
 | MetaX | `ACCELERATOR=metax` | CUDA-boxing reuse via `cu-bridge`/mxcc, or native MetaX kernels | Stable | Not validated | Experimental (NCCL-shaped `mccl` fallback; not CI-covered) | Not validated on this vendor's tracer | Experimental (Python dispatch; not CI-tested on MetaX) | Stable |
 | Ascend | `ACCELERATOR=ascend` | Native ACLNN operator backend, optional FlagGems via triton-ascend | Stable (CI-covered ops, RNG suite) | Not validated | Experimental (HCCL fallback; architectural routing only, no collective-level CI) | Runtime only (device/runtime events not emitted; profiler parity suite excluded from CI) | Experimental (Python dispatch; not CI-tested on Ascend) | Beta |
-| PPU | `ACCELERATOR=cuda` + `PPU_SDK`/`PPU_HOME` detection | Same CUDA-boxing path as NVIDIA CUDA, against the PPU's CUDA-13-compatible SDK | Experimental | Not validated | Experimental (NCCL fallback via vendor-adapted `libnccl.so.2`; not CI-covered) | Not validated on this vendor's tracer | Experimental (vendor-index Triton required) | Experimental |
+| PPU | `ACCELERATOR=cuda` + `PPU_SDK`/`PPU_HOME` detection | Same CUDA-boxing path as NVIDIA CUDA, against the PPU's CUDA-13-compatible SDK | Experimental (FP16/BF16 autocast and GradScaler measured on PPU hardware, not in CI) | Not validated | Experimental (NCCL fallback via vendor-adapted `libnccl.so.2`; not CI-covered) | Not validated on this vendor's tracer | Experimental (vendor-index Triton required) | Experimental |
 | Hygon DCU | `ACCELERATOR=dcu` | CUDA boxing over the hipified DTK torch build (HIP kernels under the CUDA dispatch key) | Beta (including FP16/BF16 autocast and GradScaler) | Experimental (FlagTree HCU validated on `gfx936`; not in CI) | Experimental (RCCL via DTK; all_reduce/DDP measured on 2 cards, not in CI) | Beta (parity suite runs in CI) | Beta (Python dispatch only) | Beta |
 | Enflame GCU | `ACCELERATOR=gcu` | Native `libtopsaten.so` operator backend, with CPU fallback for unrouted/int64 ops | Experimental | Not validated | Not validated | Not validated | Experimental (Python dispatch, requires vendor Triton) | Experimental |
 | Moore Threads MUSA | `ACCELERATOR=musa` | Native `mudnn` operator backend, with CPU fallback for unrouted ops | Experimental | Not validated | Not validated | Not validated | Experimental (Python dispatch, requires vendor Triton) | Experimental |
@@ -86,6 +86,15 @@ detection (see [`setup.py`](../../setup.py), lines 43-46 and 732-736), reusing t
 build against the PPU's CUDA-13-compatible SDK. There is no CI manifest for this platform (no
 `ppu.yml` under `.github/configs/`), so all capabilities here rest on the
 [README](../../README.md)'s build-from-source instructions rather than automated tests.
+The shared `AutocastPrivateUse1` policies and CUDA-boxing AMP routes expose
+`torch.autocast("flagos")` and `torch.amp.GradScaler("flagos")`, with FP16 and
+BF16 as the advertised target dtypes. The AMP contract is covered by
+`tests/integration/test_amp.py`, but its runtime results are only PPU evidence
+when run with `PPU_SDK` or `PPU_HOME` against a real PPU device; ordinary NVIDIA
+CUDA and CPU runs do not validate this row. The current PPU validation covered
+both FP16 and BF16 autocast, the mutable `found_inf` unscale path, finite scale
+growth, overflow backoff, and an autocast training step. The result remains
+experimental because it is not covered by CI.
 FlagGems requires a vendor-index Triton build whose version string does not satisfy the
 project's `triton>=3.5.1` pin (see [`setup.py`](../../setup.py), lines 790-807). Distributed
 support is described as working via the NCCL fallback with a vendor-adapted `libnccl.so.2`, but

--- a/docs/vendors/ppu/installation.md
+++ b/docs/vendors/ppu/installation.md
@@ -75,6 +75,46 @@ print(f'Sample result: {y.cpu()[0, 0].item():.4f}')
 
 Expected output shows `torch.cuda available: True`, `torch.version.cuda: 13.0`, and a floating-point result.
 
+### AMP and GradScaler
+
+PPU uses the shared CUDA-boxing implementation, while the public AMP device name
+is `flagos`. Autocast supports `torch.float16` and `torch.bfloat16`; the AMP
+foreach kernels used by `GradScaler` are routed through the same PPU CUDA runtime:
+
+```python
+import torch
+import torch.nn.functional as F
+import torch_fl  # noqa: F401
+
+model = torch.nn.Linear(8, 4, device="flagos")
+optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+scaler = torch.amp.GradScaler("flagos")
+inputs = torch.randn(2, 8, device="flagos")
+targets = torch.randn(2, 4, device="flagos")
+
+with torch.autocast("flagos", dtype=torch.bfloat16):
+    loss = F.mse_loss(model(inputs), targets)
+
+scaler.scale(loss).backward()
+scaler.step(optimizer)
+scaler.update()
+```
+
+Run the PPU-only AMP contract after installing the PPU torch wheel and loading
+the driver. `PPU_SDK` or `PPU_HOME` is required so the test cannot be mistaken
+for validation on an ordinary NVIDIA CUDA build:
+
+```bash
+FLAGOS_DISABLE_CUDA_ASSETS=1 \
+  PPU_SDK=/usr/local/PPU_SDK \
+  pytest tests/integration/test_amp.py -v --tb=short
+```
+
+This test requires a real PPU device. A CPU-only environment or a stock NVIDIA
+CUDA environment does not establish PPU AMP support. BF16 availability and
+GradScaler behavior must be checked against the installed PPU hardware and
+vendor torch wheel.
+
 ### Operator Validation (Pure Boxing)
 
 ```bash

--- a/tests/integration/test_amp.py
+++ b/tests/integration/test_amp.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -20,6 +22,15 @@ import torch_fl  # noqa: F401
 
 DEVICE = "flagos:0"
 AMP_DTYPES = (torch.float16, torch.bfloat16)
+
+# PPU uses the CUDA-compatible build path, so ACCELERATOR alone cannot
+# distinguish it from an NVIDIA build. Require the PPU SDK marker before
+# running tests that execute kernels on flagos:0.
+PPU_RUNTIME = bool(os.environ.get("PPU_SDK") or os.environ.get("PPU_HOME"))
+pytestmark = pytest.mark.skipif(
+    not PPU_RUNTIME,
+    reason="PPU AMP tests require PPU_SDK or PPU_HOME and a PPU runtime",
+)
 
 
 def test_amp_device_contract():


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @sunnycase
- **Session Summary**: Synchronized `flagos/main` and completed PPU-only AMP validation through the existing PrivateUse1 autocast and CUDA-boxing paths. Added PPU-specific test gating and documentation without introducing a separate PPU backend.

## Summary
This PR completes AMP integration for PPU, which uses the CUDA-compatible `ACCELERATOR=cuda` build path and the `flagos` PrivateUse1 device. The synchronized upstream implementation provides standard `AutocastPrivateUse1` policies and the existing generated CUDA wrappers provide GradScaler support, including mutable `found_inf` boxing. PPU-specific integration tests and installation/compatibility documentation now describe and validate FP16/BF16 autocast and GradScaler behavior on real PPU hardware.

## Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [x] PPU
- [ ] Platform-agnostic (all platforms)

## Problem Analysis
### What was broken/missing?
PPU exposed `get_amp_supported_dtype()` for FP16 and BF16, but its `flagos` PrivateUse1 dispatch path required standard autocast policy registration and CUDA-boxed AMP routes to make autocast and GradScaler usable. The PPU-specific test and documentation contract was also missing.

### Why did it happen?
PPU intentionally shares the CUDA-compatible build selector rather than having an `ACCELERATOR=ppu` backend. Therefore, `ACCELERATOR` alone cannot distinguish PPU validation from ordinary CUDA validation. AMP must enter through `AutocastPrivateUse1` and then redispatch through the existing CUDA boxing layer.

### Investigation process:
1. Fetched and rebased onto `flagos/main` at `81fd16c`, then inspected `csrc/aten/autocast.cc`, `csrc/aten/register.cc`, the generated CUDA AMP wrappers, the code generator, Python device registration, and `backends_cuda.conf`.
2. Confirmed the upstream `AutocastPrivateUse1` policy lists and fallthrough, the four CUDA AMP routes, and `guard.box({found_inf});` in the in-place unscale wrapper.
3. Rebuilt the extension with the PPU SDK, ran the AMP suite on 16 PPU devices, and verified that the suite passed after synchronizing the rebuilt libraries into the editable package path.

## Solution Design
### Implementation approach:
Use PyTorch's standard PrivateUse1 autocast policies and existing CUDA-boxing AMP wrappers. Gate the integration suite on `PPU_SDK` or `PPU_HOME`, document the `flagos` AMP API and PPU runtime requirements, and preserve the shared CUDA-compatible architecture.

### Key design decisions:
A new `ACCELERATOR=ppu` selector or `USE_PPU` compile gate would duplicate the existing CUDA path and require unrelated setup/CMake plumbing. No native PPU AMP shim is needed because PPU dispatches through PrivateUse1 and then the generated CUDA boxing kernels. Ascend-only float64 handling remains unchanged.

### Code changes by file:
- `tests/integration/test_amp.py`: Gate runtime AMP tests on `PPU_SDK`/`PPU_HOME` so ordinary CUDA and CPU environments skip rather than claim PPU validation.
- `docs/vendors/ppu/installation.md`: Add PPU autocast/GradScaler usage, build/runtime environment requirements, and the PPU AMP test command.
- `docs/reference/compatibility.md`: Record the experimental PPU AMP status and the hardware validation boundary.
- `csrc/aten/autocast.cc`: No new diff; synchronized upstream implementation supplies the PrivateUse1 policies.
- `csrc/aten/generated/cuda_kernels.cc`: No new diff; synchronized generated wrapper already boxes mutable `found_inf`.
- `scripts/codegen_ops.py`: No new diff; synchronized generator already emits mutable tensor boxing.

### Changes by commit:
1. `81fd16c` - `feat: add PrivateUse1 autocast and dtype support (#127)`: Synchronized upstream implementation of generic PrivateUse1 autocast policies and contract tests.
2. Pending commit in this PR - PPU AMP test gating and documentation: Constrain runtime validation to PPU and document the supported workflow.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (not applicable)
- [x] **All relevant tests pass** (unit + AMP + targeted dispatch)
- [x] **Manual testing completed** (PPU runtime smoke and AMP contract)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [x] **Documentation updated**
- [x] **Commit messages follow conventions**
- [x] **All text in English**

### Linting Results
```text
$ ruff check .
All checks passed!

$ ruff format --check .
176 files already formatted
```

### Test Results
```text
$ FLAGOS_DISABLE_CUDA_ASSETS=1 pytest tests/integration/test_amp.py -v --tb=short
24 passed in 8.67s

$ pytest tests/unit/ -q
97 passed, 28 skipped, 1 warning in 16.39s

$ pytest tests/integration/ops/test_mm_dispatch.py tests/integration/ops/test_softmax_dispatch.py tests/integration/ops/test_sum_dispatch.py -q
33 passed, 10 skipped in 70.39s

$ env -u PPU_SDK -u PPU_HOME FLAGOS_DISABLE_CUDA_ASSETS=1 pytest tests/integration/test_amp.py -q
24 skipped in 0.09s
```

### Manual Verification
```text
$ FLAGOS_DISABLE_CUDA_ASSETS=1 python -c 'import torch, torch_fl; print(torch.cuda.is_available()); print(torch.cuda.device_count()); print(torch.flagos.device_count()); print(torch.amp.is_autocast_available("flagos")); print(torch.flagos.get_amp_supported_dtype())'
True
16
16
True
[torch.float16, torch.bfloat16]

$ cmake --build build --parallel 8
[100%] Built target torch_bindings
```

The first AMP run before installing the rebuilt editable libraries used stale `.so` files and failed; after `cmake --install build`, the rebuilt `autocast.cc` and CUDA AMP wrappers were loaded and all 24 tests passed.

## Code Quality Verification
### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions
- [x] Comment density matches surrounding code
- [x] Used existing utilities and dispatch paths

### Edge Cases Considered
1. Unsupported FP32/FP64 autocast targets warn and disable autocast.
2. Both FP16 and BF16 policy paths are exercised.
3. BCE fallthrough, float64 eager copy, mutable `found_inf`, finite GradScaler growth, and overflow backoff are covered.
4. Non-PPU CUDA/CPU environments skip hardware-dependent tests and cannot falsely report PPU validation.

### Potential Risks
1. BF16 behavior depends on the installed PPU hardware and vendor PyTorch wheel.
2. PPU AMP is not covered by CI, so future regressions require the documented hardware test command.

### Rollback Plan
Revert the PPU test gate and the two documentation changes. The synchronized upstream PrivateUse1 implementation can remain or be reverted independently according to the upstream change policy.

## Related Work
- Fixes #92
- Related to #127

## Explicitly Not Included
- No new `ACCELERATOR=ppu` backend or native PPU AMP implementation.
- No DCU, Ascend, MetaX, GCU, MUSA, BPU, profiler, or cross-backend refactoring.
- No unrelated FlagGems generated output or CUDA asset changes.

## Human Review Notes
### Areas needing special attention:
1. Confirm that `PPU_SDK`/`PPU_HOME` is the appropriate reliable distinction for PPU AMP test execution.
2. Review the mutable `found_inf` boxing path and the GradScaler runtime results on the PPU environment.
3. Confirm the compatibility wording accurately reflects experimental, non-CI PPU coverage.

### Questions for reviewer:
1. Should the PPU AMP suite be added to a future PPU CI manifest once one exists?
2. Should the documented default AMP example use BF16 or FP16 for the supported PPU hardware cohort?

## Additional Context
The PPU runtime used for validation reported 16 devices and CUDA 13.0 compatibility. Code generation was run against the current environment; it produced unrelated FlagGems Python output because the installed FlagGems operator set differs from the checked-in artifact, so that unrelated generated churn was discarded. The CUDA AMP generated output remained unchanged and already contained the required mutable tensor boxing.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
