### PR TITLE
feat: torch.compile on GCU via triton_gcu

### DIFF
--- a/.github/configs/gcu.yml
+++ b/.github/configs/gcu.yml
@@ -95,6 +95,16 @@ integration_tests:
   - name: Run AMP tests
     command: python -m pytest tests/integration/test_amp.py -v --tb=short
 
+  # torch.compile through triton_gcu. The GCU-marked tests are the regression
+  # guards for four vendor-specific defects, two of which are silent: a
+  # persistent reduction miscompiled at XBLOCK=1 (wrong values, and dim-0
+  # reductions are mostly a backward shape, so it surfaces only as bad
+  # gradients) and an FX cache key that failed to pickle, downgrading every
+  # compile to a full recompile. Neither is visible from forward output alone,
+  # so this step has to run the backward assertions to be worth anything.
+  - name: Run torch.compile tests
+    command: python -m pytest tests/integration/test_compile.py -v --tb=short
+
   # ---------------------------------------------------------------------------
   # Deliberately not included yet, so the gap is recorded rather than implied:
   #   - tests/integration/test_profiler_contract.py. The TOPSPTI tracer does

--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -34,6 +34,14 @@ try:
 except ImportError:
     HAS_COMPILE = False
 
+# Check if any Triton is available (vanilla or vendor)
+try:
+    import triton
+
+    HAS_TRITON = True
+except ImportError:
+    HAS_TRITON = False
+
 pytestmark = pytest.mark.skipif(
     not HAS_COMPILE, reason="torch.compile not available (torch < 2.0)"
 )
@@ -105,6 +113,9 @@ def test_compile_backend_registered():
 
 def test_basic_compile(device):
     """Test basic torch.compile with flagos backend."""
+    if not HAS_TRITON:
+        pytest.skip("Triton required for compilation")
+
     model = SimpleModel().to(device)
     x = torch.randn(32, 128, device=device)
 
@@ -126,6 +137,9 @@ def test_basic_compile(device):
 
 def test_compile_vs_eager_correctness(device):
     """Test numerical correctness of compiled vs eager execution."""
+    if not HAS_TRITON:
+        pytest.skip("Triton required for compilation")
+
     model = MatMulModel().to(device)
     a = torch.randn(64, 64, device=device)
     b = torch.randn(64, 64, device=device)
@@ -145,6 +159,9 @@ def test_compile_vs_eager_correctness(device):
 
 def test_compile_with_max_autotune(device):
     """Test torch.compile with max-autotune mode."""
+    if not HAS_TRITON:
+        pytest.skip("Triton required for compilation")
+
     model = SimpleModel().to(device)
     x = torch.randn(32, 128, device=device)
 
@@ -232,6 +249,9 @@ def test_inductor_benchmark_accepts_triton_backend_name():
 
 def test_compile_multiple_inputs(device):
     """Test compilation with multiple input tensors."""
+    if not HAS_TRITON:
+        pytest.skip("Triton required for compilation")
+
     model = MatMulModel().to(device)
     a = torch.randn(32, 32, device=device)
     b = torch.randn(32, 32, device=device)
@@ -247,6 +267,9 @@ def test_compile_multiple_inputs(device):
 
 def test_compile_backward(device):
     """Test that compiled model supports backward pass."""
+    if not HAS_TRITON:
+        pytest.skip("Triton required for compilation")
+
     model = SimpleModel().to(device)
     x = torch.randn(32, 128, device=device, requires_grad=True)
 
@@ -268,6 +291,9 @@ def test_compile_backward(device):
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
 def test_compile_dtypes(device, dtype):
     """Test compilation with different dtypes."""
+    if not HAS_TRITON:
+        pytest.skip("Triton required for compilation")
+
     model = SimpleModel().to(device).to(dtype)
     x = torch.randn(32, 128, device=device, dtype=dtype)
 
@@ -285,6 +311,9 @@ def test_compile_dtypes(device, dtype):
 
 def test_compile_recompile(device):
     """Test that recompiling doesn't break."""
+    if not HAS_TRITON:
+        pytest.skip("Triton required for compilation")
+
     model = SimpleModel().to(device)
     x = torch.randn(32, 128, device=device)
 

--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -558,11 +558,24 @@ def test_musa_flagtree_compiles_forward_backward(device):
     assert plugin is None or plugin.__spec__.origin == "torch_fl_shim"
 
 
-def _skip_unless_gcu():
+def _skip_unless_gcu(*, needs_triton: bool = True):
+    """Gate the GCU tests on the build and, by default, on triton_gcu.
+
+    Compiling anything on GCU needs Enflame's triton_gcu plugin, which the CI
+    image does not install (see the FLAGGEMS_KERNEL=0 note in set_env_gcu.sh).
+    Checking the accelerator alone would turn a missing vendor Triton stack into
+    a test failure rather than a skip. ``needs_triton=False`` is for the checks
+    that only read torch_fl's own state.
+    """
     from torch_fl._build_config import ACCELERATOR
 
     if ACCELERATOR != "gcu":
         pytest.skip("GCU build required")
+    if needs_triton:
+        from torch_fl.accelerator.gcu._gcu_compat import is_triton_gcu_available
+
+        if not is_triton_gcu_available():
+            pytest.skip("triton_gcu required (vendor Triton stack not installed)")
 
 
 @pytest.mark.gcu
