### PR TITLE
feat: add signed runtime attestation probe

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -47,4 +47,5 @@ The `--no-build-isolation` flag is required so that generated native bindings co
 - **First steps**: See the [Quick Start Guide](quickstart.md) for platform-independent usage examples.
 - **Platform support**: Review the [Compatibility Matrix](../reference/compatibility.md) to understand what capabilities are validated for your platform.
 - **Configuration**: Environment variables controlling runtime behavior are documented in the [Environment Variables Reference](../reference/environment-variables.md).
+- **Runtime attestation**: Provisioners integrating with FlagQuantum should use the [signed runtime-attestation probe](../reference/runtime-attestation.md).
 - **Testing**: Run the test suite following the [Testing Guide](../development/testing.md) to verify your installation.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -71,6 +71,8 @@ These variables control asset loading, bundled libtorch behavior, and import-tim
 | `FLAGOS_INSTALL_PATH` | Build | No default | FlagCX torch-fl compatibility install prefix containing `include/flagos.h` and `lib/libflagos.so` |
 | `FLAGOS_INCLUDE_DIR` / `FLAGOS_LIBRARY_DIR` | Build | Derived from `FLAGOS_INSTALL_PATH` or `torch_fl` | Override the FlagOS C ABI header and library directories when building FlagCX |
 | `TORCH_DEVICE_BACKEND_AUTOLOAD` | Runtime | Set by torch_fl on MUSA builds | Stop vendor plugins (e.g., `torch_musa`) from claiming `PrivateUse1` during `import torch` |
+| `FLAGOS_LOG_FALLBACK` | Runtime | `0` (off) | Print CPU fallback operations to stderr; must be enabled before the FlagQuantum route-attestation probe starts |
+| `TORCH_FL_ATTESTATION_SIGNING_KEY` | Provisioning | No default | HMAC key used to sign provisioner-owned runtime attestations; keep it in secret management and do not pass it on the command line |
 
 ## Compiler and Feature Backends
 

--- a/docs/reference/runtime-attestation.md
+++ b/docs/reference/runtime-attestation.md
@@ -1,0 +1,67 @@
+<!--
+Copyright 2026 FlagOS Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Runtime identity and FlagQuantum attestation
+
+Torch-FL owns the mapping from the portable `flagos` device to the physical
+accelerator. `torch_fl.runtime_identity()` exposes that mapping without making
+a certification claim. Provisioning systems can additionally run Torch-FL's
+device-route canary and issue a signed attestation accepted by FlagQuantum's
+domestic single-card certification harness.
+
+## Trust boundary
+
+The attestation is intentionally fail-closed:
+
+- Torch-FL derives the accelerator class from its build and platform signals.
+  A normal CUDA build is classified as `cuda_reference`/NVIDIA and cannot issue
+  a domestic-accelerator attestation. PPU is recognized only with Torch-FL's PPU
+  platform signal because its libtorch is CUDA compatible.
+- The probe requires `flagos:0`, checks the result remains a `flagos` device,
+  and rejects any `[flagos cpu_fallback]` emitted by the C++ fallback handler.
+- The Torch-FL revision and container image must use immutable full SHA values.
+- The canonical JSON payload is authenticated with HMAC-SHA256. The provisioner
+  must store and distribute the key through its secret-management system.
+
+The no-fallback statement covers `torch_fl_device_route_canary_v1`, not every
+PyTorch operator. FlagQuantum separately runs its P0-P5 workload matrix and
+binds that evidence to this attestation's revision and image digest.
+
+## Provisioner command
+
+Set the fallback logger before starting Python so its native one-time setting
+is active for the probe. Never put the signing key on the command line.
+
+```bash
+export FLAGOS_LOG_FALLBACK=1
+export TORCH_FL_ATTESTATION_SIGNING_KEY="$(secret-tool read torch-fl-attestation)"
+
+python -m torch_fl.provisioning.attestation \
+  --provisioner flagos-lab \
+  --device-model "Hygon DCU Z100" \
+  --architecture gfx926 \
+  --device-identifier DCU-serial-0001 \
+  --driver-version 6.3.1 \
+  --vendor-runtime-version DTK-25.04 \
+  --torch-fl-revision 0123456789abcdef0123456789abcdef01234567 \
+  --container-image-digest sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  --key-id flagos-lab-2026-01 \
+  --output /secure/evidence/torch-fl-attestation.json
+```
+
+The command exits without writing verified evidence if hardware classification,
+device availability, route integrity, fallback auditing, immutable identifiers,
+or signing prerequisites are not satisfied.

