### PR TITLE
feat: validate AMP support on MetaX

### DIFF
--- a/.github/configs/metax.yml
+++ b/.github/configs/metax.yml
@@ -128,3 +128,6 @@ integration_tests:
       python -m pytest
       tests/integration/test_factory_ops.py
       -v -s --tb=short
+
+  - name: Run AMP tests
+    command: python -m pytest tests/integration/test_amp.py -v --tb=short

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -23,7 +23,7 @@
 | Platform | Build selector | Execution path | Eager and autograd | `torch.compile` | Distributed | Profiler | FlagGems | Status |
 |---|---|---|---|---|---|---|---|---|
 | NVIDIA CUDA | `ACCELERATOR=cuda` (default) | CUDA boxing over an external `libtorch_cuda.so` | Stable | Experimental (inductor GPU device registered; no CI test step) | Beta (FlagCX + NCCL fallback, DDP live-verified) | Stable (CUPTI parity) | Beta (Python + C++ dispatch paths) | Stable |
-| MetaX | `ACCELERATOR=metax` | CUDA-boxing reuse via `cu-bridge`/mxcc, or native MetaX kernels | Stable | Not validated | Experimental (NCCL-shaped `mccl` fallback; not CI-covered) | Experimental (MCPTI parity measured on C550; not CI-covered) | Experimental (Python dispatch; not CI-tested on MetaX) | Stable |
+| MetaX | `ACCELERATOR=metax` | CUDA-boxing reuse via `cu-bridge`/mxcc, or native MetaX kernels | Stable (FP16/BF16 autocast and GradScaler measured in boxing mode) | Not validated | Experimental (NCCL-shaped `mccl` fallback; not CI-covered) | Experimental (MCPTI parity measured on C550; not CI-covered) | Experimental (Python dispatch; not CI-tested on MetaX) | Stable |
 | Ascend | `ACCELERATOR=ascend` | Native ACLNN operator backend, optional FlagGems via triton-ascend | Stable (CI-covered ops, RNG suite) | Not validated | Experimental (HCCL fallback; architectural routing only, no collective-level CI) | Runtime only (device/runtime events not emitted; profiler parity suite excluded from CI) | Experimental (Python dispatch; not CI-tested on Ascend) | Beta |
 | PPU | `ACCELERATOR=cuda` + `PPU_SDK`/`PPU_HOME` detection | Same CUDA-boxing path as NVIDIA CUDA, against the PPU's CUDA-13-compatible SDK | Experimental (FP16/BF16 autocast and GradScaler measured on PPU hardware, not in CI) | Not validated | Experimental (NCCL fallback via vendor-adapted `libnccl.so.2`; not CI-covered) | Not validated on this vendor's tracer | Experimental (vendor-index Triton required) | Experimental |
 | Hygon DCU | `ACCELERATOR=dcu` | CUDA boxing over the hipified DTK torch build (HIP kernels under the CUDA dispatch key) | Beta (including FP16/BF16 autocast and GradScaler) | Experimental (FlagTree HCU validated on `gfx936`; not in CI) | Experimental (RCCL via DTK; all_reduce/DDP measured on 2 cards, not in CI) | Beta (parity suite runs in CI) | Beta (Python dispatch only) | Beta |
