### PR TITLE
[CICD] Add Enflame isolated wheel integration pipeline

### DIFF
--- a/.github/configs/gcu.yml
+++ b/.github/configs/gcu.yml
@@ -1,0 +1,87 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+display_name: Enflame GCU
+
+# GCU-specific environment preparation stays outside the common workflow.
+setup_script: .github/scripts/set_env_gcu.sh
+
+# Pinned TopsRider image used for the manual wheel validation. The setup script
+# can install python3.12-venv when this base image is used directly; a derived
+# CI image should bake it in (or provide TORCH_FL_PREBUILT_GCU_VENV) to avoid
+# the apt fallback on every job.
+ci_image: harbor.baai.ac.cn/flagtree/flagtree-enflame3.6-py312-torch2.10.0-ubuntu24.04@sha256:fadc6e46fa89dffacc6ebf6b85eb1b19b6098b16ae0ff25186aa83be4f93a718
+
+runner_labels:
+  - sy-8g-cicd-pytorch
+
+container_volumes: []
+
+integration_environment: {}
+
+container_options: >-
+  --privileged
+  --ipc=host
+  --shm-size=512g
+  --ulimit memlock=-1
+  --cap-add=SYS_PTRACE
+
+timeout_minutes: 60
+wheel_artifact_name: wheel-gcu
+# The GCU wheel is small and the integration job must test the exact artifact
+# produced by the build job.
+integration_wheel_source: artifact
+
+integration_tests:
+  - name: Check isolated GCU environment
+    command: |
+      python - <<'PY'
+      from pathlib import Path
+
+      import torch
+      import torch_fl
+
+      torch_path = Path(torch.__file__).resolve()
+      package_root = Path(torch_fl.__file__).resolve().parent
+
+      assert torch.__version__.split("+", 1)[0] == "2.10.0", torch.__version__
+      assert torch.version.cuda is None, torch.version.cuda
+      assert "/usr/local/lib/python3.12/dist-packages" not in str(torch_path), torch_path
+      assert not (package_root / "lib" / "libtorch_cuda.so").is_file(), package_root
+      assert torch_fl.flagos.is_available(), "flagos device is unavailable"
+      count = torch_fl.flagos.device_count()
+      assert count >= 8, f"expected at least 8 GCU devices, got {count}"
+
+      print(f"CPU PyTorch: {torch.__version__}")
+      print(f"torch path: {torch_path}")
+      print(f"torch_fl path: {torch_fl.__file__}")
+      print(f"GCU devices: {count}")
+      PY
+
+  # Initial GCU CI scope is limited to the operator files already passing on
+  # the S60 runner. conv1d has no GCU convolution_overrideable implementation;
+  # the RNG generator contract is tracked separately and is not hidden here.
+  - name: Run validated GCU operator tests
+    command: >-
+      python -m pytest
+      tests/integration/ops/test_abs_dispatch.py
+      tests/integration/ops/test_acos_dispatch.py
+      tests/integration/ops/test_add_dispatch.py
+      tests/integration/ops/test_all_dispatch.py
+      tests/integration/ops/test_bitwise_and_dispatch.py
+      tests/integration/ops/test_bmm_dispatch.py
+      tests/integration/ops/test_cat_dispatch.py
+      tests/integration/ops/test_clamp_dispatch.py
+      tests/integration/ops/test_constant_pad_nd_dispatch.py
+      -m "anyplatform or main_ops" -v -s --tb=short

--- a/.github/configs/gcu.yml
+++ b/.github/configs/gcu.yml
@@ -71,7 +71,9 @@ integration_tests:
 
   # Initial GCU CI scope is limited to the operator files already passing on
   # the S60 runner. conv1d has no GCU convolution_overrideable implementation;
-  # the RNG generator contract is tracked separately and is not hidden here.
+  # the RNG generator contract is tracked separately. The factory suite below
+  # is intentionally run as a gap detector: its randn-dependent cases expose
+  # the current GCU Philox state overflow instead of silently hiding it.
   - name: Run validated GCU operator tests
     command: >-
       python -m pytest
@@ -85,3 +87,8 @@ integration_tests:
       tests/integration/ops/test_clamp_dispatch.py
       tests/integration/ops/test_constant_pad_nd_dispatch.py
       -m "anyplatform or main_ops" -v -s --tb=short
+
+  - name: Expose GCU factory and RNG gaps
+    command: >-
+      python -m pytest tests/integration/test_factory_ops.py
+      -v -s --tb=short

--- a/.github/scripts/set_env_gcu.sh
+++ b/.github/scripts/set_env_gcu.sh
@@ -141,7 +141,12 @@ else
 fi
 
 VENV_PYTHON="$VENV_ROOT/bin/python"