--- a/tests/unit/test_runtime_attestation.py
+++ b/tests/unit/test_runtime_attestation.py
@@ -1,0 +1,248 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import importlib.util
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+_MODULE_PATH = (
+    Path(__file__).parents[2] / "torch_fl" / "provisioning" / "attestation.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "torch_fl_attestation_test", _MODULE_PATH
+)
+attestation = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(attestation)
+
+_KEY = "a-test-signing-key-that-is-longer-than-thirty-two-bytes"
+
+
+class _FakeFlagos:
+    def __init__(self, name="Hygon DCU Z100"):
+        self.name = name
+
+    @staticmethod
+    def is_available():
+        return True
+
+    @staticmethod
+    def device_count():
+        return 1
+
+    def get_device_properties(self, index):
+        assert index == 0
+        return SimpleNamespace(name=self.name, total_memory=64 * 1024**3)
+
+    @staticmethod
+    def synchronize(index):
+        assert index == 0
+
+
+class _FakeTensor:
+    device = SimpleNamespace(type="flagos")
+
+    def __add__(self, other):
+        return self
+
+    def __mul__(self, other):
+        return self
+
+    def sum(self):
+        return self
+
+    @staticmethod
+    def item():
+        return 96.0
+
+
+class _FakeTorch:
+    __version__ = "2.9.1"
+
+    @staticmethod
+    def ones(*args, **kwargs):
+        return _FakeTensor()
+
+    @staticmethod
+    def full(*args, **kwargs):
+        return _FakeTensor()
+
+
+def _identity(accelerator="dcu", *, platform_hint=""):
+    return attestation.collect_runtime_identity(
+        torch_module=_FakeTorch,
+        flagos_module=_FakeFlagos(),
+        build_accelerator=accelerator,
+        platform_hint=platform_hint,
+    )
+
+
+def _canary(**overrides):
+    result = {
+        "scope": attestation.AUDIT_SCOPE,
+        "logical_device": "flagos:0",
+        "result_device_type": "flagos",
+        "result": 96.0,
+        "cpu_fallback_observed": False,
+        "host_execution_observed": False,
+        "fallback_log_sha256": "0" * 64,
+    }
+    result.update(overrides)
+    return result
+
+
+def _build(identity=None, canary=None):
+    return attestation.build_attestation(
+        runtime_identity=identity or _identity(),
+        canary=canary or _canary(),
+        provisioner="flagos-lab",
+        device_model="Hygon DCU Z100",
+        architecture="gfx926",
+        device_identifier="DCU-serial-0001",
+        driver_version="6.3.1",
+        vendor_runtime_version="DTK-25.04",
+        torch_fl_revision="a" * 40,
+        container_image_digest="sha256:" + "b" * 64,
+        signing_key=_KEY,
+        key_id="flagos-lab-2026-01",
+        collected_at="2026-08-25T00:00:00Z",
+    )
+
+
+def test_dcu_runtime_identity_is_domestic():
+    identity = _identity()
+    assert identity["vendor"] == "hygon"
+    assert identity["accelerator_class"] == "domestic_accelerator"
+    assert identity["devices"][0]["logical_device"] == "flagos:0"
+
+
+def test_runtime_identity_uses_selected_physical_properties_api():
+    identity = attestation.collect_runtime_identity(
+        torch_module=_FakeTorch,
+        flagos_module=_FakeFlagos(name="generic flagos name"),
+        build_accelerator="dcu",
+        device_properties_getter=lambda index: SimpleNamespace(
+            name=f"Hygon DCU {index}", total_memory=32 * 1024**3
+        ),
+    )
+    assert identity["devices"][0]["name"] == "Hygon DCU 0"
+
+
+def test_cuda_runtime_identity_is_reference_not_domestic():
+    identity = _identity("cuda")
+    assert identity["vendor"] == "nvidia"
+    assert identity["accelerator_class"] == "cuda_reference"
+    with pytest.raises(attestation.AttestationError, match="not.*domestic"):
+        _build(identity=identity)
+
+
+def test_ppu_requires_torch_fl_platform_signal():
+    assert attestation.classify_accelerator("cuda") == ("nvidia", "cuda_reference")
+    assert attestation.classify_accelerator("cuda", platform_hint="ppu") == (
+        "thead",
+        "domestic_accelerator",
+    )
+
+
+def test_signed_payload_matches_flagquantum_contract():
+    payload = _build()
+    expected_identity = {
+        "schema": attestation.SCHEMA,
+        "status": "verified",
+        "accelerator_class": "domestic_accelerator",
+        "provider": "torch_fl",
+        "logical_device": "flagos:0",
+        "evidence_source": attestation.EVIDENCE_SOURCE,
+    }
+    assert {key: payload[key] for key in expected_identity} == expected_identity
+    assert set(payload["physical_device"]) == {
+        "vendor",
+        "model",
+        "architecture",
+        "device_identifier",
+        "logical_device_name",
+    }
+    assert set(payload["software"]) == {
+        "driver_version",
+        "vendor_runtime_version",
+        "torch_fl_revision",
+        "container_image_digest",
+    }
+    route = payload["route_audit"]
+    assert route["provider_internal_route_audited"] is True
+    assert route["logical_to_physical_device_verified"] is True
+    assert route["cpu_fallback_allowed"] is False
+    assert route["cpu_fallback_observed"] is False
+    assert route["host_execution_observed"] is False
+    assert len(route["physical_device_probe_sha256"]) == 64
+    assert attestation.verify_attestation_signature(payload, signing_key=_KEY)
+
+
+def test_signature_rejects_tampering():
+    payload = _build()
+    tampered = copy.deepcopy(payload)
+    tampered["physical_device"]["model"] = "different device"
+    assert not attestation.verify_attestation_signature(tampered, signing_key=_KEY)
+
+
+def test_fallback_observation_blocks_attestation():
+    with pytest.raises(attestation.AttestationError, match="CPU fallback"):
+        _build(canary=_canary(cpu_fallback_observed=True))
+
+
+def test_device_route_canary_captures_native_fallback(monkeypatch):
+    class FallbackTorch(_FakeTorch):
+        @staticmethod
+        def full(*args, **kwargs):
+            os.write(2, b"[flagos cpu_fallback] aten::full\n")
+            return _FakeTensor()
+
+    monkeypatch.setenv("FLAGOS_LOG_FALLBACK", "1")
+    result = attestation.run_device_route_canary(
+        torch_module=FallbackTorch, flagos_module=_FakeFlagos()
+    )
+    assert result["cpu_fallback_observed"] is True
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("torch_fl_revision", "short", "40-character"),
+        ("container_image_digest", "latest", "immutable"),
+        ("architecture", "unknown", "non-placeholder"),
+    ],
+)
+def test_invalid_immutable_or_placeholder_evidence_is_rejected(field, value, message):
+    kwargs = {
+        "runtime_identity": _identity(),
+        "canary": _canary(),
+        "provisioner": "flagos-lab",
+        "device_model": "Hygon DCU Z100",
+        "architecture": "gfx926",
+        "device_identifier": "DCU-serial-0001",
+        "driver_version": "6.3.1",
+        "vendor_runtime_version": "DTK-25.04",
+        "torch_fl_revision": "a" * 40,
+        "container_image_digest": "sha256:" + "b" * 64,
+        "signing_key": _KEY,
+        "key_id": "flagos-lab-2026-01",
+    }
+    kwargs[field] = value
+    with pytest.raises(attestation.AttestationError, match=message):
+        attestation.build_attestation(**kwargs)