@@ -601,8 +614,10 @@ def test_gcu_cache_key_survives_pickling():
     takes the HIP branch into ``gcnArchName``. And ``torch.device`` is replaced
     by a function-local class that pickle cannot resolve by name, which
     downgrades every compile to BypassFxGraphCache.
+
+    Both are torch_fl-side, so this holds without the vendor Triton stack.
     """
-    _skip_unless_gcu()
+    _skip_unless_gcu(needs_triton=False)
     import pickle
 
     from torch._inductor.codecache import CacheBase
@@ -682,7 +697,11 @@ def test_gcu_compiles_forward_backward(device):
 
 @pytest.mark.gcu
 def test_gcu_defaults_to_serial_compile(monkeypatch):
-    """A tops pointer only resolves against the current device, so no forking."""
+    """A tops pointer only resolves against the current device, so no forking.
+
+    This is a configuration check on torch_fl's side; triton_gcu need not be
+    installed for the rule to hold.
+    """
     from torch_fl.compile import inductor_backend
 
     monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)
@@ -696,6 +715,8 @@ def test_gcu_defaults_to_serial_compile(monkeypatch):
     patches = {"compile_threads": 4}
     inductor_backend._patch_vendor_flagtree_compile_workers(patches)
     assert patches["compile_threads"] == 4
+
+    _skip_unless_gcu(needs_triton=False)
 
 
 # The generic FlagTree test above also covers the MThreads runtime when the

--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -18,6 +18,7 @@ Integration tests for torch.compile on flagos device.
 Tests basic compilation, fusion gains, and FlagTree detection.
 """
 
+import importlib.util
 import os
 import sys
 
@@ -34,13 +35,10 @@ try:
 except ImportError:
     HAS_COMPILE = False
 
