### PR TITLE
test: size the profiler contract workload to emit memset records

### DIFF
--- a/tests/integration/profiler_support.py
+++ b/tests/integration/profiler_support.py
@@ -107,11 +107,23 @@ def profiler_capabilities():
 
 @pytest.fixture(scope="module")
 def profile_result():
-    """Capture one common workload and export it as a Chrome trace."""
+    """Capture one common workload and export it as a Chrome trace.
+
+    The 1024x1024 matmul size is load-bearing. Device memset records only exist
+    when a vendor library issues an async memset to zero a workspace or
+    reduction buffer, and for matmul the BLAS heuristic picks such a path only
+    at larger shapes: at 256x256 the trace contains zero ``cudaMemsetAsync``
+    runtime calls, so there is nothing for the tracer to record. This is not a
+    record-size effect -- 4-byte memsets are captured whenever they are issued
+    -- and stock torch+CUDA emits the same counts for the same shapes.
+
+    Explicit zero-filling (``torch.zeros``, ``Tensor.zero_``, ``torch.full``)
+    is not an alternative: those run a fill kernel, not a device memset.
+    """
     torch = _torch_module()
     device = _torch_device()
-    x = torch.randn(256, 256, device=device)
-    y = torch.randn(256, 256, device=device)
+    x = torch.randn(1024, 1024, device=device)
+    y = torch.randn(1024, 1024, device=device)
     small = torch.randn(16, device=device)
 
     with torch.profiler.profile(


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Investigated issue #182 (`test_profiler_memset_events` failing on CUDA). Established by differential measurement against stock torch+CUDA that the memset behavior of the flagos profiler already matches upstream exactly, and that the failure is a test-workload sizing problem rather than a tracer defect.

## Summary
The unified profiler contract workload used a 256x256 matmul, a shape that issues no
`cudaMemsetAsync` calls at all, so `test_profiler_memset_events` asserted on an
always-empty list on every backend that declares memset support. This restores the
1024x1024 shape the previous CUDA-only parity test used. Verified against stock
torch+CUDA that both stacks emit byte-for-byte identical memset records for this
workload, so the test now sits on a point where flagos and upstream agree and the
records are non-empty.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [x] CUDA
- [x] MetaX
- [ ] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)

CUDA and MetaX are the two platforms whose capability table declares `memset=True`
(`tests/integration/profiler_support.py:95`), so they are the only ones where the
memset assertion runs rather than skips. The workload itself is shared by all
platforms; the larger matmul is well within reach of every supported backend.

## Problem Analysis

### What was broken/missing?
`test_profiler_memset_events` failed on CUDA with `AssertionError: profiler produced
no gpu_memset events`. The workload in the shared `profile_result` fixture never
triggered a device memset, so the assertion could never pass.