@@ -52,12 +52,16 @@ parity with torch-cuda via CUPTI (see
 
 ### MetaX
 
-[`.github/configs/metax.yml`](../../.github/configs/metax.yml) (lines 99-125) runs representative
-operator dispatch tests and general factory/autograd tests in CI, but its test command explicitly
-excludes all FlagGems tests (`-m "not flaggems and not flaggems_python and not flaggems_cpp"` at
-line 118), so FlagGems on MetaX has no CI validation. MetaX carries FSDP2 and Qwen3 training
-parity work (see repository history). Distributed support routes through the same NCCL-shaped
-fallback as CUDA (`_VENDOR_PROFILES["metax"]` in
+[`.github/configs/metax.yml`](../../.github/configs/metax.yml) runs representative
+operator dispatch, factory/autograd, RNG, and AMP tests in CI. The operator command explicitly
+excludes all FlagGems tests, so FlagGems on MetaX has no CI validation. The shared
+`AutocastPrivateUse1` policy registrations dispatch FP16/BF16 lower-precision, FP32,
+optional-dtype, and promote groups through the existing CUDA-boxing kernels. On a C550 with
+MACA 3.8.0, the 25-case AMP suite passed, including nested autocast state, non-finite unscale,
+finite scale growth, overflow backoff, and a forward/backward optimizer step. This evidence is
+specific to MetaX boxing mode; the legacy handwritten MetaX kernels were not revalidated.
+MetaX carries FSDP2 and Qwen3 training parity work (see repository history). Distributed
+support routes through the same NCCL-shaped fallback as CUDA (`_VENDOR_PROFILES["metax"]` in
 [`torch_fl/comm/process_group.py`](../../torch_fl/comm/process_group.py), line 93), but that is
 architectural routing, not a CI-verified collective test on this platform. `torch.compile` is
 not validated. Profiler-tracer parity was measured locally on a C550 with MACA 3.8.0 MCPTI:

--- a/docs/reference/dtype-support.md
+++ b/docs/reference/dtype-support.md
@@ -23,12 +23,14 @@ is not an AMP target and is not accepted by its native matmul API.
 | --- | --- | --- | --- | --- |
 | CUDA | Native PyTorch CUDA dtype support | Native CUDA coverage | Native CUDA coverage | float16, bfloat16 |
 | Ascend | float16, bfloat16, float32, float64, integer, uint8, bool | Vendor coverage; unsupported ACLNN combinations use the CPU fallback | float16, bfloat16, float32 natively; float64 and unsupported types use the CPU fallback | float16, bfloat16 |
-| MetaX | Vendor library coverage | Vendor library coverage | Vendor library coverage | Backend-specific |
+| MetaX boxing | MACA libtorch CUDA-compatible coverage | MACA libtorch CUDA-compatible coverage | MACA libtorch CUDA-compatible coverage | float16, bfloat16 |
 | DCU | Vendor library coverage | Vendor library coverage | Vendor library coverage | Backend-specific |
 | MUSA | Vendor library coverage | Vendor library coverage | Vendor library coverage | Backend-specific |
 
-The MetaX, DCU, and MUSA entries intentionally do not claim parity without
-hardware measurements for the specific library release. Their native boxing or
+The MetaX AMP entry is measured for the CUDA-boxing path on C550 with MACA
+3.8.0; it does not cover the legacy handwritten MetaX kernel mode. The DCU and
+MUSA entries intentionally do not claim AMP target parity without hardware
+measurements for the specific library release. Their native boxing or
 code-generated kernels determine the available operator/dtype combinations.
 
 ## Ascend Boundaries

--- a/docs/reference/operator-support.md
+++ b/docs/reference/operator-support.md
@@ -282,10 +282,29 @@ change; the evidence gap is that no A100/mc550/810e re-survey was run, and the
 reduced the same cohort 546 -> 545 without a re-survey; the baseline tables
 therefore describe the original 546-route cohort, not the current HEAD.
 
+### MetaX AMP routes (2026-08-21)
+
+The shared `AutocastPrivateUse1` registrations now have explicit MetaX boxing
+coverage. They use the same PyTorch policy groups as CUDA and redispatch through
+the existing PrivateUse1-to-CUDA boxing kernels; no handwritten MetaX operator
+was added or rerouted.
+
+Measured on MetaX C550 with MACA 3.8.0 in boxing mode:
+
+- `tests/integration/test_amp.py`: **25 passed**.
+- The suite covered FP16 and BF16 lower-precision, FP32, optional-dtype, and
+  promote policies; nested autocast state; BCE fallthrough; non-finite unscale;
+  finite scale growth; overflow backoff; and a forward/backward optimizer step.
+
+The generic FlagGems route cohort is unchanged and was **not revalidated** by
+this work. The AMP result does not establish support for the legacy handwritten
+MetaX kernel mode or for additional MACA releases and devices.
+
 ## Update History
 
 | Date | Hardware | Cohort | Change | Evidence |
 |---|---|---|---|---|
+| 2026-08-21 | MetaX C550 (MACA 3.8.0) | CUDA-boxing AMP routes | Enabled the shared AMP integration contract for MetaX and added it to the MetaX CI manifest; no operator route changed. Generic FlagGems routes were **not revalidated**. | `tests/integration/test_amp.py`: 25 passed, covering FP16/BF16 autocast policies and GradScaler finite/overflow training paths. |
 | 2026-08-19 | Hygon DCU bw1000 | Generic FlagGems routes | Rerouted `index_select` from `flagos_python` to `cuda` in all FlagGems configs (cross-stream launch race drops output stores under load); generic cohort 546 -> 545 active routes, 26 -> 27 forced CUDA fallbacks. Four-platform rows **not revalidated** (A100/mc550/810e unavailable). | Targeted survey `--ops index_select` on the flagos_python route: STRICT (standalone math correct); three failing HF v5.5.0 UT nodes (T5/Qwen3/Gemma3 beam search) pass after the reroute; tiny-T5 NaN reproducer clean 3/3. |
 | 2026-08-18 | MTT S5000 (8 devices) | Native MUSA RNG, MThreads FlagGems hybrid, and MUPTI profiler | Added optional MUPTI activity tracing; the operator route cohort is unchanged. | `tests/integration/test_profiler_musa.py`: 1 passed with real positive-duration MUPTI kernel/runtime/memcpy activities and valid Chrome JSON. CPU-only Kineto resolver behavior remains environment-dependent; generic FlagGems operator coverage was not revalidated by this profiler change. |
 | 2026-08-18 | Ascend 910 (CANN 9.0) | Ascend AMP and dtype routes | Added generated AMP unscale and foreach list-add routes; fixed promotion-aware binary outputs, float64 copies, and CPU fallback for unsupported matmul/unary dtypes. | `test_amp.py`: 25 passed; `test_dtype_coverage.py`: 174 passed; targeted float64, promotion, and fallback parity probes passed. |

--- a/docs/vendors/metax/installation.md
+++ b/docs/vendors/metax/installation.md
@@ -149,6 +149,44 @@ export FLAGOS_METAX_BOXING=1
 pytest tests/integration/test_factory_ops.py -v --tb=short
 ```
 
+### Automatic Mixed Precision
+
+MetaX boxing reuses the CUDA operator path while exposing PyTorch's device-generic
+AMP API through `flagos`. Both FP16 and BF16 are supported autocast targets, and
+`GradScaler` uses the boxed CUDA non-finite check and unscale kernels:
+
+```python
+import torch_fl  # Import first on MetaX.
+import torch
+
+model = torch.nn.Linear(8, 4).to("flagos")
+optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+scaler = torch.amp.GradScaler("flagos")
+x = torch.randn(2, 8, device="flagos")
+target = torch.randn(2, 4, device="flagos")
+
+with torch.autocast("flagos", dtype=torch.float16):
+    output = model(x)
+    loss = torch.nn.functional.mse_loss(output, target)
+
+scaler.scale(loss).backward()
+scaler.step(optimizer)
+scaler.update()
+```
+
+Run the complete autocast and GradScaler contract on MetaX hardware:
+
+```bash
+export FLAGOS_METAX_BOXING=1
+pytest tests/integration/test_amp.py -v --tb=short
+```
+
+The measured C550/MACA 3.8.0 coverage includes FP16 and BF16 lower-precision,
+FP32, optional-dtype, and promote autocast policies; nested state; non-finite
+unscale; finite scale growth; overflow backoff; and a forward/backward optimizer
+step. This validation applies to the boxing path, not the legacy handwritten
+MetaX kernel mode.
+
 ## Optional: FlagGems on MetaX
 
 The MetaX boxing wheel compiles FlagGems Python-dispatch kernels by default, so FlagGems is a runtime switch. Enabling it requires two additional target-side dependencies:

--- a/tests/integration/test_amp.py
+++ b/tests/integration/test_amp.py
@@ -15,21 +15,23 @@
 import os
 
 import pytest
+import torch_fl
 import torch
 import torch.nn.functional as F
-import torch_fl  # noqa: F401
 
 
 DEVICE = "flagos:0"
 AMP_DTYPES = (torch.float16, torch.bfloat16)
 
 # PPU uses the CUDA-compatible build path, so ACCELERATOR alone cannot
-# distinguish it from an NVIDIA build. Require the PPU SDK marker before
-# running tests that execute kernels on flagos:0.
+# distinguish it from an NVIDIA build. MetaX has an explicit build selector.
+# Run this hardware contract only on those two validated vendor runtimes.
+BUILD_ACCELERATOR = torch_fl._build_accelerator()
 PPU_RUNTIME = bool(os.environ.get("PPU_SDK") or os.environ.get("PPU_HOME"))
+AMP_RUNTIME = BUILD_ACCELERATOR == "metax" or PPU_RUNTIME
 pytestmark = pytest.mark.skipif(
-    not PPU_RUNTIME,
-    reason="PPU AMP tests require PPU_SDK or PPU_HOME and a PPU runtime",
+    not AMP_RUNTIME,
+    reason="AMP tests require a MetaX build or PPU_SDK/PPU_HOME runtime",
 )
 
 


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5
- **Human Reviewer**: @aoyulong
- **Session Summary**: Extended the existing CUDA-compatible PrivateUse1 AMP contract to MetaX boxing builds after syncing with the latest upstream code. Validated the complete autocast and GradScaler suite on a MetaX C550 with MACA 3.8.0, added CI coverage, and documented the measured boundary.

## Summary
This change enables the existing AMP integration contract for MetaX boxing builds instead of leaving the suite gated to PPU only. MetaX reuses the shared `AutocastPrivateUse1` policy registrations and existing PrivateUse1-to-CUDA boxing kernels; no new handwritten MetaX kernel or operator route is introduced. The change adds the AMP suite to MetaX CI and records measured FP16/BF16 autocast and GradScaler behavior on C550/MACA 3.8.0.

## Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [x] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [x] MetaX
- [ ] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)

## Problem Analysis
### What was broken/missing?

The repository already registered PyTorch's standard `AutocastPrivateUse1` policies and exposed FP16/BF16 through `torch.flagos.get_amp_supported_dtype()`, but `tests/integration/test_amp.py` was globally skipped unless `PPU_SDK` or `PPU_HOME` was set. As a result, MetaX boxing had no active AMP integration contract or CI step, and the compatibility and dtype references still described its AMP targets as backend-specific.

### Why did it happen?

The shared PrivateUse1 autocast implementation was added before the PPU-specific hardware validation. The later PPU change gated the whole test module on PPU runtime markers because PPU has no distinct `ACCELERATOR` selector. MetaX does have an explicit `ACCELERATOR=metax` build identity, but it was not included in that gate even though boxing mode redispatches through the same CUDA-compatible operator path.

### Investigation process:
1. Compared `csrc/aten/autocast.cc`, the CUDA-compatible boxing registration in `csrc/aten/register.cc`, `tests/integration/test_amp.py`, and the PPU/DCU AMP documentation.
2. Inspected the MetaX CMake commands to confirm that `csrc/aten/autocast.cc` and `csrc/aten/generated/cuda_kernels.cc` are both compiled in boxing mode.
3. Rebuilt `libtorch_fl.so`, verified `aten::mm` has an `AutocastPrivateUse1` kernel and AMP unscale has a `PrivateUse1` kernel, then ran the full 25-case suite on C550/MACA 3.8.0.

## Solution Design
### Implementation approach:

Treat MetaX boxing as a validated consumer of the existing shared AMP implementation. Extend the test module's runtime gate to accept either an explicit MetaX build or PPU runtime markers, preserve the MetaX import-order requirement by importing `torch_fl` before `torch`, add the suite to the MetaX CI manifest, and update support documentation with the measured scope.

### Key design decisions:

- Reuse the standard `AutocastPrivateUse1` policy groups rather than duplicating CUDA policy tables for MetaX.
- Keep all device execution on the existing PrivateUse1-to-CUDA boxing route; no handwritten MetaX operator is needed.
- Limit the claim to MetaX boxing on C550/MACA 3.8.0. The legacy handwritten MetaX kernel mode and other SDK/device combinations are explicitly not claimed.
- Leave PPU gating intact because PPU still requires SDK markers to distinguish it from ordinary `ACCELERATOR=cuda` builds.

### Code changes by file:
- `.github/configs/metax.yml`: run the AMP integration suite on the MetaX hardware CI job.
- `tests/integration/test_amp.py`: import `torch_fl` first for MetaX and enable the hardware contract for explicit MetaX builds as well as PPU runtimes.
- `docs/vendors/metax/installation.md`: document autocast, GradScaler usage, the test command, and the measured boxing-mode boundary.
- `docs/reference/compatibility.md`: record measured MetaX FP16/BF16 autocast and GradScaler coverage.
- `docs/reference/dtype-support.md`: list FP16 and BF16 as measured MetaX boxing AMP targets.
- `docs/reference/operator-support.md`: record the C550/MACA 3.8.0 evidence and state that the generic FlagGems cohort was not revalidated.

### Changes by commit:
1. `e7bd237` - `feat: validate AMP support on MetaX`: enables MetaX AMP testing and CI coverage and documents the measured behavior.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [ ] **Type checking passed** (not applicable; no typed production Python API was changed)
- [x] **All tests pass** (relevant unit and integration suites)
- [x] **Manual testing completed** (dispatch registration and full AMP workload verified on MetaX hardware)
- [x] **No debug/temporary code** (no debug prints, commented code, or TODOs added)
- [x] **Documentation updated** (MetaX installation, compatibility, dtype, and operator support references)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ ruff check .
All checks passed!

$ ruff format --check .
179 files already formatted

$ git diff --check
# No output; exit code 0
```

### Test Results
```bash
# Command:
env -u PYTHONPATH -u PPU_SDK -u PPU_HOME \
  ACCELERATOR=metax METAX_PATH=/opt/maca-3.8.0 FLAGOS_METAX_BOXING=1 \
  LD_LIBRARY_PATH=/opt/maca-3.8.0/lib:$LD_LIBRARY_PATH \
  /public-flash/lvyufeng/miniconda3/envs/maca-torch210-py312/bin/python \
  -m pytest tests/integration/test_amp.py -v --tb=short

# Output:
============================== 25 passed in 4.29s ==============================

# Command:
env -u PYTHONPATH -u PPU_SDK -u PPU_HOME \
  ACCELERATOR=metax METAX_PATH=/opt/maca-3.8.0 FLAGOS_METAX_BOXING=1 \
  LD_LIBRARY_PATH=/opt/maca-3.8.0/lib:$LD_LIBRARY_PATH \
  /public-flash/lvyufeng/miniconda3/envs/maca-torch210-py312/bin/python \
  -m pytest tests/unit/ -q --tb=short

# Output:
98 passed, 29 skipped, 2 warnings in 16.34s

# Command:
env -u PYTHONPATH -u PPU_SDK -u PPU_HOME \
  ACCELERATOR=metax METAX_PATH=/opt/maca-3.8.0 FLAGOS_METAX_BOXING=1 \
  LD_LIBRARY_PATH=/opt/maca-3.8.0/lib:$LD_LIBRARY_PATH \
  /public-flash/lvyufeng/miniconda3/envs/maca-torch210-py312/bin/python \
  -m pytest tests/integration/ops/test_mm_dispatch.py \
  tests/integration/ops/test_softmax_dispatch.py \
  tests/integration/ops/test_sum_dispatch.py -q --tb=short

# Output:
27 passed, 16 skipped in 72.94s
```

### Manual Verification
```bash
# Dispatch registration probe on the rebuilt MetaX boxing extension:
env -u PPU_SDK -u PPU_HOME \
  ACCELERATOR=metax METAX_PATH=/opt/maca-3.8.0 FLAGOS_METAX_BOXING=1 \
  LD_LIBRARY_PATH=/opt/maca-3.8.0/lib:$LD_LIBRARY_PATH \
  /public-flash/lvyufeng/miniconda3/envs/maca-torch210-py312/bin/python - <<'PY'
import torch_fl
import torch

assert torch_fl._build_accelerator() == "metax"
assert torch._C._dispatch_has_kernel_for_dispatch_key(
    "aten::mm", "AutocastPrivateUse1"
)
assert torch._C._dispatch_has_kernel_for_dispatch_key(
    "aten::_amp_foreach_non_finite_check_and_unscale_", "PrivateUse1"
)
print("MetaX AMP dispatch registrations present")
PY

# Output AFTER change:
MetaX AMP dispatch registrations present

# Before the test-gate change, the same MetaX invocation collected 25 tests but
# skipped all 25 because the module required PPU_SDK/PPU_HOME. After the change:
25 passed in 4.29s
```

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked PPU and DCU AMP integration)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (shared autocast policies and `_build_accelerator()`)

### Edge Cases Considered
1. MetaX requires `torch_fl` to be imported before `torch` so vendor libtorch linking and runtime setup happen before PyTorch initialization.
2. PPU remains distinguishable only by `PPU_SDK`/`PPU_HOME`; the existing PPU behavior is preserved.
3. Unsupported autocast targets (`float32` and `float64`) disable autocast with the expected warning.
4. Both FP16 and BF16 exercise lower-precision, FP32, optional-dtype, and promote policy groups.
5. GradScaler covers finite growth, non-finite detection, optimizer-step skipping, and backoff.

### Potential Risks
1. The measured MetaX result is specific to C550 and MACA 3.8.0; behavior may differ on other devices or SDK releases.
2. The legacy handwritten MetaX kernel mode does not necessarily have the same dtype coverage and is intentionally outside this claim.

### Rollback Plan
Revert commit `e7bd237`. This removes the MetaX test/CI gate and documentation updates without changing any operator implementation or routing table.

## Related Work
- Related to PR #127, which added the shared PrivateUse1 autocast policies.
- Related to PR #140, which validated the same shared contract on PPU.
- No issue number was provided for this MetaX follow-up.

## Explicitly Not Included
- No new handwritten MetaX kernels or code-generated operator routes.
- No FlagGems AMP validation or generic FlagGems overload re-survey.
- No claim for legacy non-boxing MetaX kernels, additional MACA versions, or other MetaX devices.
- No AMP performance benchmark or optimization.

## Human Review Notes
### Areas needing special attention:
1. Confirm that `ACCELERATOR=metax` is the correct durable test identity for both local builds and the MetaX CI wheel.
2. Review the explicit boxing-mode evidence boundary in the compatibility and dtype documentation.
3. Confirm that preserving PPU SDK-marker gating avoids enabling this hardware suite on ordinary CUDA jobs.

### Questions for reviewer:
1. Should future MetaX SDK/device variants be added as a matrix once those runners become available?
2. Should legacy handwritten MetaX kernels remain undocumented for AMP until a separate hardware run verifies them?

## Additional Context
- The branch was based on the latest `flagos/main` (`06bf923`) before the final lint and test run.
- The generic FlagGems operator cohort is unchanged and explicitly marked not revalidated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