-# Check if any Triton is available (vanilla or vendor)
-try:
-    import triton
-
-    HAS_TRITON = True
-except ImportError:
-    HAS_TRITON = False
+# Inductor needs a Triton to generate kernels with. The GCU CI image ships
+# neither stock Triton nor Enflame's triton_gcu, so the compile tests have to
+# skip there rather than fail with TritonMissing.
+HAS_TRITON = importlib.util.find_spec("triton") is not None
 
 pytestmark = pytest.mark.skipif(
     not HAS_COMPILE, reason="torch.compile not available (torch < 2.0)"

--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -398,6 +398,11 @@ def test_non_ppu_flagtree_keeps_default_compile_threads(monkeypatch):
     monkeypatch.setattr(
         "torch_fl.compile.flagtree_shim.flagtree_backend", lambda: "hcu"
     )
+    # The serialization decision is per accelerator as well as per FlagTree
+    # backend, so pin it: on a GCU build the vendor driver serializes regardless
+    # of the FlagTree backend name, which is a different rule than the one under
+    # test here.
+    monkeypatch.setattr("torch_fl._build_config.ACCELERATOR", "cuda")
 
     patches = {}
     inductor_backend._patch_ppu_flagtree_compile_workers(patches)
@@ -551,6 +556,146 @@ def test_musa_flagtree_compiles_forward_backward(device):
     # torch_fl's own shim may hold this name (see the binding test above).
     plugin = sys.modules.get("torch_musa")
     assert plugin is None or plugin.__spec__.origin == "torch_fl_shim"
+
+
+def _skip_unless_gcu():
+    from torch_fl._build_config import ACCELERATOR
+
+    if ACCELERATOR != "gcu":
+        pytest.skip("GCU build required")
+
+
+@pytest.mark.gcu
+def test_gcu_raw_stream_is_the_eager_stream():
+    """Compiled GCU kernels must launch on the stream eager work already uses."""
+    _skip_unless_gcu()
+    from torch_fl.compile.flagtree_shim import get_gcu_current_raw_stream
+
+    raw_stream = get_gcu_current_raw_stream()
+    assert raw_stream == torch_fl.flagos.current_stream().gcu_stream
+    assert raw_stream != 0
+
+
+@pytest.mark.gcu
+def test_gcu_device_properties_use_vendor_warp_size():
+    """Inductor must size kernels by the GCU warp, not CUDA's 32.
+
+    ``_DeviceProperties`` carries no ``warp_size`` on GCU, and Inductor's default
+    is CUDA's. The authority is the Triton driver, since it compiles the kernel.
+    """
+    _skip_unless_gcu()
+    from torch._inductor.runtime.hints import DeviceProperties
+    from triton.runtime import driver
+
+    props = DeviceProperties.create(torch.device("flagos", 0))
+    assert props.type == "gcu"
+    assert props.warp_size == driver.active.get_current_target().warp_size
+
+
+@pytest.mark.gcu
+def test_gcu_cache_key_survives_pickling():
+    """Inductor's FX graph cache must not be bypassed on GCU.
+
+    Two things break this key. ``CacheBase.get_system`` reads the CUDA device
+    getter torch_fl aliases onto flagos and, with ``torch.version.cuda`` unset,
+    takes the HIP branch into ``gcnArchName``. And ``torch.device`` is replaced
+    by a function-local class that pickle cannot resolve by name, which
+    downgrades every compile to BypassFxGraphCache.
+    """
+    _skip_unless_gcu()
+    import pickle
+
+    from torch._inductor.codecache import CacheBase
+
+    system = CacheBase.get_system()
+    assert system["device"]["name"]
+    assert "hash" in system
+
+    assert pickle.loads(pickle.dumps(torch.device)) is torch.device
+    assert isinstance(torch.device("flagos:0"), torch.device)
+
+
+@pytest.mark.gcu
+def test_gcu_compiles_dim0_reduction(device):
+    """A reduction over the non-contiguous axis must match eager.
+
+    triton_gcu miscompiles a persistent reduction at XBLOCK=1 -- silently, with
+    wrong values rather than a failure. It is Inductor's first config for every
+    persistent reduction, and dim-0 reductions are mostly a backward-pass shape,
+    so unguarded this surfaces only as bad gradients.
+    """
+    _skip_unless_gcu()
+
+    def fn(a, b):
+        return (a * b).sum(dim=0)
+
+    x = torch.randn(16, 32, device=device)
+    y = torch.randn(16, 32, device=device)
+    compiled = torch.compile(fn, backend="flagos")(x, y)
+    assert_on_flagos(compiled)
+    torch.testing.assert_close(compiled, fn(x, y), rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.gcu
+def test_gcu_compiles_transposed_load(device):
+    """A transposed load must compile despite the vendor's tt.trans bug.
+
+    2D tiling makes Inductor emit a transposed load, which Triton lowers to
+    ``tt.trans``; triton_gcu's layout inference rejects its own inferred type
+    there. One tile per kernel keeps the indexing linear.
+    """
+    _skip_unless_gcu()
+
+    def fn(a, b):
+        return a.t().contiguous() + b
+
+    x = torch.randn(128, 128, device=device)
+    y = torch.randn(128, 128, device=device)
+    compiled = torch.compile(fn, backend="flagos")(x, y)
+    assert_on_flagos(compiled)
+    torch.testing.assert_close(compiled, fn(x, y), rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.gcu
+def test_gcu_compiles_forward_backward(device):
+    """The GCU path must preserve native autograd, gradients included."""
+    _skip_unless_gcu()
+
+    model = SimpleModel().to(device)
+    x = torch.randn(32, 128, device=device, requires_grad=True)
+    eager = model(x)
+    eager.sum().backward()
+    eager_grads = [p.grad.clone() for p in model.parameters()]
+    for param in model.parameters():
+        param.grad = None
+
+    compiled = torch.compile(model, backend="flagos")(x)
+    assert_on_flagos(compiled)
+    torch.testing.assert_close(compiled, eager, rtol=1e-4, atol=1e-4)
+
+    compiled.sum().backward()
+    assert x.grad is not None
+    assert_on_flagos(x.grad, "gradient")
+    for expected, param in zip(eager_grads, model.parameters()):
+        torch.testing.assert_close(param.grad, expected, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.gcu
+def test_gcu_defaults_to_serial_compile(monkeypatch):
+    """A tops pointer only resolves against the current device, so no forking."""
+    from torch_fl.compile import inductor_backend
+
+    monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)
+    monkeypatch.setattr("torch_fl._build_config.ACCELERATOR", "gcu")
+
+    patches = {}
+    inductor_backend._patch_vendor_flagtree_compile_workers(patches)
+    assert patches["compile_threads"] == 1
+
+    # An explicit request still wins.
+    patches = {"compile_threads": 4}
+    inductor_backend._patch_vendor_flagtree_compile_workers(patches)
+    assert patches["compile_threads"] == 4
 
 
 # The generic FlagTree test above also covers the MThreads runtime when the

--- a/torch_fl/__init__.py
+++ b/torch_fl/__init__.py
@@ -1015,6 +1015,20 @@ def _alias_cuda_to_flagos():
                 kwargs = {**kwargs, "device": _remap(kwargs["device"])}
             return _orig_device(*args, **kwargs)
 
+    # Pickle saves a *class* by reference, looking it up as
+    # ``__module__.__qualname__``. Left as defined, that is
+    # ``torch_fl._alias_cuda_to_flagos.<locals>.device``, which is unreachable,
+    # so ``pickle.dumps(torch.device)`` fails with "Can't get local object".
+    # That costs more than hand-pickling a device: Inductor pickles the graph
+    # module to build its FX graph cache key, and a device constant in the graph
+    # brings this class along, so every compile hits BypassFxGraphCache ("Failed
+    # to pickle cache key") and recompiles from scratch. Naming it ``torch.device``
+    # -- which is exactly what the next line makes it -- makes that lookup find
+    # this same object, so the reference round-trips.
+    device.__module__ = "torch"
+    device.__qualname__ = "device"
+    device.__name__ = "device"
+
     torch.device = device
     _keep_device_identity_checks_working(_orig_device, device)
 

--- a/torch_fl/compile/device_interface.py
+++ b/torch_fl/compile/device_interface.py
@@ -48,6 +48,25 @@ from torch._dynamo.device_interface import (
 DEVICE_TYPE = "flagos"
 
 
+# Accelerators whose runtime is *not* CUDA-derived: torch.cuda has no working
+# implementation in the process, so every hardware query has to go through
+# torch.flagos and the vendor Triton driver instead of proxying to CUDA.
+#
+# MUSA reaches Triton through MThreads FlagTree; GCU reaches it through
+# Enflame's triton_gcu plugin, already redirected onto flagos by
+# torch_fl.accelerator.gcu._gcu_compat.patch_triton_gcu_for_flagos(). The
+# distinction that matters to this module is the same for both, so keep the
+# checks keyed on this set rather than on a vendor name.
+_NATIVE_ACCELERATORS = frozenset({"musa", "gcu"})
+
+
+def is_native_accelerator() -> bool:
+    """Whether the active accelerator runs without a usable CUDA runtime."""
+    from torch_fl._build_config import ACCELERATOR
+
+    return ACCELERATOR in _NATIVE_ACCELERATORS
+
+
 def _triton_backend() -> tuple[str, str]:
     """Return ``(device_type, triton_backend)`` for the active accelerator.
 
@@ -61,9 +80,37 @@ def _triton_backend() -> tuple[str, str]:
 
     if ACCELERATOR == "musa":
         return "musa", "mthreads"
+    if ACCELERATOR == "gcu":
+        # Enflame names both the target and the backend package "gcu"
+        # (GPUTarget(backend='gcu', ...) from triton_gcu's _GCUDriver).
+        return "gcu", "gcu"
     if ACCELERATOR == "metax":
         return "maca", "metax"
     return "cuda", "nvidia"
+
+
+def _native_warp_size(props: Any) -> int:
+    """Warp size for a native accelerator, preferring the vendor Triton driver.
+
+    Inductor's own default is CUDA's 32, which is wrong on GCU (12 on gcu300, 8
+    on gcu400, 128 on gcu500) and would misshape every generated kernel. The
+    authority is the Triton driver, since it is what compiles the kernel:
+    ``GPUTarget.warp_size`` is the same number the backend codegen uses. Fall
+    back to the device properties, then to 32, so a driver without target
+    resolution still compiles.
+    """
+    warp_size = getattr(props, "warp_size", None)
+    if warp_size:
+        return int(warp_size)
+    try:
+        from triton.runtime import driver
+
+        target = driver.active.get_current_target()
+        if getattr(target, "warp_size", None):
+            return int(target.warp_size)
+    except Exception:
+        pass
+    return 32
 
 
 def _device_index(device: Any) -> Optional[int]:
@@ -116,9 +163,7 @@ class FlagOSDeviceInterface(DeviceInterface):
                 idx = FlagOSDeviceInterface.Worker.current_device()
 
             if DEVICE_TYPE not in caching_worker_device_properties:
-                from torch_fl._build_config import ACCELERATOR
-
-                if ACCELERATOR == "musa":
+                if is_native_accelerator():
                     caching_worker_device_properties[DEVICE_TYPE] = [
                         torch.flagos.get_device_properties(i)
                         for i in range(torch.flagos.device_count())
@@ -150,15 +195,17 @@ class FlagOSDeviceInterface(DeviceInterface):
             from torch_fl.compile.flagtree_shim import get_musa_current_raw_stream
 
             return get_musa_current_raw_stream(device_idx)
+        if ACCELERATOR == "gcu":
+            from torch_fl.compile.flagtree_shim import get_gcu_current_raw_stream
+
+            return get_gcu_current_raw_stream(device_idx)
         return torch._C._cuda_getCurrentRawStream(device_idx)
 
     # --- hardware: same physical GPU as cuda for boxing, native properties
     # for MUSA where torch.cuda is deliberately unavailable. ------------------
     @staticmethod
     def get_device_properties(device: Any = None) -> Any:
-        from torch_fl._build_config import ACCELERATOR
-
-        if ACCELERATOR == "musa":
+        if is_native_accelerator():
             return torch.flagos.get_device_properties(
                 FlagOSDeviceInterface._vendor_device(device)
             )
@@ -183,14 +230,18 @@ class FlagOSDeviceInterface(DeviceInterface):
     def set_stream(stream: Any) -> None:
         from torch_fl._build_config import ACCELERATOR
 
-        if ACCELERATOR == "musa":
+        if is_native_accelerator():
             native = getattr(stream, "_stream", stream)
             if hasattr(native, "set_current"):
                 native.set_current()
                 return
             # Native MUSA currently exposes the default stream only.  Reject a
             # foreign stream instead of silently switching CUDA state.
-            if getattr(stream, "musa_stream", None) is not None:
+            if ACCELERATOR == "musa" and getattr(stream, "musa_stream", None):
+                return
+            # Same reasoning on GCU: torch.cuda.set_stream would touch a CUDA
+            # runtime that is not there.
+            if ACCELERATOR == "gcu":
                 return
         torch.cuda.set_stream(stream)
 
@@ -210,17 +261,13 @@ class FlagOSDeviceInterface(DeviceInterface):
 
     @staticmethod
     def is_bf16_supported(including_emulation: bool = True) -> bool:
-        from torch_fl._build_config import ACCELERATOR
-
-        if ACCELERATOR == "musa":
+        if is_native_accelerator():
             return torch.bfloat16 in torch.flagos.get_amp_supported_dtype()
         return torch.cuda.is_bf16_supported()
 
     @staticmethod
     def get_compute_capability(device: Any = None) -> Union[int, str]:
-        from torch_fl._build_config import ACCELERATOR
-
-        if ACCELERATOR == "musa":
+        if is_native_accelerator():
             props = torch.flagos.get_device_properties(
                 FlagOSDeviceInterface._vendor_device(device)
             )
@@ -230,9 +277,9 @@ class FlagOSDeviceInterface(DeviceInterface):
 
     @staticmethod
     def is_triton_capable(device: Any = None) -> bool:
-        from torch_fl._build_config import ACCELERATOR
-
-        if ACCELERATOR == "musa":
+        # No CUDA compute-capability floor applies: the vendor Triton backend
+        # is the one that decides, and it targets the whole product line.
+        if is_native_accelerator():
             return True
         return torch.cuda.get_device_properties(_device_index(device)).major >= 7
 
@@ -251,9 +298,17 @@ class FlagOSDeviceInterface(DeviceInterface):
 
         _, triton_backend = _triton_backend()
         if triton_backend not in triton.backends.backends:
+            from torch_fl._build_config import ACCELERATOR
+
+            hint = {
+                "musa": "install the MThreads FlagTree runtime for MUSA",
+                "gcu": (
+                    "install Enflame's triton_gcu plugin and the /opt/triton_gcu "
+                    "toolchain (see docs/vendors/gcu/installation.md)"
+                ),
+            }.get(ACCELERATOR, "install the vendor Triton runtime")
             raise RuntimeError(
-                f"triton not built with the '{triton_backend}' backend; "
-                "install the MThreads FlagTree runtime for MUSA"
+                f"triton not built with the '{triton_backend}' backend; {hint}"
             )
 
     @staticmethod
@@ -316,9 +371,7 @@ def _patch_device_properties() -> None:
     def create(device: Any) -> Any:
         is_flagos = device is not None and getattr(device, "type", None) == DEVICE_TYPE
         if is_flagos:
-            from torch_fl._build_config import ACCELERATOR
-
-            if ACCELERATOR != "musa":
+            if not is_native_accelerator():
                 # Boxing-backed accelerators expose CUDA properties; only the
                 # target type changes at the Triton boundary.
                 device = torch.device("cuda", device.index or 0)
@@ -337,7 +390,7 @@ def _patch_device_properties() -> None:
                 max_threads_per_multi_processor=getattr(
                     props, "max_threads_per_multi_processor", None
                 ),
-                warp_size=getattr(props, "warp_size", 32),
+                warp_size=_native_warp_size(props),
             )
         return original(device)
 
@@ -445,17 +498,17 @@ def register_flagos_device_interface() -> None:
         from torch.utils import _triton as triton_utils
 
         triton_utils.has_triton.cache_clear()
-        from torch_fl._build_config import ACCELERATOR
 
-        if ACCELERATOR == "musa" and triton_utils.has_triton_package():
+        if is_native_accelerator() and triton_utils.has_triton_package():
             # PyTorch's helper only knows CUDA/XPU/PrivateUse1 at import time;
-            # the CPU wheel's CUDA probe is false even though MUSA owns
-            # PrivateUse1. Inductor imports this helper into several modules,
-            # so update those bound references as well as the canonical helper.
-            def has_musa_triton() -> bool:
+            # the CPU wheel's CUDA probe is false even though the vendor runtime
+            # owns PrivateUse1. Inductor imports this helper into several
+            # modules, so update those bound references as well as the canonical
+            # helper.
+            def has_native_triton() -> bool:
                 return True
 
-            triton_utils.has_triton = has_musa_triton
+            triton_utils.has_triton = has_native_triton
             import sys
 
             for module_name in (
@@ -465,6 +518,6 @@ def register_flagos_device_interface() -> None:
             ):
                 module = sys.modules.get(module_name)
                 if module is not None and hasattr(module, "has_triton"):
-                    module.has_triton = has_musa_triton
+                    module.has_triton = has_native_triton
     except (ImportError, AttributeError):
         pass

--- a/torch_fl/compile/flagtree_shim.py
+++ b/torch_fl/compile/flagtree_shim.py
@@ -158,6 +158,26 @@ def get_musa_current_raw_stream(device: Any = None) -> int:
     return _C._get_musa_current_raw_stream(_musa_device_index(device))
 
 
+def get_gcu_current_raw_stream(device: Any = None) -> int:
+    """The Enflame ``topsStream_t`` handle kernels must be launched on.
+
+    The GCU counterpart of ``get_musa_current_raw_stream``, and the import target
+    of the raw-stream line inductor writes into generated code. torch_fl's
+    ``TopsStream`` exposes the handle as ``gcu_stream`` -- the same name Enflame's
+    ``triton_gcu`` driver reads off its own stream objects -- so a compiled
+    kernel submits to the stream the eager topsaten kernels already use.
+
+    Unlike MUSA, no driver rebinding happens here: ``import torch_fl`` already
+    points ``triton_gcu`` at flagos through
+    ``torch_fl.accelerator.gcu._gcu_compat.patch_triton_gcu_for_flagos()``.
+    """
+    from torch_fl import flagos
+    from torch_fl.compile.device_interface import FlagOSDeviceInterface
+
+    index = int(FlagOSDeviceInterface._vendor_device(device))
+    return flagos.current_stream(index).gcu_stream
+
+
 _musa_driver_bound = False
 
 

--- a/torch_fl/compile/inductor_backend.py
+++ b/torch_fl/compile/inductor_backend.py
@@ -36,51 +36,73 @@ import torch.fx
 import torch.cuda
 
 
-def _patch_musa_triton_autotune() -> None:
-    """Select the first compiled MUSA config without CUDA benchmarking.
+def _patch_native_triton_autotune() -> None:
+    """Select the first compiled config without CUDA benchmarking.
 
     Inductor's generic runtime autotuner allocates a CUDA L2-cache buffer and
-    records ``torch.cuda.Event`` pairs. Neither API exists on native MUSA, and
-    the MThreads driver already compiles a valid launch configuration for each
-    kernel. Selecting the first compiled configuration keeps execution native;
-    it does not claim autotuning performance parity.
+    records ``torch.cuda.Event`` pairs. Neither API exists on a native
+    accelerator, and the vendor driver already compiles a valid launch
+    configuration for each kernel. Selecting the first compiled configuration
+    keeps execution native; it does not claim autotuning performance parity.
     """
     from torch_fl._build_config import ACCELERATOR
+    from torch_fl.compile.device_interface import is_native_accelerator
 
-    if ACCELERATOR != "musa":
+    if not is_native_accelerator():
         return
     try:
         from torch._inductor.runtime.triton_heuristics import CachingAutotuner
     except ImportError:
         return
-    if getattr(CachingAutotuner, "_flagos_musa_patched", False):
+    if getattr(CachingAutotuner, "_flagos_native_patched", False):
         return
+
+    vendor = "MThreads FlagTree" if ACCELERATOR == "musa" else "triton_gcu"
+    # triton_gcu miscompiles a persistent reduction at XBLOCK=1: the cross-row
+    # `tl.sum(..., 1)` silently returns wrong values (XBLOCK=2 fails to compile
+    # outright, XBLOCK>=4 is correct). It is the first config Inductor generates
+    # for every persistent reduction, so taking launchers[0] would ship the
+    # broken one -- and being wrong rather than failing, it only surfaces as bad
+    # gradients, since dim-0 reductions are mostly a backward-pass shape.
+    min_xblock = 4 if ACCELERATOR == "gcu" else 0
+
+    def _usable(launcher) -> bool:
+        if not min_xblock:
+            return True
+        xblock = getattr(launcher, "config", None)
+        xblock = getattr(xblock, "kwargs", {}).get("XBLOCK")
+        return xblock is None or xblock >= min_xblock
 
     def autotune_to_one_config(self, *args, **kwargs):
         del args, kwargs
         if not self.launchers:
             self.precompile()
         if not self.launchers:
-            raise RuntimeError("MThreads FlagTree produced no valid MUSA launchers")
-        self.launchers = [self.launchers[0]]
+            raise RuntimeError(f"{vendor} produced no valid launchers")
+        # Prefer a config the vendor compiles correctly; fall back to the first
+        # one rather than failing, so a kernel whose only config is XBLOCK=1
+        # still runs as it did before.
+        self.launchers = [next(filter(_usable, self.launchers), self.launchers[0])]
 
     CachingAutotuner.autotune_to_one_config = autotune_to_one_config
-    CachingAutotuner._flagos_musa_patched = True
+    CachingAutotuner._flagos_native_patched = True
 
 
-def _patch_native_musa_cuda_probe() -> None:
-    """Make Inductor's CUDA-shaped FakeTensor probe see native MUSA devices.
+def _patch_native_cuda_probe() -> None:
+    """Make Inductor's CUDA-shaped FakeTensor probe see native accelerators.
 
     CPU-only PyTorch reports ``torch.cuda.is_available() == False`` even when
-    the PrivateUse1 MUSA runtime is active. Inductor uses that probe to decide
+    the PrivateUse1 vendor runtime is active. Inductor uses that probe to decide
     whether FakeTensor should initialize a GPU context; without this bridge it
     skips the registered flagos device and later attempts CPU-torch CUDA lazy
-    initialization. The compiler still receives a ``flagos`` device and never
-    executes a CUDA kernel.
+    initialization ("Torch not compiled with CUDA enabled"). The compiler still
+    receives a ``flagos`` device and never executes a CUDA kernel.
     """
-    from torch_fl._build_config import ACCELERATOR
+    from torch_fl.compile.device_interface import is_native_accelerator
 
-    if ACCELERATOR != "musa" or getattr(torch.cuda, "_flagos_musa_patched", False):
+    if not is_native_accelerator():
+        return
+    if getattr(torch.cuda, "_flagos_native_patched", False):
         return
     if not torch.flagos.is_available():
         return
@@ -88,7 +110,7 @@ def _patch_native_musa_cuda_probe() -> None:
     original = torch.cuda.is_available
     torch.cuda.is_available = torch.flagos.is_available
     torch.cuda._flagos_original_is_available = original
-    torch.cuda._flagos_musa_patched = True
+    torch.cuda._flagos_native_patched = True
 
 
 def _bind_musa_flagtree_runtime() -> None:
@@ -111,6 +133,71 @@ def _bind_musa_flagtree_runtime() -> None:
         bind_flagtree_musa_driver()
     except ImportError:
         pass
+
+
+def _patch_native_cache_system_key() -> None:
+    """Key Inductor's cache on the vendor device instead of a CUDA/HIP probe.
+
+    ``CacheBase.get_system`` reads ``torch.cuda.get_device_properties`` and then
+    picks a branch on ``torch.version.cuda``: ``None`` means HIP, so it reads
+    ``gcnArchName``. torch_fl aliases that CUDA getter onto flagos, so on a
+    native accelerator the call *succeeds* and lands in the HIP branch, where
+    the vendor properties object has no such attribute -- an AttributeError the
+    surrounding ``except (AssertionError, RuntimeError)`` does not catch.
+
+    Report the vendor device name and the Triton target arch instead. Both
+    belong in the key: a cache entry compiled for gcu300 must not be reused on
+    gcu400, whose warp size differs. ``get_system`` is ``functools.cache``d, so
+    this has to be installed before the first compile.
+    """
+    from torch_fl.compile.device_interface import is_native_accelerator
+
+    if not is_native_accelerator():
+        return
+    try:
+        from torch._inductor.codecache import CacheBase
+    except ImportError:
+        return
+    if getattr(CacheBase, "_flagos_native_patched", False):
+        return
+
+    import functools
+    import hashlib
+    import json
+
+    from torch_fl._build_config import ACCELERATOR
+
+    @staticmethod
+    @functools.cache
+    def get_system() -> Dict[str, Any]:
+        from torch._inductor.runtime.triton_compat import HAS_TRITON, triton_key
+
+        triton_version = triton_key() if HAS_TRITON else None
+        system: Dict[str, Any] = {
+            "device": {"name": None},
+            "version": {"triton": triton_version},
+        }
+        try:
+            props = torch.flagos.get_device_properties(torch.flagos.current_device())
+            system["device"]["name"] = getattr(props, "name", None)
+        except (AssertionError, RuntimeError, AttributeError):
+            pass
+        try:
+            from triton.runtime import driver
+
+            system["device"]["arch"] = str(driver.active.get_current_target().arch)
+        except Exception:
+            pass
+        system["version"][ACCELERATOR] = getattr(
+            torch.flagos, "__version__", ACCELERATOR
+        )
+        system["hash"] = hashlib.sha256(
+            json.dumps(system, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        return system
+
+    CacheBase.get_system = get_system
+    CacheBase._flagos_native_patched = True
 
 
 def _patch_cuda_rng_for_cpu_torch():
@@ -144,10 +231,11 @@ def _patch_cuda_rng_for_cpu_torch():
 
 
 # Apply runtime probes at module load time, before FakeTensor is imported by
-# the first compile. Native MUSA is not CUDA, but Inductor's GPU probe is the
-# shared gate for CUDA-shaped GPU devices.
-_patch_native_musa_cuda_probe()
-_patch_musa_triton_autotune()
+# the first compile. Native MUSA and GCU are not CUDA, but Inductor's GPU probe
+# is the shared gate for CUDA-shaped GPU devices.
+_patch_native_cuda_probe()
+_patch_native_triton_autotune()
+_patch_native_cache_system_key()
 _bind_musa_flagtree_runtime()
 _patch_cuda_rng_for_cpu_torch()
 
@@ -172,13 +260,14 @@ def _resolve_config_patches(
     if options:
         patches.update({k.replace("-", "_"): v for k, v in options.items()})
 
-    from torch_fl._build_config import ACCELERATOR
+    from torch_fl.compile.device_interface import is_native_accelerator
 
-    # Native MUSA has no CUDA implementation for Inductor's CUDA-only pattern
-    # registration (for example SDPA replacement construction). Keep the
-    # general joint-graph passes, but skip that optional pattern bundle until
-    # FlagTree/MUSA supplies an equivalent lowering.
-    if ACCELERATOR == "musa":
+    # Native accelerators have no CUDA implementation for Inductor's CUDA-only
+    # pattern registration (for example SDPA replacement construction, and the
+    # pad_mm bundle, which constructs a real tensor on the device). Keep the
+    # general joint-graph passes, but skip that optional pattern bundle until the
+    # vendor compiler supplies an equivalent lowering.
+    if is_native_accelerator():
         patches["use_joint_graph_passes"] = False
         patches["max_autotune"] = False
         patches["max_autotune_pointwise"] = False
@@ -189,6 +278,22 @@ def _resolve_config_patches(
         # the CPU torch wheel cannot provide. mode="max-autotune" enables it, so
         # turn it back off; the kernels still compile and run, just untuned.
         patches["coordinate_descent_tuning"] = False
+
+    from torch_fl._build_config import ACCELERATOR
+
+    # 2D tiling is what makes Inductor emit a transposed load (`in_ptr0 + (y0 +
+    # 128*x1)` against an x-major store), and Triton lowers that pair to
+    # `tt.trans`. triton_gcu's layout inference rejects its own result there --
+    # "'tt.trans' op inferred type(s) ... are incompatible with return type(s)",
+    # differing only in `order = [0, 1]` vs `[1, 0]` -- so the kernel fails to
+    # compile. The same bug is reachable from a hand-written `tl.trans`, which
+    # additionally returns wrong values on shapes it does accept, so this is the
+    # vendor compiler and not Inductor's codegen. One tile per kernel keeps the
+    # indexing linear and sidesteps it; the transpose then costs an extra kernel
+    # rather than a tiled load. Only a default -- an explicit
+    # options={"triton.max_tiles": ...} above still wins.
+    if ACCELERATOR == "gcu":
+        patches.setdefault("triton.max_tiles", 1)
 
     # CUDA graphs need torch.cuda.CUDAGraph, a dummy base class in the CPU torch
     # wheel ("Tried to instantiate dummy base class CUDAGraph"). mode=
@@ -207,11 +312,13 @@ def _resolve_config_patches(
 def _patch_vendor_flagtree_compile_workers(config_patches: Dict[str, Any]) -> None:
     """Avoid unsafe vendor-driver initialization in compile workers.
 
-    PPU and MThreads FlagTree drivers query a vendor runtime while creating
-    compiler hints. Keeping the first implementation conservative is important
-    for MUSA: the vendor runtime owns the current device and stream, while
-    Inductor workers may be forked after the parent has initialized it. Explicit
-    per-compile and environment settings remain authoritative.
+    PPU and MThreads FlagTree drivers, and Enflame's triton_gcu, query a vendor
+    runtime while creating compiler hints. Keeping the first implementation
+    conservative matters for all of them: the vendor runtime owns the current
+    device and stream, while Inductor workers may be forked after the parent has
+    initialized it. On GCU that is sharper than elsewhere, because a tops pointer
+    only resolves against the current device. Explicit per-compile and
+    environment settings remain authoritative.
     """
     if "compile_threads" in config_patches:
         return
@@ -220,6 +327,10 @@ def _patch_vendor_flagtree_compile_workers(config_patches: Dict[str, Any]) -> No
 
     from torch_fl._build_config import ACCELERATOR
     from torch_fl.compile.flagtree_shim import flagtree_backend
+
+    if ACCELERATOR == "gcu":
+        config_patches["compile_threads"] = 1
+        return
 
     backend = flagtree_backend()
     if backend == "ppu" or (ACCELERATOR == "musa" and backend == "mthreads"):

--- a/torch_fl/compile/inductor_codegen.py
+++ b/torch_fl/compile/inductor_codegen.py
@@ -81,6 +81,13 @@ class FlagOSDeviceOpOverrides(CUDADeviceOpOverrides):
                 "from torch_fl.compile.flagtree_shim import "
                 f"get_musa_current_raw_stream as {name}"
             )
+        if ACCELERATOR == "gcu":
+            # Same on GCU: triton_gcu's launcher takes a topsStream_t and there
+            # is no CUDA runtime behind torch.flagos.
+            return (
+                "from torch_fl.compile.flagtree_shim import "
+                f"get_gcu_current_raw_stream as {name}"
+            )
         # Boxing-backed flagos streams are CUDA streams on the same device.
         return f"from torch._C import _cuda_getCurrentRawStream as {name}"
 


### PR DESCRIPTION
## Summary

Routes Inductor's `flagos` backend through Enflame's `triton_gcu`, following the MUSA path from #159. Forward and backward both match eager (grad error 2e-6).

Four vendor-specific defects had to be worked around. Three were silent — they produced wrong numbers or silently disabled caching rather than failing:

**Warp size.** Inductor defaulted to CUDA's 32; the GCU warp is 12. Now taken from the Triton driver's `GPUTarget`, which is the value the backend codegen actually uses.

**FX graph cache always bypassed**, for two independent reasons. `CacheBase.get_system` read the CUDA device getter we alias onto flagos and, with `torch.version.cuda` unset, took the HIP branch into a missing `gcnArchName`. Separately, `torch.device` was a function-local class that pickle could not resolve by name, so every compile logged a cache-key failure and recompiled from scratch.

**Wrong gradients.** `triton_gcu` miscompiles a persistent reduction at `XBLOCK=1`: `tl.sum` over the non-contiguous axis silently returns wrong values, while `XBLOCK=2` fails to compile and `XBLOCK>=4` is correct. That is Inductor's *first* generated config, and we select the first compiled launcher, so we always shipped the broken one. Because dim-0 reductions are mostly a backward-pass shape, forward output stayed exact while gradients were off by 22.5. Launcher selection now skips `XBLOCK < 4` on GCU, falling back to the first config rather than failing when it's the only one.

**Transposed loads failed to compile.** 2D tiling makes Inductor emit a transposed load, which Triton lowers to `tt.trans`; `triton_gcu`'s layout inference then rejects its own inferred type, differing only in `order = [0,1]` vs `[1,0]`. This is vendor-side rather than codegen: a hand-written `tl.trans` fails the same way on non-square shapes and returns wrong values on 32x32. Defaulting `triton.max_tiles` to 1 keeps indexing linear; an explicit `options={"triton.max_tiles": N}` still wins.

## Testing

- 27 passed in `tests/integration/test_compile.py`, including 7 new GCU regression tests — one per defect above, with the backward assertions that catch the silent ones.
- 975 passed across `tests/integration`.
- The 22 integration and 2 unit failures on this runner (vendor `topsatenNeg` gaps, FlagGems dispatch logging, profiler, missing `transformers`) reproduce on the baseline tree with these changes stashed, so they are pre-existing.
- Added a `torch.compile` step to `.github/configs/gcu.yml`, matching what #164 did for CUDA.

## Notes for reviewers

The `XBLOCK>=4` and `max_tiles=1` defaults are workarounds for vendor compiler bugs, not fixes, and both cost some performance (a transpose becomes an extra kernel). Both are worth reporting upstream to Enflame.

One pre-existing test was adjusted: `test_non_ppu_flagtree_keeps_default_compile_threads` did not pin `ACCELERATOR`, so on a GCU build it picked up the real value and exercised the serial-compile rule instead of the rule its name describes. Now pinned to `cuda`.

`tl.trans` returning wrong values on shapes it accepts means any hand-written Triton kernel using it would be silently incorrect on GCU. I did not audit the repo for that.