### Why did it happen?
Commit `79d5c95` (#154) unified the per-platform profiler tests into one contract and
introduced the memset assertion. In doing so it reduced the workload matmul from
1024x1024 (the shape the pre-existing CUDA-only `test_profiler_parity.py` used, and
still uses) to 256x256. Device memset records only exist when a vendor library issues
an async memset to zero a workspace or reduction buffer, and the BLAS heuristic
selects such a path only at larger shapes. At 256x256 there are zero
`cudaMemsetAsync` runtime calls, so there is nothing for the tracer to record.

### Investigation process
1. Reproduced the failure: 1 failed, 11 passed.
2. Confirmed `test_profiler_parity.py`, which covers the same tracer with a
   1024x1024 workload, passes 7/7 — isolating the difference to the workload.
3. Tested the fix proposed in the issue (adding `torch.zeros` / `torch.full`).
   **It does not work**: those produce 0 memset records, on flagos *and* on stock
   torch+CUDA. They run a fill kernel, not a device memset. Options 2 and 3 from the
   issue were therefore also rejected — the capability declaration is correct and the
   assertion should not be weakened.
4. Ruled out the "small records get dropped by the tracer" hypothesis with two
   independent oracles:
   - CUPTI collects runtime-API records through a path separate from device activity.
     At 256x256 the trace contains **0** `cudaMemsetAsync` runtime calls and 0
     `gpu_memset` records; at 1024x1024 it contains 4 and 4 — an exact 1:1 match with
     no drops. Nothing is being missed; nothing is being issued.
   - A 4-byte memset *is* captured whenever it occurs (it is one of the four records
     at 1024x1024, and a 32x32 `conv2d` emits 4-byte and 20736-byte records with
     `dur=1.376us`). So the effect is which algorithm path allocates a workspace it
     must zero, not tensor size or record size.
5. Ran the identical workload on stock torch+CUDA (`torch 2.10.0+cu128`, CUDA
   activity) and on flagos (PrivateUse1 activity), dumping a structural fingerprint
   from each and diffing them. Results in Manual Verification below.

## Solution Design

### Implementation approach
Change the shared fixture's matmul operands from 256x256 to 1024x1024, matching the
shape `test_profiler_parity.py` already uses. No production code changes.

### Key design decisions
- **Fix the workload, not the assertion.** The differential run shows the flagos
  tracer's memset behavior is already identical to upstream, so the contract is
  sound and the capability declaration is accurate. Removing CUDA from the
  capability table (issue option 2) or downgrading the assertion to a skip (option 3)
  would have discarded real, working coverage to accommodate a workload bug.
- **Reuse the shape that was already validated** rather than inventing a new one.
  1024x1024 has been exercised by the parity test and its baseline since PR #55.
- **Document why the size is load-bearing** in the fixture docstring, including the
  explicit note that `torch.zeros`/`zero_` are not substitutes. The previous
  reduction to 256x256 was a silent regression precisely because nothing recorded
  that the shape carried meaning.

### Code changes by file
- `tests/integration/profiler_support.py` (lines 108-127): matmul operands 256x256 ->
  1024x1024 in the `profile_result` fixture; expanded the docstring to record why the
  size matters, that the effect is a workspace-path rather than record-size effect,
  and that explicit zero-filling is not an alternative.

### Changes by commit
1. `c46959c` - `test: size the profiler contract workload to emit memset records`:
   the single behavioral change plus its rationale.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [ ] **Type checking passed** (if applicable) — no type checker configured in this repo
- [x] **All tests pass** (unit + integration)
- [x] **Manual testing completed** (include reproduction of original issue)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [x] **Documentation updated** (fixture docstring records the constraint)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ ruff check
All checks passed!

$ ruff format --check
180 files already formatted
```

### Test Results
```bash
# Command:
FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_cuda.conf \
  python -m pytest tests/integration/test_profiler_contract.py -v -m profiler --tb=short

# Output:
tests/integration/test_profiler_contract.py::test_profiler_cpu_api_and_trace_export PASSED [  8%]
tests/integration/test_profiler_contract.py::test_profiler_kernel_events PASSED [ 16%]
tests/integration/test_profiler_contract.py::test_profiler_runtime_events PASSED [ 25%]
tests/integration/test_profiler_contract.py::test_profiler_kernel_device_metadata PASSED [ 33%]
tests/integration/test_profiler_contract.py::test_profiler_flow_events_are_paired PASSED [ 41%]
tests/integration/test_profiler_contract.py::test_profiler_device_time_linkage PASSED [ 50%]
tests/integration/test_profiler_contract.py::test_profiler_memcpy_events PASSED [ 58%]
tests/integration/test_profiler_contract.py::test_profiler_memset_events PASSED [ 66%]
tests/integration/test_profiler_contract.py::test_profiler_device_arg_keys PASSED [ 75%]
tests/integration/test_profiler_contract.py::test_profiler_capture_window_contains_device_events PASSED [ 83%]
tests/integration/test_profiler_contract.py::test_profiler_kernel_names_are_demangled PASSED [ 91%]
tests/integration/test_profiler_contract.py::test_profiler_runtime_names_are_not_all_fallback PASSED [100%]

======================== 12 passed, 1 warning in 1.23s =========================

# Regression check on the rest of the profiler and unit suites:
FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_cuda.conf \
  python -m pytest tests/integration/test_profiler_parity.py \
  tests/unit/test_profiler_privateuse1.py tests/unit/ -q

114 passed, 29 skipped, 1 warning in 7.50s

# Stability (the assertion must not be flaky), 5 consecutive runs:
12 passed, 1 warning in 0.56s
12 passed, 1 warning in 0.53s
12 passed, 1 warning in 0.52s
12 passed, 1 warning in 0.55s
12 passed, 1 warning in 0.57s
```

### Manual Verification
```bash
# Command to reproduce original issue:
FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_cuda.conf \
  python -m pytest tests/integration/test_profiler_contract.py -m profiler --tb=line

# Output BEFORE fix:
tests/integration/test_profiler_contract.py .......F....                 [100%]
E   AssertionError: profiler produced no gpu_memset events
tests/integration/test_profiler_contract.py:149: AssertionError: profiler produced no gpu_memset events
=================== 1 failed, 11 passed, 1 warning in 0.54s ====================

# Output AFTER fix:
12 passed, 1 warning in 1.23s
```

**Differential check against stock torch+CUDA.** The identical workload was run on
`torch 2.10.0+cu128` with `ProfilerActivity.CUDA` and on flagos with
`ProfilerActivity.PrivateUse1`, on the same A100-SXM4-40GB:

| Fingerprint | n=256 stock CUDA | n=256 flagos | n=1024 stock CUDA | n=1024 flagos |
|---|---|---|---|---|
| `gpu_memset` count | 0 | 0 | 4 | 4 |
| memset bytes | `[]` | `[]` | `[4,512,512,512]` | `[4,512,512,512]` |
| memset by op | `{}` | `{}` | `mm:3, sum:1` | `mm:3, sum:1` |
| `cudaMemsetAsync` runtime calls | 0 | 0 | 4 | 4 |
| `gpu_memcpy` count / bytes | 4 / `[4,64,64,128]` | 4 / `[4,64,64,128]` | 4 / `[4,64,64,128]` | 4 / `[4,64,64,128]` |
| `kernel` count | 12 | 12 | 9 | 9 |
| kernel name set | — | identical | — | identical |
| kernel/memset/memcpy/runtime arg keys | — | no keys missing | — | no keys missing |

This establishes both halves of the claim: at 256x256 upstream also emits zero
memsets (so the old workload could not have passed on a correct tracer either), and
at 1024x1024 flagos matches upstream exactly.

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (no reinventing)

### Edge Cases Considered
1. **Flakiness / run-to-run drift.** Memset counts on a shared GPU could vary. Ran
   the suite 5 consecutive times (12 passed each) and sampled the raw counts 3x per
   shape: 1024x1024 gave `(4 memset, 4 memcpy)` identically every time.
2. **Threshold proximity.** If 1024 sat just above the boundary, an allocator or
   cuBLAS-heuristic change could silently drop it back to zero. Swept 256/384/512/
   768/1024: 0/1/1/1/4 records. 1024 is not marginal — it is a step above the first
   non-zero shape and yields 4 records, so losing one does not fail the test.
3. **Other declared-memset platforms.** MetaX also declares `memset=True`. Its
   `zeros.cc` calls `Memset` directly and its MCPTI tracer maps
   `MCPTI_ACTIVITY_KIND_MEMSET`, so a larger matmul does not reduce its coverage.
   Not executed here — no MetaX hardware in this environment; flagged below.
4. **Non-memset assertions on the same fixture.** The fixture is module-scoped and
   shared by all 12 tests, so changing the shape affects every one. All 12 pass; the
   kernel-name and `warps per SM` reasoning that motivated the 16-element `torch.sort`
   is untouched, since the sort remains in the workload.
5. **Runtime cost.** The suite went from 0.54s to ~1.2s wall clock. Negligible for CI.

### Potential Risks
1. A future cuBLAS/vendor-library version could stop issuing workspace memsets for
   1024x1024, which would resurface the same failure. Mitigated by the docstring
   explaining what the shape is for, so the next person sees the constraint before
   changing it. Detecting it would be immediate (the test fails).
2. The larger allocation raises the workload's memory footprint from ~0.5 MB to ~12 MB
   of device memory. Trivially small, but it is a shared fixture that now runs on
   every profiler-capable backend including memory-constrained ones.

### Rollback Plan
Revert the single commit (`git revert c46959c`). It touches one test-support file with
no production code, so the blast radius is confined to
`tests/integration/test_profiler_contract.py`, which returns to its current failing
state.

## Related Work
- Fixes #182
- Related to #154 (`79d5c95`, the unification that reduced the workload size)
- Related to #55 (`11457c9`, which introduced the CUPTI tracer and the 1024x1024
  parity workload this restores)

## Explicitly Not Included
- **Runtime event-name parity.** The differential run surfaced a separate, real gap:
  180 of 203 `privateuse1_runtime` events fall back to the generic label
  `cudaRuntime`, where stock CUDA names every one. The cause is the hand-written
  cbid table in `csrc/profiler/cupti_shim.h:78` (~20 entries against 486 in the
  official enum); the 10 unmapped ids seen here all resolve to real symbols
  (`cudaGetDevice` x94, `cudaDeviceGetAttribute` x35, `cudaEventCreateWithFlags` x18,
  `cudaGetLastError` x16, ...). The existing
  `test_profiler_runtime_names_are_not_all_fallback` uses a weak
  "more than one name **or** a cbid key present" condition, so it passes despite the
  degradation. This needs a C++ change and a rebuild, so it is filed separately
  rather than mixed into a test-only fix.
- **`overhead` category and flow-arrow pairing differences.** Both are pre-existing
  and already documented in `tests/data/profiler_cuda_baseline.json`; unrelated to
  this failure.
- **`cpu_op` double-counting.** flagos records roughly 2x the `cpu_op` events of stock
  CUDA (`aten::mm` 6 vs 3), an artifact of PrivateUse1 boxing forwarding through two
  dispatch layers. Architectural, not a collection defect; out of scope.
- **Broadening the capability table to other platforms.** Untouched.

## Human Review Notes

### Areas needing special attention
1. **Whether 1024x1024 is the right shape** versus something explicitly above the
   threshold on all vendor BLAS libraries. The sweep in this environment puts the
   first non-zero shape at 384; 1024 was chosen for continuity with the parity test,
   not because it is a measured safety margin on non-NVIDIA stacks.
2. **MetaX verification.** I could not execute the contract on MetaX hardware. Worth a
   CI run before merge, since MetaX is the other platform declaring `memset=True`.
3. **Whether the memset assertion belongs in a shared contract at all**, given that it
   depends on a vendor BLAS heuristic rather than on anything the profiler controls. An
   alternative design would assert memset capability against a workload that forces a
   memset deterministically, if such an op exists on all such backends.

### Questions for reviewer
1. Should the runtime event-name gap be filed as an issue by me, or do you want to
   triage it first? (I have not filed it yet.)
2. Unrelated but worth knowing: `scripts/with_cuda_libtorch.sh` now aborts with
   `Duplicated key 'graph_capture_record_stream_reuse'` because the wheel already
   preloads its own bundled `libc10_cuda.so`, so the wrapper's `LD_PRELOAD` double-
   registers. I ran pytest directly instead. Want that fixed separately?

## Additional Context
Environment: A100-SXM4-40GB, conda env `torch-fl-210` (torch 2.10.0+cpu with external
cu128 `libtorch_cuda.so`), `FLAGOS_BACKEND_CONFIG=torch_fl/configs/backends_cuda.conf`.
The stock-CUDA reference side ran in conda env `torch-cuda-210` (torch 2.10.0+cu128).