-if [[ ! -x "$VENV_PYTHON" ]]; then
+venv_is_usable() {
+  [[ -x "$VENV_PYTHON" ]] || return 1
+  "$VENV_PYTHON" -m pip --version >/dev/null 2>&1
+}
+
+if ! venv_is_usable; then
   # The current TopsRider base image does not ship python3.12-venv.  Keep the
   # dependency in the chip-specific setup path so the common workflow remains
   # image/workflow agnostic; a derived CI image should still bake this package
@@ -155,8 +160,7 @@ if [[ ! -x "$VENV_PYTHON" ]]; then
   fi
 fi
 
-VENV_PYTHON="$VENV_ROOT/bin/python"
-if [[ ! -x "$VENV_PYTHON" ]]; then
+if ! venv_is_usable; then
   echo "::error::Isolated Python was not created at $VENV_ROOT; install python3.12-venv in the CI image" >&2
   exit 1
 fi

--- a/.github/scripts/set_env_gcu.sh
+++ b/.github/scripts/set_env_gcu.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Enflame GCU environment for the common build/integration workflow.
+#
+# GCU uses the TopsRider runtime directly. The vendor torch-gcu package that
+# may be present in the base image is intentionally not copied into the
+# isolated environment: this backend builds against stock CPU PyTorch and
+# links TopsRider's libtopsrt/libtopsaten libraries instead.
+set -euo pipefail
+
+case "${CI_STAGE:-}" in
+  build|integration) ;;
+  *)
+    echo "::error::CI_STAGE must be either 'build' or 'integration'"
+    exit 1
+    ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CPU_TORCH_INDEX_URL="${TORCH_FL_CPU_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}"
+CPU_TORCH_VERSION="${TORCH_FL_CPU_TORCH_VERSION:-2.10.0}"
+
+discover_tops_root() {
+  local candidate found
+  local -a candidates=(
+    "${TOPS_HOME:-}"
+    "/opt/tops"
+    "/opt/topsrider"
+    "/opt/tops-rider"
+    "/usr/local/tops"
+  )
+
+  for candidate in "${candidates[@]}"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ -f "$candidate/lib/libtopsrt.so" &&
+          -f "$candidate/include/gcu/topsaten/topsaten.h" ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+
+  found="$(find /opt /usr/local -maxdepth 5 -type f -name libtopsrt.so \
+    -print -quit 2>/dev/null || true)"
+  if [[ -n "$found" ]]; then
+    candidate="$(dirname "$(dirname "$found")")"
+    if [[ -f "$candidate/include/gcu/topsaten/topsaten.h" ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+if ! TOPS_HOME="$(discover_tops_root)"; then
+  echo "::error::TopsRider SDK not found; expected lib/libtopsrt.so and include/gcu/topsaten/topsaten.h" >&2
+  exit 1
+fi
+export TOPS_HOME
+echo "TOPS_HOME=$TOPS_HOME"
+
+TOPSATEN_LIB="${TOPSATEN_LIB:-}"
+if [[ -z "$TOPSATEN_LIB" ]]; then
+  for candidate in \
+    "$TOPS_HOME/lib/libtopsaten.so" \
+    /usr/lib/libtopsaten.so \
+    /usr/lib64/libtopsaten.so; do
+    if [[ -f "$candidate" ]]; then
+      TOPSATEN_LIB="$candidate"
+      break
+    fi
+  done
+fi
+if [[ -z "$TOPSATEN_LIB" || ! -f "$TOPSATEN_LIB" ]]; then
+  echo "::error::libtopsaten.so was not found under $TOPS_HOME/lib, /usr/lib, or /usr/lib64" >&2
+  exit 1
+fi
+export TOPSATEN_LIB
+TOPSATEN_LIB_DIR="$(dirname "$(readlink -f "$TOPSATEN_LIB")")"
+echo "TOPSATEN_LIB=$TOPSATEN_LIB"
+
+if [[ "$CI_STAGE" == "integration" && ! -c /dev/gcu0 ]]; then
+  echo "::error::Enflame device node /dev/gcu0 is unavailable"
+  exit 1
+fi
+
+export ACCELERATOR=gcu
+export GCU_KERNEL=1
+export CUDA_KERNEL=0
+export METAX_KERNEL=0
+export ASCEND_KERNEL=0
+export MUSA_KERNEL=0
+# The base image currently has no triton_gcu/FlagGems package. Keep the native
+# Topsaten path deterministic; FlagGems can be enabled later when the vendor
+# Triton stack is explicitly provisioned and validated.
+export FLAGGEMS_KERNEL=0
+export FLAGGEMS_PYTHON="${FLAGOS_GCU_FLAGGEMS_PYTHON:-0}"
+export FLAGOS_USE_FLAGGEMS=0
+export FLAGOS_USE_FLAGGEMS_CPP=0
+export FLAGOS_DISABLE_CUDA_ASSETS=1
+unset CUDA_HOME 2>/dev/null || true
+unset CUDA_PATH 2>/dev/null || true
+
+export CPATH="$TOPS_HOME/include/gcu:$TOPS_HOME/include${CPATH:+:$CPATH}"
+export LIBRARY_PATH="$TOPS_HOME/lib:$TOPSATEN_LIB_DIR${LIBRARY_PATH:+:$LIBRARY_PATH}"
+export LD_LIBRARY_PATH="$TOPS_HOME/lib:$TOPSATEN_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+VENDOR_PYTHON="${TORCH_FL_VENDOR_PYTHON:-}"
+if [[ -z "$VENDOR_PYTHON" || ! -x "$VENDOR_PYTHON" ]]; then
+  for candidate in python3.12 python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      VENDOR_PYTHON="$(command -v "$candidate")"
+      break
+    fi
+  done
+fi
+if [[ -z "$VENDOR_PYTHON" || ! -x "$VENDOR_PYTHON" ]]; then
+  echo "::error::Unable to find Python 3.12 to bootstrap the isolated environment"
+  exit 1
+fi
+
+PREBUILT_VENV="${TORCH_FL_PREBUILT_GCU_VENV:-/opt/torch-fl-gcu-venv}"
+if [[ -z "${TORCH_FL_VENV_ROOT:-}" && -x "$PREBUILT_VENV/bin/python" ]]; then
+  VENV_ROOT="$PREBUILT_VENV"
+  echo "Using prebuilt GCU venv: $VENV_ROOT"
+else
+  VENV_ROOT="${TORCH_FL_VENV_ROOT:-${RUNNER_TEMP:-$REPO_ROOT/.ci}/torch-fl-gcu-${CI_STAGE}}"
+  if ! "$VENDOR_PYTHON" -m venv --clear "$VENV_ROOT"; then
+    echo "::warning::Python cannot create a venv; trying uv"
+    if ! command -v uv >/dev/null 2>&1; then
+      "$VENDOR_PYTHON" -m pip install --upgrade uv
+    fi
+    uv venv --clear --seed --python "$VENDOR_PYTHON" "$VENV_ROOT"
+  fi
+fi
+
+VENV_PYTHON="$VENV_ROOT/bin/python"
+if [[ ! -x "$VENV_PYTHON" ]]; then
+  echo "::error::Isolated Python was not created at $VENV_ROOT"
+  exit 1
+fi
+
+if [[ "$VENV_ROOT" != "$PREBUILT_VENV" ]]; then
+  "$VENV_PYTHON" -m pip install --upgrade pip setuptools wheel cmake ninja
+  "$VENV_PYTHON" -m pip install \
+    --index-url "$CPU_TORCH_INDEX_URL" \
+    "torch==$CPU_TORCH_VERSION"
+fi
+
+export VIRTUAL_ENV="$VENV_ROOT"
+export PATH="$VENV_ROOT/bin:$PATH"
+export PYTHONNOUSERSITE=1
+export PYTHONPATH=""
+
+"$VENV_PYTHON" - <<'PY'
+from pathlib import Path
+import importlib.util
+import os
+import sys
+import torch
+
+torch_path = Path(torch.__file__).resolve()
+assert torch.__version__.split("+", 1)[0] == "2.10.0", torch.__version__
+assert torch.version.cuda is None, torch.version.cuda
+assert "/usr/local/lib/python3.12/dist-packages" not in str(torch_path), torch_path
+assert importlib.util.find_spec("torch_gcu") is None, "torch_gcu leaked into isolated venv"
+print(f"Isolated Python: {sys.executable}")
+print(f"CPU PyTorch: {torch.__version__}")
+print(f"CPU torch path: {torch_path}")
+print(f"Topsaten library: {os.environ['TOPSATEN_LIB']}")
+PY
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  printf '%s\n' "$VENV_ROOT/bin" >> "$GITHUB_PATH"
+fi
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  for name in \
+    PATH VIRTUAL_ENV PYTHONNOUSERSITE PYTHONPATH ACCELERATOR GCU_KERNEL \
+    CUDA_KERNEL METAX_KERNEL ASCEND_KERNEL MUSA_KERNEL FLAGGEMS_KERNEL \
+    FLAGGEMS_PYTHON FLAGOS_USE_FLAGGEMS FLAGOS_USE_FLAGGEMS_CPP \
+    FLAGOS_DISABLE_CUDA_ASSETS TOPS_HOME TOPSATEN_LIB CPATH LIBRARY_PATH \
+    LD_LIBRARY_PATH; do
+    printf '%s=%s\n' "$name" "${!name}" >> "$GITHUB_ENV"
+  done
+fi
+
+cd "$REPO_ROOT"
+if [[ "$CI_STAGE" == "build" ]]; then
+  # Prebuild so package_data contains the generated libtorch_fl.so before the
+  # common wheel workflow stages the final artifact.
+  python setup.py build_ext --inplace
+
+  python - <<'PY'
+import torch_fl
+
+assert torch_fl.flagos.is_available(), "flagos device is unavailable"
+print(f"flagos devices: {torch_fl.flagos.device_count()}")
+PY
+fi

--- a/.github/scripts/set_env_gcu.sh
+++ b/.github/scripts/set_env_gcu.sh
@@ -137,18 +137,27 @@ if [[ -z "${TORCH_FL_VENV_ROOT:-}" && -x "$PREBUILT_VENV/bin/python" ]]; then
   echo "Using prebuilt GCU venv: $VENV_ROOT"
 else
   VENV_ROOT="${TORCH_FL_VENV_ROOT:-${RUNNER_TEMP:-$REPO_ROOT/.ci}/torch-fl-gcu-${CI_STAGE}}"
-  if ! "$VENDOR_PYTHON" -m venv --clear "$VENV_ROOT"; then
-    echo "::warning::Python cannot create a venv; trying uv"
-    if ! command -v uv >/dev/null 2>&1; then
-      "$VENDOR_PYTHON" -m pip install --upgrade uv
-    fi
-    uv venv --clear --seed --python "$VENDOR_PYTHON" "$VENV_ROOT"
+  "$VENDOR_PYTHON" -m venv --clear "$VENV_ROOT" || true
+fi
+
+VENV_PYTHON="$VENV_ROOT/bin/python"
+if [[ ! -x "$VENV_PYTHON" ]]; then
+  # The current TopsRider base image does not ship python3.12-venv.  Keep the
+  # dependency in the chip-specific setup path so the common workflow remains
+  # image/workflow agnostic; a derived CI image should still bake this package
+  # in to avoid the apt fallback on every job.
+  if command -v apt-get >/dev/null 2>&1 && [[ "$(id -u)" -eq 0 ]]; then
+    python_mm="$($VENDOR_PYTHON -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y --no-install-recommends "python${python_mm}-venv"
+    "$VENDOR_PYTHON" -m venv --clear "$VENV_ROOT"
   fi
 fi
 
 VENV_PYTHON="$VENV_ROOT/bin/python"
 if [[ ! -x "$VENV_PYTHON" ]]; then
-  echo "::error::Isolated Python was not created at $VENV_ROOT"
+  echo "::error::Isolated Python was not created at $VENV_ROOT; install python3.12-venv in the CI image" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Adds the Enflame GCU CI pipeline with an isolated CPU-PyTorch build environment and wheel-based integration testing.

The pipeline builds `torch-fl` against the TopsRider GCU runtime while keeping the vendor `torch-gcu` package out of the isolated Python environment. Integration tests install and execute the exact wheel produced by the build job.

The common workflow remains chip-agnostic. GCU is enabled only through a platform configuration file and a GCU-specific environment setup script.

## What's included

- `.github/configs/gcu.yml`
  - Enflame GCU runner: `sy-8g-cicd-pytorch`
  - Pinned TopsRider image digest
  - GCU container options and device access
  - `wheel-gcu` artifact configuration
  - Integration uses the build job artifact wheel
  - Automatically discovered by the existing common platform workflow

- `.github/scripts/set_env_gcu.sh`
  - Discovers the TopsRider SDK and `libtopsaten.so`
  - Creates an isolated Python 3.12 environment
  - Installs standard CPU PyTorch 2.10
  - Ensures vendor `torch-gcu` is not visible from the isolated environment
  - Builds the GCU-native `torch-fl` extension
  - Handles base images without `python3.12-venv`
  - Disables CUDA/FlagGems paths for the current native Topsaten setup

- GCU wheel-only integration validation
  - Tests run outside the source tree to avoid importing the repository copy
  - Confirms the installed package and CPU PyTorch come from the isolated venv

## Validation

Manual validation on the Enflame runner:

- Wheel built successfully:

  ```text
  torch_fl-0.1.0-cp312-cp312-linux_x86_64.whl