### PR TITLE
fix: serialize PPU FlagTree compilation

### DIFF
--- a/docs/architecture/torch-compile-integration.md
+++ b/docs/architecture/torch-compile-integration.md
@@ -136,6 +136,15 @@ Detection uses the FlagTree-only module `triton._flagtree_spec`. Note that
 empty string on nvidia/amd builds, since upstream directs you not to set
 `FLAGTREE_BACKEND` for those.
 
+PPU FlagTree currently queries `torch.cuda.current_device()` while selecting
+compiler hints. Inductor's asynchronous compile workers can make that query
+after a PPU CUDA context was initialized in the parent, which PyTorch rejects as
+CUDA reinitialization after `fork` ([FlagTree #1031](https://github.com/flagos-ai/FlagTree/issues/1031)).
+The flagos backend therefore defaults PPU FlagTree to one compile thread until
+the upstream driver no longer initializes CUDA in a worker. An explicit
+`TORCHINDUCTOR_COMPILE_THREADS` value or `compile_threads` compile option remains
+authoritative.
+
 ## Architecture
 
 ### Phase 1: Inductor Integration

--- a/docs/vendors/ppu/installation.md
+++ b/docs/vendors/ppu/installation.md
@@ -75,6 +75,34 @@ print(f'Sample result: {y.cpu()[0, 0].item():.4f}')
 
 Expected output shows `torch.cuda available: True`, `torch.version.cuda: 13.0`, and a floating-point result.
 
+### `torch.compile` with FlagTree
+
+Build FlagTree from source with its PPU backend; the resulting `flagtree` wheel
+installs a `triton` module, so it must replace or shadow the vendor Triton:
+
+```bash
+git clone https://github.com/flagos-ai/FlagTree.git
+cd FlagTree
+pip install -r python/requirements.txt
+FLAGTREE_BACKEND=ppu MAX_JOBS=32 \
+  pip install . --no-build-isolation -v
+```
+
+Require the active compiler to be FlagTree and run the compile contract:
+
+```bash
+FLAGOS_DISABLE_CUDA_ASSETS=1 \
+  FLAGOS_USE_FLAGTREE=1 \
+  pytest tests/integration/test_compile.py -v --tb=short
+```
+
+PPU FlagTree currently initializes CUDA while selecting compiler hints in an
+asynchronous Inductor worker, which can fail after the parent process has already
+initialized the PPU context ([FlagTree #1031](https://github.com/flagos-ai/FlagTree/issues/1031)).
+Torch-FL defaults PPU FlagTree to serial compilation as a compatibility measure.
+Set `TORCHINDUCTOR_COMPILE_THREADS` explicitly only when testing an upstream fix
+or deliberately selecting a different worker configuration.
+
 ### AMP and GradScaler
 
 PPU uses the shared CUDA-boxing implementation, while the public AMP device name

--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -280,6 +280,54 @@ def test_flagtree_requires_flagtree_install():
             require_flagtree()
 
 
+def test_ppu_flagtree_defaults_to_serial_compile(monkeypatch):
+    """PPU FlagTree must avoid CUDA initialization in forked compile workers."""
+    from torch_fl.compile import inductor_backend
+
+    monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)
+    monkeypatch.setattr(
+        "torch_fl.compile.flagtree_shim.flagtree_backend", lambda: "ppu"
+    )
+
+    patches = {}
+    inductor_backend._patch_ppu_flagtree_compile_workers(patches)
+
+    assert patches["compile_threads"] == 1
+
+
+def test_ppu_flagtree_preserves_explicit_compile_threads(monkeypatch):
+    """An explicit per-compile or environment setting remains authoritative."""
+    from torch_fl.compile import inductor_backend
+
+    monkeypatch.setattr(
+        "torch_fl.compile.flagtree_shim.flagtree_backend", lambda: "ppu"
+    )
+
+    patches = {"compile_threads": 4}
+    inductor_backend._patch_ppu_flagtree_compile_workers(patches)
+    assert patches["compile_threads"] == 4
+
+    monkeypatch.setenv("TORCHINDUCTOR_COMPILE_THREADS", "8")
+    patches = {}
+    inductor_backend._patch_ppu_flagtree_compile_workers(patches)
+    assert "compile_threads" not in patches
+
+
+def test_non_ppu_flagtree_keeps_default_compile_threads(monkeypatch):
+    """Other FlagTree backends keep Inductor's asynchronous compilation."""
+    from torch_fl.compile import inductor_backend
+
+    monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)
+    monkeypatch.setattr(
+        "torch_fl.compile.flagtree_shim.flagtree_backend", lambda: "hcu"
+    )
+
+    patches = {}
+    inductor_backend._patch_ppu_flagtree_compile_workers(patches)
+
+    assert "compile_threads" not in patches
+
+
 def test_flagtree_is_never_importable_as_flagtree():
     """Guard the packaging trap: the wheel is 'flagtree', the module is 'triton'.
 

--- a/torch_fl/compile/inductor_backend.py
+++ b/torch_fl/compile/inductor_backend.py
@@ -104,6 +104,26 @@ def _resolve_config_patches(
     return patches
 
 
+def _patch_ppu_flagtree_compile_workers(config_patches: Dict[str, Any]) -> None:
+    """Keep PPU FlagTree compilation in the parent process by default.
+
+    FlagTree's PPU driver queries ``torch.cuda.current_device()`` while choosing
+    compiler hints. Inductor's asynchronous workers may be forked after the PPU
+    CUDA context is initialized, where that query triggers PyTorch's fork-safety
+    error. Serial compilation avoids the unsafe reinitialization until the
+    upstream driver can discover its device without touching CUDA in the worker.
+    """
+    if "compile_threads" in config_patches:
+        return
+    if os.environ.get("TORCHINDUCTOR_COMPILE_THREADS") is not None:
+        return
+
+    from torch_fl.compile.flagtree_shim import flagtree_backend
+
+    if flagtree_backend() == "ppu":
+        config_patches["compile_threads"] = 1
+
+
 def flagos_compile_backend(
     gm: torch.fx.GraphModule,
     example_inputs: List[torch.Tensor],
@@ -150,6 +170,8 @@ def flagos_compile_backend(
         from torch_fl.compile.flagtree_shim import require_flagtree
 
         require_flagtree()
+
+    _patch_ppu_flagtree_compile_workers(config_patches)
 
     # Make inductor treat flagos as a GPU device. Order matters: is_gpu() must
     # answer True and the device interface must be resolvable before the


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @sunnycase
- **Session Summary**: Built FlagTree's PPU backend from source, reproduced an asynchronous Inductor worker failure on real PPU hardware, filed the upstream issue, and added a scoped Torch-FL compatibility workaround.

## Summary
FlagTree's PPU driver queries `torch.cuda.current_device()` while selecting compiler hints. Inductor's asynchronous compile workers can execute that query after the parent has initialized the PPU CUDA context, causing PyTorch to reject CUDA reinitialization after fork. This PR defaults only PPU FlagTree compilation to one compile thread, preserves explicit user settings, adds regression coverage, and documents the behavior and upstream issue.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [x] PPU
- [ ] Platform-agnostic (all platforms)

## Problem Analysis
### What was broken/missing?
With a real PPU FlagTree build and Inductor's default asynchronous compilation, the Torch-FL compile suite failed while compiling backward and FP16 kernels. The error was `RuntimeError: Cannot re-initialize CUDA in forked subprocess`.

### Why did it happen?
`triton/compiler/hint_manager.py` asks the active PPU driver for a torch device. `PPUDriver.get_active_torch_device()` calls `torch.cuda.current_device()`. When an Inductor worker is forked after the parent initializes the PPU CUDA context, that call attempts CUDA initialization in the child and triggers PyTorch's fork-safety guard.

### Investigation process:
1. Synchronized to `flagos/main` at `2e00b39` and reviewed the FlagTree substitution/detection path and FlagOS Inductor registration.
2. Built FlagTree commit `52678a8b` with `FLAGTREE_BACKEND=ppu` in an isolated target and confirmed `flagtree 0.6.0+ppu.git52678a8b`, Triton 3.6.0, the FlagTree marker, and backend `ppu`.
3. Reproduced the failures with a clean Inductor cache and default `compile_threads=32`; verified the full suite passes with `TORCHINDUCTOR_COMPILE_THREADS=1`; filed https://github.com/flagos-ai/FlagTree/issues/1031.

## Solution Design
### Implementation approach:
Apply `compile_threads=1` as a per-compile Inductor config patch only when the active compiler is FlagTree and its recorded backend is `ppu`.

### Key design decisions:
The workaround is scoped to the affected backend and compile invocation. It does not globally mutate Inductor configuration, does not affect PPU vendor Triton or other FlagTree backends, and does not override an explicit `TORCHINDUCTOR_COMPILE_THREADS` environment value or per-compile `compile_threads` option.

### Code changes by file:
- `torch_fl/compile/inductor_backend.py`: Add the scoped PPU FlagTree compile-worker patch and apply it before `compile_fx`.
- `tests/integration/test_compile.py`: Cover PPU default serialization, explicit setting precedence, and non-PPU behavior.
- `docs/architecture/torch-compile-integration.md`: Explain the upstream failure and scoped compatibility behavior.
- `docs/vendors/ppu/installation.md`: Document PPU FlagTree build, verification, and worker configuration.

### Changes by commit:
1. `8f78ddc` - `fix: serialize PPU FlagTree compilation`: Add the compatibility patch, tests, and documentation.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (not applicable)
- [x] **All relevant tests pass** (unit + integration + real PPU FlagTree)
- [x] **Manual testing completed** (real PPU FlagTree build and compiled result comparison)
- [x] **No debug/temporary code**
- [x] **Documentation updated**
- [x] **Commit messages follow conventions**
- [x] **All text in English**

### Linting Results
```text
$ ruff check .
All checks passed!

$ ruff format --check .
180 files already formatted
```

### Test Results
```text
$ pytest tests/unit/ -q
99 passed, 28 skipped, 1 warning in 17.37s

$ FLAGOS_DISABLE_CUDA_ASSETS=1 pytest tests/integration/test_compile.py -v --tb=short
17 passed, 1 skipped, 14 warnings in 5.26s

$ PYTHONPATH=/tmp/flagtree-ppu-target \
  FLAGOS_DISABLE_CUDA_ASSETS=1 \
  FLAGOS_USE_FLAGTREE=1 \
  TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor-flagtree-ppu-workaround \
  pytest tests/integration/test_compile.py -v --tb=short
18 passed, 14 warnings in 11.73s
```

### Manual Verification
```text
# Before the fix, default compile_threads=32 with a fresh cache:
13 passed, 2 failed
FAILED test_compile_backward
FAILED test_compile_dtypes[dtype1]
RuntimeError: Cannot re-initialize CUDA in forked subprocess

# Control result with manually forced serial compilation:
TORCHINDUCTOR_COMPILE_THREADS=1 pytest tests/integration/test_compile.py -v
15 passed, 14 warnings in 5.22s

# After the fix, without setting TORCHINDUCTOR_COMPILE_THREADS:
18 passed, 14 warnings in 11.73s
```

FlagTree package and smoke result:

```text
flagtree 0.6.0+ppu.git52678a8b
triton 3.6.0
flagtree_active True
flagtree_backend ppu
device flagos:0
match True
```

## Code Quality Verification
### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions
- [x] Comment density matches surrounding code
- [x] Used existing config-patch and FlagTree detection helpers

### Edge Cases Considered
1. Explicit per-compile `compile_threads` remains authoritative.
2. Explicit `TORCHINDUCTOR_COMPILE_THREADS` remains authoritative.
3. Non-PPU FlagTree backends keep asynchronous compilation.
4. PPU vendor Triton is not mistaken for FlagTree and retains its normal configuration.
5. Backward and FP16 compilation are verified on real PPU hardware.

### Potential Risks
1. Serial compilation reduces compile-time parallelism for PPU FlagTree until the upstream driver is fixed.
2. Users overriding compile threads can reproduce the upstream failure if their process initializes PPU CUDA before workers are created.

### Rollback Plan
Revert commit `8f78ddc`. Users can continue applying `TORCHINDUCTOR_COMPILE_THREADS=1` manually until the upstream FlagTree fix is available.

## Related Work
- Related to https://github.com/flagos-ai/FlagTree/issues/1031
- Related to #132

## Explicitly Not Included
- No changes to FlagTree itself; the root cause is tracked upstream.
- No changes to NVIDIA, MetaX, DCU, Ascend, GCU, MUSA, or vendor Triton compilation behavior.
- No global environment mutation or permanent Inductor configuration change.

## Human Review Notes
### Areas needing special attention:
1. Confirm the per-compile `compile_threads` patch is scoped narrowly enough.
2. Confirm explicit user settings should remain authoritative despite the known upstream failure.
3. Review the PPU installation guidance and upstream issue linkage.

### Questions for reviewer:
1. Should the workaround be removed as soon as FlagTree #1031 is fixed, or retained behind a version check during transition?
2. Should future PPU CI build FlagTree and exercise this full compile suite?

## Additional Context
The isolated FlagTree target was used through `PYTHONPATH`; it did not replace the environment's existing PPU vendor Triton. The repository contains no generated-code changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