--- a/torch_fl/__init__.py
+++ b/torch_fl/__init__.py
@@ -1609,6 +1609,46 @@ def _register_bpu_compile_backend() -> None:
 _register_bpu_compile_backend()
 
 
+def runtime_identity():
+    """Return Torch-FL's logical-to-physical runtime identity.
+
+    The result is descriptive, not an attestation. Provisioners issue signed,
+    workload-scoped evidence through :mod:`torch_fl.provisioning.attestation`.
+    """
+
+    from torch_fl.provisioning.attestation import collect_runtime_identity
+
+    platform_hint = ""
+    marker = os.path.join(os.path.dirname(__file__), "lib", "flagos_platform")
+    try:
+        with open(marker) as stream:
+            platform_hint = stream.read().strip().lower()
+    except OSError:
+        pass
+
+    # PPU builds use ACCELERATOR=cuda. A Torch-FL-owned bundle is the durable
+    # signal that distinguishes them from a normal NVIDIA CUDA wheel.
+    if not platform_hint and os.path.isfile(
+        os.path.join(os.path.dirname(__file__), "lib_ppu", "libtorch_cuda.so")
+    ):
+        platform_hint = "ppu"
+
+    accelerator = _build_accelerator()
+    get_properties = None
+    if accelerator in ("cuda", "dcu", "metax") and hasattr(
+        torch.cuda, "get_device_properties"
+    ):
+        get_properties = torch.cuda.get_device_properties
+
+    return collect_runtime_identity(
+        torch_module=torch,
+        flagos_module=flagos,
+        build_accelerator=accelerator,
+        platform_hint=platform_hint,
+        device_properties_getter=get_properties,
+    )
+
+
 __all__ = [
     "flagos",
     "distributed",
@@ -1617,4 +1657,5 @@ __all__ = [
     "is_flaggems_available",
     "enable_flaggems_for_flagos",
     "use_flaggems",
+    "runtime_identity",
 ]

--- a/torch_fl/provisioning/__init__.py
+++ b/torch_fl/provisioning/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provisioner-owned runtime identity and attestation support."""

--- a/torch_fl/provisioning/attestation.py
+++ b/torch_fl/provisioning/attestation.py
@@ -1,0 +1,390 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Issue a signed, fail-closed FlagQuantum device-route attestation.
+
+This module deliberately keeps policy in Torch-FL, the component that owns the
+``flagos`` logical-to-physical route. Importing it does not import PyTorch, which
+also makes the classification and signing policy independently testable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import ctypes
+import hashlib
+import hmac
+import json
+import os
+import re
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, BinaryIO, Iterator, Mapping
+
+
+SCHEMA = "flagquantum_domestic_single_card_attestation_v1"
+EVIDENCE_SOURCE = "provisioner_owned_runtime_probe"
+FALLBACK_MARKER = "[flagos cpu_fallback]"
+AUDIT_SCOPE = "torch_fl_device_route_canary_v1"
+
+_COMMIT_RE = re.compile(r"[0-9a-f]{40}")
+_IMAGE_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}")
+_PLACEHOLDER_TOKENS = ("replace", "placeholder", "unknown", "todo", "tbd")
+
+_ACCELERATOR_IDENTITIES = {
+    "ascend": ("huawei", "domestic_accelerator"),
+    "bpu": ("d-robotics", "domestic_accelerator"),
+    "dcu": ("hygon", "domestic_accelerator"),
+    "gcu": ("enflame", "domestic_accelerator"),
+    "metax": ("metax", "domestic_accelerator"),
+    "musa": ("moore_threads", "domestic_accelerator"),
+    "tsingmicro": ("tsingmicro", "domestic_accelerator"),
+}
+
+
+class AttestationError(RuntimeError):
+    """Raised when a runtime cannot produce verified attestation evidence."""
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+
+
+def _non_placeholder(name: str, value: str) -> str:
+    normalized = str(value).strip()
+    if not normalized or any(
+        token in normalized.lower() for token in _PLACEHOLDER_TOKENS
+    ):
+        raise AttestationError(f"{name} must be a concrete, non-placeholder value")
+    return normalized
+
+
+def classify_accelerator(
+    build_accelerator: str, *, platform_hint: str = ""
+) -> tuple[str, str]:
+    """Return ``(vendor, accelerator_class)`` from Torch-FL-owned signals.
+
+    PPU uses a CUDA-compatible libtorch build, so it must additionally carry
+    Torch-FL's PPU platform signal. An arbitrary vendor environment variable is
+    intentionally not sufficient to turn a normal CUDA build into a domestic
+    accelerator.
+    """
+
+    accelerator = str(build_accelerator).strip().lower()
+    platform = str(platform_hint).strip().lower()
+    if platform == "ppu":
+        if accelerator not in ("", "cuda"):
+            return "unknown", "unknown"
+        return "thead", "domestic_accelerator"
+    if accelerator == "cuda":
+        return "nvidia", "cuda_reference"
+    return _ACCELERATOR_IDENTITIES.get(accelerator, ("unknown", "unknown"))
+
+
+def collect_runtime_identity(
+    *,
+    torch_module: Any,
+    flagos_module: Any,
+    build_accelerator: str,
+    platform_hint: str = "",
+    device_properties_getter: Any | None = None,
+) -> dict[str, Any]:
+    """Collect the self-reported Torch-FL runtime identity without running ops."""
+
+    vendor, accelerator_class = classify_accelerator(
+        build_accelerator, platform_hint=platform_hint
+    )
+    count = int(flagos_module.device_count())
+    get_properties = device_properties_getter or flagos_module.get_device_properties
+    devices = []
+    for index in range(count):
+        properties = get_properties(index)
+        devices.append(
+            {
+                "index": index,
+                "logical_device": f"flagos:{index}",
+                "name": str(getattr(properties, "name", "")),
+                "total_memory": int(getattr(properties, "total_memory", 0)),
+            }
+        )
+    version = getattr(torch_module, "__version__", "")
+    return {
+        "provider": "torch_fl",
+        "device_type": "flagos",
+        "build_accelerator": str(build_accelerator).strip().lower(),
+        "platform_hint": str(platform_hint).strip().lower(),
+        "vendor": vendor,
+        "accelerator_class": accelerator_class,
+        "torch_version": str(version),
+        "device_count": count,
+        "devices": devices,
+    }
+
+
+@contextlib.contextmanager
+def _capture_process_stderr() -> Iterator[BinaryIO]:
+    """Capture Python and native stderr emitted through file descriptor 2."""
+
+    sys.stderr.flush()
+    saved_fd = os.dup(2)
+    with tempfile.TemporaryFile(mode="w+b") as stream:
+        try:
+            os.dup2(stream.fileno(), 2)
+            yield stream
+        finally:
+            try:
+                ctypes.CDLL(None).fflush(None)
+            except (AttributeError, OSError):
+                pass
+            sys.stderr.flush()
+            os.dup2(saved_fd, 2)
+            os.close(saved_fd)
+
+
+def run_device_route_canary(
+    *, torch_module: Any, flagos_module: Any, device_index: int = 0
+) -> dict[str, Any]:
+    """Run a small operator chain and record whether it left the device route."""
+
+    if os.environ.get("FLAGOS_LOG_FALLBACK") in (None, "", "0"):
+        raise AttestationError(
+            "FLAGOS_LOG_FALLBACK must be enabled before running the route canary"
+        )
+    if device_index != 0:
+        raise AttestationError(f"{SCHEMA} currently certifies exactly flagos:0")
+    if not flagos_module.is_available() or int(flagos_module.device_count()) <= 0:
+        raise AttestationError("no flagos device is available")
+
+    logical_device = f"flagos:{device_index}"
+    with _capture_process_stderr() as captured:
+        left = torch_module.ones(16, device=logical_device)
+        right = torch_module.full((16,), 2.0, device=logical_device)
+        result = ((left + right) * right).sum()
+        flagos_module.synchronize(device_index)
+        device_type = str(result.device.type)
+        scalar = float(result.item())
+        try:
+            ctypes.CDLL(None).fflush(None)
+        except (AttributeError, OSError):
+            pass
+        sys.stderr.flush()
+        captured.seek(0)
+        fallback_log = captured.read().decode("utf-8", errors="replace")
+
+    fallback_observed = FALLBACK_MARKER in fallback_log
+    host_observed = device_type not in ("flagos", "privateuseone")
+    return {
+        "scope": AUDIT_SCOPE,
+        "logical_device": logical_device,
+        "result_device_type": device_type,
+        "result": scalar,
+        "cpu_fallback_observed": fallback_observed,
+        "host_execution_observed": host_observed,
+        "fallback_log_sha256": hashlib.sha256(fallback_log.encode()).hexdigest(),
+    }
+
+
+def build_attestation(
+    *,
+    runtime_identity: Mapping[str, Any],
+    canary: Mapping[str, Any],
+    provisioner: str,
+    device_model: str,
+    architecture: str,
+    device_identifier: str,
+    driver_version: str,
+    vendor_runtime_version: str,
+    torch_fl_revision: str,
+    container_image_digest: str,
+    signing_key: str | bytes,
+    key_id: str,
+    collected_at: str | None = None,
+) -> dict[str, Any]:
+    """Validate probe evidence and construct a signed FlagQuantum attestation."""
+
+    if runtime_identity.get("provider") != "torch_fl":
+        raise AttestationError("runtime identity is not owned by Torch-FL")
+    if runtime_identity.get("accelerator_class") != "domestic_accelerator":
+        raise AttestationError(
+            "runtime is not a Torch-FL-classified domestic accelerator"
+        )
+    if int(runtime_identity.get("device_count", 0)) <= 0:
+        raise AttestationError("runtime identity contains no flagos devices")
+    if canary.get("scope") != AUDIT_SCOPE or canary.get("logical_device") != "flagos:0":
+        raise AttestationError(
+            "route canary does not cover the required flagos:0 scope"
+        )
+    if canary.get("cpu_fallback_observed") is not False:
+        raise AttestationError("CPU fallback was observed during the route canary")
+    if canary.get("host_execution_observed") is not False:
+        raise AttestationError("host execution was observed during the route canary")
+
+    devices = runtime_identity.get("devices", [])
+    if not devices or devices[0].get("logical_device") != "flagos:0":
+        raise AttestationError("runtime identity does not map flagos:0 to device zero")
+    logical_name = _non_placeholder(
+        "logical device name", devices[0].get("logical_device", "")
+    )
+    revision = str(torch_fl_revision).strip().lower()
+    image_digest = str(container_image_digest).strip().lower()
+    if not _COMMIT_RE.fullmatch(revision):
+        raise AttestationError(
+            "torch_fl_revision must be a full 40-character Git revision"
+        )
+    if not _IMAGE_DIGEST_RE.fullmatch(image_digest):
+        raise AttestationError(
+            "container_image_digest must be an immutable sha256 digest"
+        )
+
+    physical_probe = {
+        "runtime_identity": runtime_identity,
+        "route_canary": canary,
+        "device_identifier": _non_placeholder("device_identifier", device_identifier),
+    }
+    probe_digest = hashlib.sha256(_canonical_json(physical_probe)).hexdigest()
+    timestamp = collected_at or datetime.now(timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": "verified",
+        "accelerator_class": "domestic_accelerator",
+        "provider": "torch_fl",
+        "logical_device": "flagos:0",
+        "evidence_source": EVIDENCE_SOURCE,
+        "collected_at": _non_placeholder("collected_at", timestamp),
+        "provisioner": _non_placeholder("provisioner", provisioner),
+        "physical_device": {
+            "vendor": _non_placeholder("vendor", runtime_identity.get("vendor", "")),
+            "model": _non_placeholder("device_model", device_model),
+            "architecture": _non_placeholder("architecture", architecture),
+            "device_identifier": _non_placeholder(
+                "device_identifier", device_identifier
+            ),
+            "logical_device_name": logical_name,
+        },
+        "software": {
+            "driver_version": _non_placeholder("driver_version", driver_version),
+            "vendor_runtime_version": _non_placeholder(
+                "vendor_runtime_version", vendor_runtime_version
+            ),
+            "torch_fl_revision": revision,
+            "container_image_digest": image_digest,
+        },
+        "route_audit": {
+            "provider_internal_route_audited": True,
+            "logical_to_physical_device_verified": True,
+            "physical_device_probe_sha256": probe_digest,
+            "cpu_fallback_allowed": False,
+            "cpu_fallback_observed": False,
+            "host_execution_observed": False,
+            "audit_scope": AUDIT_SCOPE,
+        },
+    }
+    return sign_attestation(payload, signing_key=signing_key, key_id=key_id)
+
+
+def sign_attestation(
+    payload: Mapping[str, Any], *, signing_key: str | bytes, key_id: str
+) -> dict[str, Any]:
+    """Return a copy of *payload* signed over canonical JSON with HMAC-SHA256."""
+
+    key = signing_key.encode() if isinstance(signing_key, str) else signing_key
+    if len(key) < 32:
+        raise AttestationError("attestation signing key must contain at least 32 bytes")
+    unsigned = dict(payload)
+    unsigned.pop("signature", None)
+    signature = hmac.new(key, _canonical_json(unsigned), hashlib.sha256).hexdigest()
+    signed = dict(unsigned)
+    signed["signature"] = {
+        "algorithm": "hmac-sha256",
+        "key_id": _non_placeholder("key_id", key_id),
+        "value": signature,
+    }
+    return signed
+
+
+def verify_attestation_signature(
+    payload: Mapping[str, Any], *, signing_key: str | bytes
+) -> bool:
+    """Verify an attestation signature without mutating the supplied payload."""
+
+    signature = payload.get("signature", {})
+    if signature.get("algorithm") != "hmac-sha256":
+        return False
+    value = signature.get("value", "")
+    if not isinstance(value, str):
+        return False
+    unsigned = dict(payload)
+    unsigned.pop("signature", None)
+    key = signing_key.encode() if isinstance(signing_key, str) else signing_key
+    expected = hmac.new(key, _canonical_json(unsigned), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(value, expected)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--provisioner", required=True)
+    parser.add_argument("--device-model", required=True)
+    parser.add_argument("--architecture", required=True)
+    parser.add_argument("--device-identifier", required=True)
+    parser.add_argument("--driver-version", required=True)
+    parser.add_argument("--vendor-runtime-version", required=True)
+    parser.add_argument("--torch-fl-revision", required=True)
+    parser.add_argument("--container-image-digest", required=True)
+    parser.add_argument("--key-id", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--signing-key-env", default="TORCH_FL_ATTESTATION_SIGNING_KEY")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    signing_key = os.environ.get(args.signing_key_env, "")
+    if not signing_key:
+        raise AttestationError(
+            f"signing key environment variable {args.signing_key_env!r} is unset"
+        )
+
+    # Import the initialized public package only for the actual runtime probe.
+    import torch_fl
+    import torch
+
+    identity = torch_fl.runtime_identity()
+    canary = run_device_route_canary(torch_module=torch, flagos_module=torch_fl.flagos)
+    payload = build_attestation(
+        runtime_identity=identity,
+        canary=canary,
+        provisioner=args.provisioner,
+        device_model=args.device_model,
+        architecture=args.architecture,
+        device_identifier=args.device_identifier,
+        driver_version=args.driver_version,
+        vendor_runtime_version=args.vendor_runtime_version,
+        torch_fl_revision=args.torch_fl_revision,
+        container_image_digest=args.container_image_digest,
+        signing_key=signing_key,
+        key_id=args.key_id,
+    )
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: OpenAI Codex desktop
- **Model**: GPT-5
- **Human Reviewer**: @FlagQuantum
- **Session Summary**: Added a Torch-FL-owned, fail-closed runtime identity and signed device-route attestation producer for FlagQuantum's domestic single-card certification contract.

## Summary
This change makes Torch-FL the source of truth for mapping `flagos` to a physical accelerator and adds a provisioner CLI that issues signed, machine-readable FlagQuantum attestations. The probe rejects NVIDIA CUDA as a domestic accelerator, audits a scoped on-device canary for native CPU fallback, binds evidence to immutable Torch-FL and container revisions, and authenticates canonical JSON with HMAC-SHA256. Documentation defines the trust boundary: this route canary does not replace FlagQuantum's separate P0-P5 workload validation.

## Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [x] Platform-agnostic (all platforms)

## Problem Analysis
### What was broken/missing?
FlagQuantum could consume a provisioner-owned physical-device attestation, but Torch-FL did not expose a stable runtime identity or produce that evidence. A downstream caller could therefore report `flagos:0` without Torch-FL proving which accelerator owned the route or whether the audited operator chain used CPU fallback.

### Why did it happen?
Torch-FL historically focused on device registration and operator routing. Runtime identity, immutable deployment provenance, route attestation, and evidence signing were not part of its public API.

### Investigation process:
1. Examined `torch_fl/__init__.py`, `torch_fl/flagos/__init__.py`, accelerator routing, generated build metadata, and PPU's CUDA-compatible bundle detection.
2. Examined `csrc/aten/fallback.cc` and `csrc/aten/dispatcher.h`; confirmed CPU fallback emits `[flagos cpu_fallback]` under `FLAGOS_LOG_FALLBACK`, independently from dispatch logging.
3. Compared the emitted payload directly with FlagQuantum's current `attestation_errors()` contract and reviewed documented platform fallback behavior.

## Solution Design
### Implementation approach:
Expose a descriptive `torch_fl.runtime_identity()` API, keep classification/signing logic importable without PyTorch, and provide `python -m torch_fl.provisioning.attestation` for the live probe. The CLI captures native stderr at file-descriptor level, runs an on-device `flagos:0` canary, fails on fallback or host execution evidence, validates immutable identifiers, hashes the physical probe, and signs canonical JSON.

### Key design decisions:
- Accelerator class is derived from Torch-FL build/platform signals; callers cannot self-declare domestic status.
- Plain `ACCELERATOR=cuda` is NVIDIA/`cuda_reference`; PPU additionally requires Torch-FL's durable PPU platform signal.
- Physical model is explicit provisioner inventory, while logical device identity comes from Torch-FL. CUDA-derived backends use their physical runtime properties API when available.
- HMAC keys come only from an environment-backed secret and are never accepted as CLI arguments.
- No-fallback evidence is explicitly scoped to `torch_fl_device_route_canary_v1`; FlagQuantum still owns P0-P5 workload evidence.

### Code changes by file:
- `torch_fl/__init__.py`: exposes the public runtime identity and selects physical property reporting for CUDA-derived platforms.
- `torch_fl/provisioning/__init__.py`: adds the provisioning namespace.
- `torch_fl/provisioning/attestation.py`: implements classification, runtime probing, fallback capture, schema generation, signing, verification, and CLI handling.
- `tests/unit/test_runtime_attestation.py`: covers domestic classification, CUDA negative control, PPU signal requirements, physical properties, fallback rejection, schema fields, immutable provenance, and signature tampering.
- `docs/reference/runtime-attestation.md`: documents the trust boundary and provisioner command.
- `docs/reference/environment-variables.md`: documents fallback logging and signing-key variables.
- `docs/getting-started/installation.md`: links operators to the attestation guide.

### Changes by commit:
1. `c519245f2d77ea8b153bfd4f1dbdffd3008e6e7d` - `feat: add signed runtime attestation probe`: adds the API, CLI, policy tests, and operator documentation as one cohesive feature.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (not configured; Python compilation and Ruff passed)
- [x] **All relevant tests pass** (focused unit suite + cross-repository contract integration)
- [x] **Manual testing completed** (current FlagQuantum validator accepts the emitted payload)
- [x] **No debug/temporary code** (no debug prints, commented code, or TODOs)
- [x] **Documentation updated** (operator guide, environment reference, installation link, docstrings)
- [x] **Commit messages follow conventions** (`feat:` prefix)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ python -m ruff check .
All checks passed!

$ python -m ruff format --check .
183 files already formatted
```

### Test Results
```bash
$ python -m pytest -p no:cacheprovider tests/unit/test_runtime_attestation.py -v
collected 11 items
tests/unit/test_runtime_attestation.py::test_dcu_runtime_identity_is_domestic PASSED
tests/unit/test_runtime_attestation.py::test_runtime_identity_uses_selected_physical_properties_api PASSED
tests/unit/test_runtime_attestation.py::test_cuda_runtime_identity_is_reference_not_domestic PASSED
tests/unit/test_runtime_attestation.py::test_ppu_requires_torch_fl_platform_signal PASSED
tests/unit/test_runtime_attestation.py::test_signed_payload_matches_flagquantum_contract PASSED
tests/unit/test_runtime_attestation.py::test_signature_rejects_tampering PASSED
tests/unit/test_runtime_attestation.py::test_fallback_observation_blocks_attestation PASSED
tests/unit/test_runtime_attestation.py::test_device_route_canary_captures_native_fallback PASSED
tests/unit/test_runtime_attestation.py::test_invalid_immutable_or_placeholder_evidence_is_rejected[torch_fl_revision-short-40-character] PASSED
tests/unit/test_runtime_attestation.py::test_invalid_immutable_or_placeholder_evidence_is_rejected[container_image_digest-latest-immutable] PASSED
tests/unit/test_runtime_attestation.py::test_invalid_immutable_or_placeholder_evidence_is_rejected[architecture-unknown-non-placeholder] PASSED
============================== 11 passed in 0.03s ==============================

$ python validate_cross.py
FlagQuantum contract: accepted
```

The complete `pytest tests/unit/ -v` collection was also attempted in the source-only disposable container. It reported seven collection errors because `torch_fl._C` was not built in that container; six platform suites skipped. The new pure-Python test module collected and passed independently, and no failure originated from this change.

### Manual Verification
```bash
# Before: no public provider identity or attestation producer
$ rg "def runtime_identity" torch_fl
# no matches

# After: direct validation with FlagQuantum's current validator
$ python validate_cross.py
FlagQuantum contract: accepted
```

## Code Quality Verification
### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (build accelerator and flagos APIs)

### Edge Cases Considered
1. NVIDIA CUDA is a reference platform and cannot issue domestic evidence.
2. PPU cannot inherit domestic status from CUDA compatibility without a Torch-FL-owned PPU signal.
3. Missing devices, CPU fallback, host execution, wrong canary scope, placeholders, abbreviated revisions, mutable image tags, weak keys, and modified signatures fail closed.
4. Native C/C++ stderr is captured at file-descriptor level and flushed before inspection.
5. The physical model comes from provisioner inventory rather than potentially generic logical-device properties.

### Potential Risks
1. A platform whose audited canary legitimately uses CPU fallback will be unable to issue this no-fallback certification; this is intentional and must be resolved through platform kernel coverage, not policy relaxation.
2. HMAC verification requires the verifier and provisioner to share a protected key; asymmetric signing can be introduced in a separately reviewed trust-policy change.

### Rollback Plan
Revert commit `c519245f2d77ea8b153bfd4f1dbdffd3008e6e7d`. The new API is additive, so existing Torch-FL runtime and routing behavior remains unchanged.

## Related Work
- Related to FlagQuantum PR #26 and its domestic single-card certification contract.
- No Torch-FL issue is currently linked.

## Explicitly Not Included
- FlagQuantum P0-P5 workload execution or signature-policy enforcement.
- Vendor driver/runtime autodetection beyond Torch-FL-owned routing signals.
- Asymmetric signing, certificate issuance, key rotation services, or remote attestation hardware.
- A claim that every PyTorch operator avoids CPU fallback.

## Human Review Notes
### Areas needing special attention:
1. The accelerator classification table and PPU negative-control boundary.
2. The distinction between provisioner inventory (`model`, serial, driver) and Torch-FL logical identity.
3. The HMAC key-management and canonical-JSON contract.

### Questions for reviewer:
1. Should a follow-up replace HMAC with an organization-managed asymmetric signature before production certification?
2. Which first domestic platform should receive a hardware-backed attestation run after merge?

## Additional Context
Validation ran on `jp-a800-172` in a disposable, read-only container. Test and lint dependencies were installed only into tmpfs; no shared image was modified.
