### PR TITLE
feat: add fail-closed FlagCX validation

### DIFF
--- a/.claude/skills/flagcx-integration/SKILL.md
+++ b/.claude/skills/flagcx-integration/SKILL.md
@@ -1,0 +1,598 @@
+---
+name: flagcx-integration
+description: >
+  Integrate and validate FlagCX distributed communication for torch_fl after the
+  device runtime and vendor communication path are available. Use this for a
+  new FlagCX vendor adaptor, a FlagCX or PyTorch version change, a process-group
+  routing change, or a distributed correctness survey. Covers the FlagCX
+  registration contract, vendor profiles, NCCL/HCCL/MCCL fallback, zero-copy
+  tensor views, process-group and DDP automation, multi-process collectives,
+  and evidence boundaries. Do not infer distributed support from import success.
+---
+
+# FlagCX integration (torch_fl)
+
+## Scope and prerequisites
+
+FlagCX is the heterogeneous distributed-communication layer. It is an optional
+inner backend below torch-fl's `ProcessGroupFlagOS`; it does not replace device
+allocation, streams, copies, synchronization, vendor kernels, or rendezvous.
+A FlagCX integration is ready only when a real multi-process collective reaches
+the intended adaptor and produces the expected result.
+
+Complete these first:
+
+- [[runtime-bringup]] — device discovery, allocation, streams, and copies pass on
+  the target hardware.
+- [[torch-version-port]] — the active PyTorch minor line matches the generated
+  bindings and the c10d creator ABI.
+- [[cuda-compat-vendor]] or [[native-op-backend]] — the vendor's compute path and
+  its communication fallback are understood before adding distributed routing.
+- [[pre-pr-checks]] — fetch and rebase before linting or opening a PR.
+
+The integration has four separate surfaces:
+
+| Surface | Source of truth | What it does |
+|---|---|---|
+| FlagCX package/adaptor | `import flagcx` and the vendor FlagCX build | Registers the `flagcx` c10d backend and exposes its creator/inner process group |
+| torch-fl process group | `torch_fl/comm/process_group.py` | Tries FlagCX first, converts tensors for the selected backend, and falls back to the vendor native backend |
+| vendor profile | `_VENDOR_PROFILES` in `process_group.py` | Maps `GEMS_VENDOR` to FlagCX device name, tensor view, direct/native mode, and fallback |
+| public registration | `torch_fl/__init__.py`, `torch_fl/distributed.py` | Registers `flagos` for PrivateUse1 and makes standard c10d/DDP APIs work |
+
+A backend import is discovery, not validation. A process-group constructor is
+also not validation. The minimum correctness claim is a two-rank collective
+against a CPU-computed expected result, followed by the DDP gradient path when
+that platform supports it.
+
+## Non-negotiable correctness contract
+
+A FlagCX integration is **correctly connected** only when all of these gates pass:
+
+1. The intended `flagcx` package and shared libraries are loaded by the same
+   interpreter that loads torch-fl.
+2. Importing `flagcx` registers the expected c10d backend and the adaptor's
+   actual compile-time device name is recorded.
+3. A strict live run proves that `ProcessGroupFlagOS` selected FlagCX. A native
+   fallback must be made fatal in this run; a successful NCCL/HCCL/MCCL fallback
+   is not FlagCX evidence.
+4. At least two independent ranks complete `all_reduce`, `broadcast`,
+   `all_gather`, `_allgather_base`, `_reduce_scatter_base`, and `barrier` with
+   CPU-computed expected values and a zero process exit status.
+5. DDP forward/backward completes when the platform claims DDP support, and
+   rank-wise gradients agree within the documented tolerance.
+6. A separate fallback run disables or rejects FlagCX and proves the documented
+   native backend path. Its output is reported separately from the FlagCX run.
+7. The harness fails closed: missing FlagCX, wrong adaptor selection, a fallback
+   call, a rank mismatch, a timeout, or an unchecked assertion makes the command
+   nonzero.
+
+If any gate is missing, report **FlagCX not validated**. Never use the phrase
+"FlagCX works" when only the routing unit tests, import check, process-group
+construction, or native fallback passed.
+
+The final status must be one of these, with the corresponding evidence attached:
+
+| Status | Required evidence |
+|---|---|
+| `FlagCX validated` | strict two-rank FlagCX selection proof + collective matrix + DDP where claimed + zero exit |
+| `FlagCX validated; native fallback validated` | all of the above plus an independent forced-fallback matrix |
+| `FlagCX not validated; native fallback validated` | strict run blocked or failed, independent fallback matrix passes |
+| `Distributed communication not validated` | neither a strict FlagCX matrix nor an independent fallback matrix passes |
+
+Never collapse these statuses into one generic "distributed supported" label.
+
+## Step 0 — make backend selection observable and fail closed
+
+The live harness must distinguish "FlagCX selected" from "some backend selected".
+Do not infer this from a class name, a successful collective, or the absence of
+a warning: a CUDA/NCCL fallback can produce the same result. Use one of these
+mechanical proofs:
+
+- **Preferred:** expose a diagnostic `ProcessGroupFlagOS._inner_backend` value
+  (`"flagcx"` or `"native:<builder>"`) and assert it on every rank.
+- **Required when the diagnostic field is not available:** monkeypatch the native
+  builders to raise a sentinel error in the strict FlagCX run, and wrap
+  `_try_build_flagcx` so a false return raises immediately. This makes fallback
+  impossible to mistake for success:
+
+```python
+from torch_fl.comm.process_group import ProcessGroupFlagOS
+
+_NATIVE = ("_try_build_nccl", "_try_build_hccl", "_try_build_mccl")
+_original_flagcx = ProcessGroupFlagOS._try_build_flagcx
+
+def _require_flagcx(self, store, rank, world_size, timeout):
+    selected = _original_flagcx(self, store, rank, world_size, timeout)
+    if not selected:
+        raise AssertionError("FlagCX was unavailable or not selected")
+    return True
+
+ProcessGroupFlagOS._try_build_flagcx = _require_flagcx
+for _name in _NATIVE:
+    setattr(
+        ProcessGroupFlagOS,
+        _name,
+        lambda *args, _name=_name, **kwargs: (_ for _ in ()).throw(
+            AssertionError(f"native fallback {_name} was selected")
+        ),
+    )
+```
+
+Apply this in every spawned rank before `init_process_group`. Do not catch the
+sentinel. The strict run must fail if `flagcx` is missing, its creator returns
+false, or any fallback builder is reached. The fallback run uses the inverse
+proof: force `_try_build_flagcx` to return false, assert the expected native
+builder was called, and label the result as fallback evidence.
+
+## Step 1 — identify the communication environment
+
+Keep the torch, FlagCX, vendor runtime, and launcher explicit. The torch used
+to build torch-fl must match the branch's PyTorch minor line. Do not install a
+CPU-only or NVIDIA wheel merely to make `import flagcx` succeed on a vendor box.
+
+Record the environment before changing code:
+
+```bash
+python - <<'PY'
+import importlib.util
+import os
+import sys
+import torch
+
+print("python", sys.version)
+print("torch", torch.__version__)
+print("torch file", torch.__file__)
+print("cuda", torch.version.cuda)
+print("GEMS_VENDOR", os.environ.get("GEMS_VENDOR", "<unset>"))
+print("FLAGCX_TORCH_BACKEND", os.environ.get("FLAGCX_TORCH_BACKEND", "<unset>"))
+for name in ("flagcx", "torch.distributed"):
+    spec = importlib.util.find_spec(name)
+    print(name, spec.origin if spec else "not found")
+try:
+    import flagcx
+    print("flagcx file", flagcx.__file__)
+    print("creator", getattr(flagcx, "createFlagcxBackend", None))
+    print("pg class", getattr(flagcx, "ProcessGroupFlagCX", None))
+except Exception as exc:
+    print("flagcx import failed:", repr(exc))
+PY
+
+python -m pip show torch flagcx torch-fl 2>/dev/null || true
+```
+
+For a vendor box, also record:
+
+- vendor and adaptor name (`GEMS_VENDOR`, `USE_NVIDIA_ADAPTOR`, `USE_ASCEND_ADAPTOR`, etc.);
+- FlagCX revision and build options;
+- PyTorch version and c10d ABI;
+- vendor runtime/driver/SDK revision;
+- physical device count and visible-device mapping;
+- launcher (`torchrun`, `mp.spawn`, scheduler) and rendezvous settings;
+- `LD_LIBRARY_PATH`, `PYTHONPATH`, and any `FLAGCX_*` variables.
+
+A missing package is not the end of discovery. If `import flagcx` fails, fetch
+FlagCX from its upstream GitHub repository and build the matching C++ library and
+PyTorch plugin before declaring the FlagCX path unavailable. A genuinely missing
+vendor SDK/CCL, unresolved shared library, ABI mismatch, or failed source build
+is an environment failure; record the exact blocker and only then test the native
+fallback. Never silently report a successful FlagCX integration.
+
+## Step 2 — fetch and build FlagCX when the package is absent
+
+Use the upstream repository, not an unrelated PyPI placeholder:
+
+```bash
+export FLAGCX_SRC=${FLAGCX_SRC:-$PWD/.vendor/FlagCX}
+if ! python -c 'import flagcx' >/dev/null 2>&1; then
+  if [ ! -d "$FLAGCX_SRC/.git" ]; then
+    git clone --recurse-submodules https://github.com/FlagOpen/FlagCX.git "$FLAGCX_SRC"
+  else
+    git -C "$FLAGCX_SRC" fetch --tags origin
+    git -C "$FLAGCX_SRC" pull --ff-only
+    git -C "$FLAGCX_SRC" submodule update --init --recursive
+  fi
+fi
+```
+
+Select the adaptor from the actual hardware and the FlagCX build table. For a
+Kunlun P800, the upstream source currently uses `USE_KUNLUNXIN=1`,
+`DEVICE_HOME=/usr/local/xpu`, and `CCL_HOME=/usr/local/xccl`; the CCL SDK must
+provide `include/` and `so/libbkcl.so`. Do not substitute `/usr/local/xpu` for
+`/usr/local/xccl`: the device runtime and the collective library are separate
+inputs.
+
+The vendor torch may ship BKCL inside its Python package rather than in the
+standard `/usr/local/xccl` layout. It is valid to stage a temporary compatibility
+layout with symlinks, without copying or modifying vendor files:
+
+```bash
+TORCH_XMLIR=$(python -c 'import torch_xmlir, pathlib; print(pathlib.Path(torch_xmlir.__file__).parent)')
+export FLAGCX_CCL_STAGING=${FLAGCX_CCL_STAGING:-/tmp/flagcx-ccl}
+mkdir -p "$FLAGCX_CCL_STAGING/include" "$FLAGCX_CCL_STAGING/so"
+ln -sf "$TORCH_XMLIR/xccl/include/bkcl.h" "$FLAGCX_CCL_STAGING/include/bkcl.h"
+ln -sf "$TORCH_XMLIR/libbkcl.so" "$FLAGCX_CCL_STAGING/so/libbkcl.so"
+```
+
+Before building, assert both files exist and inspect their dependencies with
+`ldd`; a header-only directory is not a usable CCL SDK. If the SDK is absent,
+stop with an explicit build gap instead of linking a different vendor's CCL.
+
+Build the C++ library first, then build the torch plugin against the same source,
+interpreter, torch, and adaptor:
+
+```bash
+cd "$FLAGCX_SRC"
+git submodule update --init --recursive
+make USE_KUNLUNXIN=1 DEVICE_HOME=/usr/local/xpu \
+  CCL_HOME="${FLAGCX_CCL_HOME:-$FLAGCX_CCL_STAGING}" \
+  PLATFORM_EXTRA_SRCS=flagcx/adaptor/device_api/default_dev_api_backend.cc \
+  -j"${FLAGCX_BUILD_JOBS:-$(nproc)}"
+
+cd plugin/torch
+CUDA_HOME=/usr/local/cuda-12.9 \
+CXXFLAGS="-I/usr/local/cuda-12.9/targets/x86_64-linux/include -I/usr/local/xpu/include" \
+CPPFLAGS="$CXXFLAGS" \
+LDFLAGS="-L/usr/local/xcudart/lib -L/usr/local/xpu/so -L${FLAGCX_CCL_HOME:-$FLAGCX_CCL_STAGING}/so" \
+LIBRARY_PATH="/usr/local/xcudart/lib:/usr/local/xpu/so:${FLAGCX_CCL_HOME:-$FLAGCX_CCL_STAGING}/so" \
+FLAGCX_ADAPTOR=klx \
+python -m pip install . --no-build-isolation
+```
+
+The explicit `PLATFORM_EXTRA_SRCS` is required for current FlagCX source when
+the Kunlun makefile leaves the device API backend empty; without it
+`libflagcx.so` can build with an unresolved `devApiBackend` and the Python
+plugin fails at import. Keep this workaround in the evidence and re-check it
+when the upstream makefile changes.
+
+Use the adaptor name expected by `plugin/torch/_build_config.py`; the root Make
+variable (`USE_KUNLUNXIN`) and the torch plugin adaptor (`klx`) are not always
+the same string. For other vendors, read the corresponding `makefiles/*.mk`
+and `ADAPTOR_MAP` entry instead of guessing paths or flags.
+
+After installation, point the loader and Python at the artifacts and verify the
+exact files loaded:
+
+```bash
+export PYTHONPATH="$FLAGCX_SRC/plugin/torch:$PYTHONPATH"
+export LD_LIBRARY_PATH="$FLAGCX_SRC/build/lib:$FLAGCX_SRC/build/lib64:$LD_LIBRARY_PATH"
+python - <<'PY'
+import flagcx
+import torch
+import torch.distributed as dist
+print("flagcx", flagcx.__file__)
+print("torch", torch.__version__, torch.__file__)
+print("creator", getattr(flagcx, "createFlagcxBackend", None))
+print("backend map", getattr(dist.Backend, "default_device_backend_map", {}))
+PY
+```
+
+If the vendor CCL SDK is absent, stop the build with an explicit evidence gap:
+`FlagCX source fetched but not buildable: missing <path>`. Do not weaken the
+adaptor to compile against a different vendor or mark the package as installed
+just because the Python directory exists. Re-run this whole step after every
+FlagCX or torch minor-line change.
+
+## Step 3 — verify the FlagCX registration contract
+
+Do not guess the contract from an older integration or from a package name.
+For the current FlagCX build, inspect the actual registration and creator:
+
+```bash
+python - <<'PY'
+import torch
+import torch.distributed as dist
+import flagcx
+
+print("flagcx", flagcx.__file__)
+print("creator", flagcx.createFlagcxBackend)
+print("flagcx ProcessGroup", getattr(flagcx, "ProcessGroupFlagCX", None))
+print("registered backends", getattr(dist.Backend, "default_device_backend_map", {}))
+PY
+```
+
+The torch-fl integration currently relies on this contract:
+
+1. `import flagcx` self-registers the c10d backend named `flagcx` through
+   `Backend.register_backend`.
+2. The adaptor's compile-time device name is not necessarily `privateuseone`.
+   NVIDIA/MetaX CUDA adaptors use `cuda`; other adaptors may use `cann`, `musa`,
+   `mlu`, `flagos`, or another vendor device name. That value belongs in the
+   vendor profile, not in a global constant.
+3. NVIDIA and MetaX builds on current PyTorch expose the extended creator form:
+   `createFlagcxBackend(_DistributedBackendOptions, Options)`.
+4. Other adaptors may expose the plain c10d form:
+   `createFlagcxBackend(store, rank, world_size, timeout)`.
+5. `ProcessGroupFlagOS._try_build_flagcx` must try the extended form, retry the
+   plain form only for a signature `TypeError`, and warn/fall back for real
+   initialization failures.
+6. The creator's registered device and the tensor view passed to the inner
+   backend are separate decisions. A backend registered for `cuda` can consume
+   a zero-copy CUDA view; a native FlagCX adaptor may consume a PrivateUse1
+   tensor directly.
+
+Capture the exact creator signature and registered device for the adaptor under
+test. A passing import with a different device name or creator ABI is not enough.
+
+## Step 3a — define the vendor profile before wiring code
+
+Add or review one row in `_VENDOR_PROFILES` rather than adding vendor-specific
+branches throughout `ProcessGroupFlagOS`:
+
+| Field | Meaning |
+|---|---|
+| `flagcx_dev` | Device name under which the adaptor registers FlagCX |
+| `view` | `torch_fl._C` helper that creates the zero-copy physical-device view, or `None` |
+| `native` | Native fallback builder such as `_try_build_nccl`, `_try_build_hccl`, or `_try_build_mccl` |
+| `flagcx_native` | FlagCX adaptor accepts PrivateUse1 tensors directly; no view is needed on that path |
+| `direct` | The inner backend receives the PrivateUse1 tensor directly for all paths; opt in only after measurement |
+
+Examples in the current implementation:
+
+- CUDA-ABI vendors (`nvidia`, `metax`, `hygon`, `kunlunxin`, `thead`) use
+  `flagcx_dev="cuda"`, `_flagos_to_cuda_view`, and an NCCL/RCCL fallback.
+- Ascend uses `flagcx_dev="cann"`, no view, `flagcx_native=True`, and HCCL as a
+  fallback. The HCCL fallback must not receive a raw PrivateUse1 tensor unless a
+  measured view is added.
+- Enflame uses `flagcx_dev="flagos"`, `direct=True`, and no native fallback in
+  the torch-fl-compatible FlagCX mode.
+- MUSA uses `flagcx_dev="musa"`, `_flagos_identity_view`, and MCCL fallback.
+
+For a CUDA-compatible vendor, prove the zero-copy view preserves `data_ptr`,
+device index, lifetime, and stream semantics before using it for collectives. For
+a native adaptor, prove that the adaptor consumes the PrivateUse1 tensor itself
+before setting `flagcx_native` or `direct`. Otherwise fail loudly rather than
+passing a tensor with the wrong device type to a communication library.
+
+## Step 4 — implement automatic selection and fallback
+
+The required selection order is:
+
+```text
+FlagCX available and constructible
+    -> use FlagCX and the profile's FlagCX view/direct mode
+FlagCX absent or initialization fails
+    -> use the profile's native backend and view
+No suitable inner backend
+    -> raise a diagnostic RuntimeError
+```
+
+Keep the logic table-driven in `ProcessGroupFlagOS._build_inner`:
+
+```python
+if self._try_build_flagcx(...):
+    return self._resolve_view(profile, vendor, backend="flagcx")
+if profile.native is not None and getattr(self, profile.native)(...):
+    return self._resolve_view(profile, vendor, backend="native")
+raise RuntimeError(...)
+```
+
+Requirements for automatic behavior:
+
+1. `import torch_fl` must register `flagos` for `privateuseone` without requiring
+   callers to monkeypatch every `torch.distributed` collective.
+2. `init_process_group(backend="auto")` and `backend="flagos"` must select the
+   torch-fl process group.
+3. FlagCX import failure must be a controlled fallback, not process-group
+   construction failure when a native backend is available.
+4. A FlagCX creator signature mismatch must retry the supported alternate form;
+   arbitrary runtime errors must emit a warning and then use the fallback.
+5. An absent tensor view must raise a clear `NotImplementedError` for a native
+   fallback, not silently hand raw PrivateUse1 memory to HCCL/NCCL/MCCL.
+6. DDP must use the torch-fl Python reducer and its all-reduce hooks when the
+   model is on `privateuseone`.
+7. Device guards must make the communicator's device current before a collective
+   when the vendor's streams or pointers are device-scoped.
+
+Do not add a second hardware-detection scheme in the distributed layer. Reuse
+`GEMS_VENDOR` selected by `torch_fl` and preserve an explicit
+`FLAGCX_TORCH_BACKEND` choice. For Enflame's torch-fl-compatible build, default
+`FLAGCX_TORCH_BACKEND=flagos` before importing FlagCX; never overwrite an
+explicit user value.
+
+## Step 5 — test the automation without hardware first
+
+The first automated gate is pure Python and must run on every platform:
+
+```bash
+pytest tests/unit/test_vendor_routing.py -q
+```
+
+These tests should cover at least:
+
+- every profile has a coherent device/view/fallback combination;
+- known CUDA-ABI and native vendors resolve without warnings;
+- unknown vendors warn and use the documented default;
+- FlagCX is attempted before the native fallback;
+- both extended and plain creator signatures are exercised;
+- hard creator failures warn and fall back;
+- no-backend errors are diagnostic;
+- missing view helpers fail loudly;
+- direct PrivateUse1 mode is opt-in;
+- all base collective virtuals (`_allgather_base`, `_reduce_scatter_base`) remain
+  overridden and apply the selected view;
+- vendor-specific environment defaults preserve explicit overrides.
+
+Use fakes for FlagCX and native builders. Do not make unit tests import a vendor
+runtime, allocate a device, or depend on a particular FlagCX wheel. The fake
+creator must reject the wrong signature exactly as the real pybind binding does,
+so a test that only accepts `*args` is insufficient.
+
+Then run the static/public registration checks:
+
+```bash
+pytest tests/unit/test_vendor_routing.py tests/integration/ops/test_flaggems_conf_consistency.py -q
+python -m compileall -q torch_fl tests
+```
+
+A pure-Python pass proves selection and fallback automation only. It does not
+prove a communicator can exchange data.
+
+## Step 6 — run the two-rank live collective harness
+
+Use the repository harness or an equivalent `torchrun` command. Keep the
+interpreter, library path, visible devices, profiler settings, and rendezvous
+variables explicit. On the measured Kunlun XPU-RT stack, do not set
+`XPU_CUPTI_ENABLE_DEVICE` for a multi-process run: selecting devices for CUPTI
+event sampling can make `etiEventSamplingSetMode` fail with error 17 before
+ProcessGroup construction. Leave it unset unless the vendor profiler setup has
+been independently validated.
+
+```bash
+unset XPU_CUPTI_ENABLE_DEVICE
+XPU_ENABLE_PROFILER_TRACING=1 \
+MASTER_ADDR=127.0.0.1 MASTER_PORT=29531 \
+  torchrun --standalone --nproc-per-node=2 \
+  tests/manual/test_flagos_dist_live.py --world-size 2 --require-flagcx
+```
+
+The checked-in harness also supports `--force-native` for an independent
+fallback run. Do not replace `--require-flagcx` with a successful fallback run.
+```bash
+unset XPU_CUPTI_ENABLE_DEVICE
+XPU_ENABLE_PROFILER_TRACING=1 \
+  tests/manual/test_flagos_dist_live.py --world-size 2 --force-native
+```
+
+The minimum live matrix is:
+
+| Check | Required assertion |
+|---|---|
+| process-group initialization | both ranks construct `ProcessGroupFlagOS` |
+| FlagCX path | every rank proves `inner_backend == "flagcx"`; a native fallback is fatal |
+| native fallback | a separate run disables or rejects FlagCX and proves the expected native builder |
+| `all_reduce` | every rank receives the CPU-expected sum |
+| `broadcast` | every rank receives rank-0 data |
+| `all_gather` | list output has one expected value per rank |
+| `all_gather_into_tensor` | `_allgather_base` path returns ordered values |
+| `reduce_scatter_tensor` | each rank receives its expected shard |
+| barrier | all ranks complete without a hang |
+| DDP | forward/backward completes and gradients agree across ranks |
+| device guard | deliberately select a different current device before a collective and still pass, when the vendor requires it |
+
+A harness that prints `OK` without asserting exit status, tests only one rank,
+or merely observes that a collective returned is not evidence. The strict
+FlagCX harness must:
+
+- run with `world_size >= 2` and a finite timeout;
+- assert the selected inner backend on every rank before the first collective;
+- make native fallback selection raise a sentinel error;
+- compare every result with a CPU-computed expected value, including rank order;
+- synchronize at the end and emit one all-ranks success marker;
+- propagate any child exception, timeout, assertion, or nonzero exit status.
+
+Capture stdout/stderr, the selected backend proof from every rank, device model,
+FlagCX revision, creator ABI, and environment in the evidence file. A result
+without the backend proof is **not validated**, even if all numerical checks pass.
+
+For a new vendor adaptor, run two mechanically separate matrices:
+
+1. **Strict FlagCX run:** FlagCX must import, construct, be selected on every
+   rank, and complete the matrix. Any fallback is a failure.
+2. **Fallback run:** force `_try_build_flagcx` to return false or hide the package,
+   assert the expected native builder was selected, and complete the matrix if a
+   native backend is supported.
+
+If FlagCX is unavailable on the target, report the FlagCX path as **not
+validated** and still run the fallback path if the vendor provides one. Never
+substitute a successful NCCL/HCCL/MCCL run for FlagCX evidence.
+
+## Step 7 — extend beyond basic collectives
+
+After the two-rank smoke passes, test the communication operations used by the
+actual workloads:
+
+- list and tensor forms of all-gather and reduce-scatter;
+- all-to-all and all-to-all-single;
+- gather/scatter with roots;
+- send/recv/isend/irecv;
+- barrier with device IDs;
+- functional collectives used by DTensor, `torch.compile`, FSDP2, or ZeRO;
+- DDP gradient synchronization and optimizer step;
+- FSDP2 parameter all-gather, gradient reduce-scatter, and sharded state dict;
+- process failure, timeout, and repeated init/destroy where production requires.
+
+Test both contiguous and non-contiguous tensors, multiple dtypes supported by
+the adaptor, nonzero device indices, and repeated operations on the same stream.
+For CUDA-compatible vendors, compare the physical pointer and stream behavior of
+the view. For direct native adaptors, test that the adaptor receives the expected
+device type and current device.
+
+Do not claim multi-node, failure recovery, point-to-point, root collectives, or
+FSDP2 from a basic two-rank all-reduce. Keep those as separate evidence rows.
+
+## Step 8 — record evidence and review the boundary
+
+For each claimed vendor, record:
+
+- torch-fl revision and branch;
+- FlagCX revision, adaptor, and build options;
+- PyTorch version and creator ABI;
+- vendor runtime/driver/SDK and device model;
+- visible device count and rank mapping;
+- selected `GEMS_VENDOR`, `FLAGCX_*`, and library paths;
+- whether FlagCX or the native fallback was selected;
+- exact launcher and command;
+- all live test output, exit status, and timeout policy;
+- operations, dtypes, layouts, world sizes, and device indices exercised.
+
+Keep FlagCX evidence separate from native fallback evidence. A vendor row may say:
+
+```text
+FlagCX: validated for two-rank all_reduce/broadcast/all_gather and DDP
+Native fallback: validated separately for the same basic matrix
+FSDP2 / P2P / multi-node / failure recovery: not validated
+```
+
+If FlagCX is missing, say **FlagCX not validated; native fallback tested** or
+**distributed communication not validated**. Do not convert an import failure
+into a zero, and do not infer support from `_VENDOR_PROFILES` or a registered
+backend name.
+
+Update `docs/architecture/distributed-flagcx.md` and the platform compatibility
+or installation document in the same change when the supported scope changes.
+Do not copy vendor runtimes, drivers, XMLIR, or Python environments into a wheel.
+
+## Step 9 — pre-PR automation gate
+
+Before opening a PR:
+
+```bash
+git fetch flagos main
+git rebase flagos/main
+ruff check .
+ruff format --check .
+pytest tests/unit/test_vendor_routing.py -q
+pytest tests/unit/test_vendor_routing.py tests/integration/ops/test_flaggems_conf_consistency.py -q
+```
+
+Then verify:
+
+- the second run of every generator or environment setup is idempotent;
+- the loaded torch-fl extension and FlagCX package are the intended artifacts;
+- unit tests exercise both creator signatures and fallback paths;
+- the strict live harness proves FlagCX was selected on every rank and fails if fallback occurs;
+- the fallback harness separately proves the expected native builder;
+- the live harness has a nonzero failure path and asserts every result;
+- FlagCX and native fallback evidence are not mixed;
+- unsupported capabilities are explicitly marked **not validated**;
+- the PR includes exact test output, environment versions, and human reviewer;
+- all GitHub-facing text and documentation are in English.
+
+## Common failure modes
+
+| Symptom | Likely cause | Correct response |
+|---|---|---|
+| `No module named flagcx` | FlagCX is not installed in the active interpreter | Fetch the matching source from `https://github.com/FlagOpen/FlagCX.git`, build the vendor adaptor and torch plugin, then record the exact SDK/build blocker if the source build cannot complete |
+| `createFlagcxBackend` missing | Old or incomplete FlagCX build | Inspect the build/revision; treat the path as unavailable and fall back |
+| `incompatible function arguments` | Plain adaptor called with extended creator or vice versa | Retry the alternate supported signature; add a fake-signature unit test |
+| Process group initializes but collectives fail | Wrong adaptor device name, tensor view, stream, or current device | Inspect profile, pointer/view, stream, and device guard; rerun a two-rank harness |
+| `No backend type associated with device type flagos` | PrivateUse1 backend registration or base virtual override missing | Check `register_flagos_backend()` and `_allgather_base`/`_reduce_scatter_base` overrides |
+| HCCL/NCCL receives raw PrivateUse1 tensors | Missing or unsafe view conversion | Fail loudly or use a measured native FlagCX adaptor; never reinterpret blindly |
+| FlagCX silently becomes NCCL/HCCL | Import/creator failure swallowed as success | Emit selected-backend evidence and test FlagCX available and unavailable separately |
+| DDP hangs or gradients differ | Reducer hooks or stream ordering bypass ProcessGroupFlagOS | Run DDP with rank-wise gradient comparison and inspect device guards |
+| Tests pass only with one rank | Harness does not exercise communication | Require `world_size >= 2`, expected values, and rank synchronization |
+
+## Related
+
+[[runtime-bringup]] · [[torch-version-port]] · [[cuda-compat-vendor]] ·
+[[native-op-backend]] · [[pre-pr-checks]]

--- a/tests/manual/test_flagos_dist_live.py
+++ b/tests/manual/test_flagos_dist_live.py
@@ -12,32 +12,90 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Live multi-GPU test for ProcessGroupFlagOS (run on the 8xA100 box).
+"""Live multi-device test for ProcessGroupFlagOS.
 
-Launches N processes, each binding one flagos device, and exercises:
-  1. init_process_group("flagos")
-  2. all_reduce / broadcast / all_gather on flagos tensors
-  3. DistributedDataParallel forward/backward with the auto-patched hook
+Launches N processes, each binding one flagos device, and exercises the basic
+collective matrix plus DDP. By default it checks numerical results only. Use
+``--require-flagcx`` for a strict FlagCX run: native fallback is made fatal and
+the selected inner backend is asserted on every rank. Use ``--force-native``
+to validate the fallback path independently.
 
 Run:
     LD_LIBRARY_PATH=... python tests/manual/test_flagos_dist_live.py --world-size 2
+    ... python tests/manual/test_flagos_dist_live.py --require-flagcx
+    ... python tests/manual/test_flagos_dist_live.py --force-native
 """
 
 import argparse
 import os
+import sys
+
+if "--require-flagcx" in sys.argv:
+    os.environ["FLAGOS_REQUIRE_FLAGCX"] = "1"
+if "--force-native" in sys.argv:
+    os.environ["FLAGOS_FORCE_NATIVE"] = "1"
 
 # torch_fl MUST be imported before torch (preloads libtorch_cuda.so).
 import torch_fl  # noqa: F401
 import torch
 
 try:
-    import flagcx  # noqa: F401  self-registers "flagcx" backend (nvidia adaptor)
+    import flagcx  # noqa: F401  self-registers the "flagcx" backend
 except ImportError:
     flagcx = None
 import torch.distributed as dist
+import torch_fl.comm.process_group as _process_group
 import torch.multiprocessing as mp
 import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel
+
+
+_FORCE_NATIVE = False
+_REQUIRE_FLAGCX = False
+
+
+def _configure_selection_mode() -> None:
+    """Install fail-closed selection guards for the requested live mode."""
+    global _FORCE_NATIVE, _REQUIRE_FLAGCX
+    _FORCE_NATIVE = os.environ.get("FLAGOS_FORCE_NATIVE") == "1"
+    _REQUIRE_FLAGCX = os.environ.get("FLAGOS_REQUIRE_FLAGCX") == "1"
+
+    if _FORCE_NATIVE:
+        _process_group.ProcessGroupFlagOS._try_build_flagcx = lambda *args, **kwargs: (
+            False
+        )
+        return
+
+    if not _REQUIRE_FLAGCX:
+        return
+
+    original_flagcx_builder = _process_group.ProcessGroupFlagOS._try_build_flagcx
+
+    def require_flagcx(self, store, rank, world_size, timeout):
+        selected = original_flagcx_builder(self, store, rank, world_size, timeout)
+        if not selected:
+            raise AssertionError("FlagCX was unavailable or not selected")
+        return True
+
+    _process_group.ProcessGroupFlagOS._try_build_flagcx = require_flagcx
+    for native_name in ("_try_build_nccl", "_try_build_hccl", "_try_build_mccl"):
+        setattr(
+            _process_group.ProcessGroupFlagOS,
+            native_name,
+            lambda *args, _name=native_name, **kwargs: (_ for _ in ()).throw(
+                AssertionError(f"native fallback {_name} was selected")
+            ),
+        )
+
+
+_configure_selection_mode()
+
+
+def _assert_close(name: str, actual: torch.Tensor, expected: torch.Tensor) -> None:
+    if not torch.allclose(actual.cpu(), expected.cpu()):
+        raise AssertionError(
+            f"{name}: got {actual.cpu().tolist()}, expected {expected.cpu().tolist()}"
+        )
 
 
 def worker(rank: int, world_size: int):
@@ -45,7 +103,7 @@ def worker(rank: int, world_size: int):
     os.environ.setdefault("MASTER_PORT", "29531")
 
     dev = torch.device(f"flagos:{rank}")
-    torch.cuda.set_device(rank)  # flagos:i shares physical GPU i
+    torch.cuda.set_device(rank)  # flagos:i shares the physical device i
 
     dist.init_process_group(
         backend="flagos",
@@ -53,68 +111,74 @@ def worker(rank: int, world_size: int):
         world_size=world_size,
     )
 
+    pg = dist.distributed_c10d._get_default_group()
+    inner_backend = getattr(pg, "_inner_backend", None)
+    if _REQUIRE_FLAGCX and inner_backend != "flagcx":
+        raise AssertionError(f"rank {rank}: selected inner backend {inner_backend!r}")
+    if _FORCE_NATIVE and not str(inner_backend).startswith("native:"):
+        raise AssertionError(
+            f"rank {rank}: expected native fallback, got {inner_backend!r}"
+        )
+    print(f"[rank {rank}] selected inner backend: {inner_backend}")
+
     # --- all_reduce ---
     t = torch.ones(4, device=dev) * (rank + 1)
     dist.all_reduce(t, op=dist.ReduceOp.SUM)
     expected = sum(range(1, world_size + 1))
-    ok_ar = torch.allclose(t.cpu(), torch.full((4,), float(expected)))
-    print(
-        f"[rank {rank}] all_reduce -> {t[0].item()} (expect {expected}) {'OK' if ok_ar else 'FAIL'}"
-    )
+    _assert_close("all_reduce", t, torch.full((4,), float(expected)))
+    print(f"[rank {rank}] all_reduce -> {t[0].item()} (expect {expected}) OK")
 
     # --- broadcast ---
     b = torch.arange(4, device=dev, dtype=torch.float32) + rank * 10
     dist.broadcast(b, src=0)
-    ok_bc = torch.allclose(b.cpu(), torch.arange(4, dtype=torch.float32))
-    print(f"[rank {rank}] broadcast -> {b.tolist()} {'OK' if ok_bc else 'FAIL'}")
+    _assert_close("broadcast", b, torch.arange(4, dtype=torch.float32))
+    print(f"[rank {rank}] broadcast -> {b.tolist()} OK")
 
     # --- all_gather ---
     src = torch.ones(2, device=dev) * (rank + 1)
     gathered = [torch.zeros(2, device=dev) for _ in range(world_size)]
     dist.all_gather(gathered, src)
     vals = [g[0].item() for g in gathered]
-    ok_ag = vals == [float(i + 1) for i in range(world_size)]
-    print(f"[rank {rank}] all_gather -> {vals} {'OK' if ok_ag else 'FAIL'}")
+    expected_vals = [float(i + 1) for i in range(world_size)]
+    if vals != expected_vals:
+        raise AssertionError(f"all_gather: got {vals}, expected {expected_vals}")
+    print(f"[rank {rank}] all_gather -> {vals} OK")
 
     # --- all_gather_into_tensor (_allgather_base) ---
-    # Separate virtual from allgather(); the FSDP/ZeRO parameter-gather path.
     agb = torch.empty(world_size, device=dev)
     dist.all_gather_into_tensor(agb, torch.full((1,), float(rank), device=dev))
-    ok_agb = agb.cpu().tolist() == [float(i) for i in range(world_size)]
-    print(
-        f"[rank {rank}] all_gather_into_tensor -> {agb.cpu().tolist()} "
-        f"{'OK' if ok_agb else 'FAIL'}"
+    _assert_close(
+        "all_gather_into_tensor",
+        agb,
+        torch.arange(world_size, dtype=torch.float32),
     )
+    print(f"[rank {rank}] all_gather_into_tensor -> {agb.cpu().tolist()} OK")
 
     # --- reduce_scatter_tensor (_reduce_scatter_base) ---
-    # FSDP gradient-reduction path. Every rank contributes the same arange, so
-    # rank r's shard is world_size * arange[2r : 2r+2].
     rs_in = torch.arange(2 * world_size, dtype=torch.float32, device=dev)
     rs_out = torch.empty(2, device=dev)
     dist.reduce_scatter_tensor(rs_out, rs_in)
-    exp_rs = [float(world_size) * (2 * rank), float(world_size) * (2 * rank + 1)]
-    ok_rs = rs_out.cpu().tolist() == exp_rs
-    print(
-        f"[rank {rank}] reduce_scatter_tensor -> {rs_out.cpu().tolist()} "
-        f"(expect {exp_rs}) {'OK' if ok_rs else 'FAIL'}"
+    exp_rs = torch.tensor(
+        [float(world_size) * (2 * rank), float(world_size) * (2 * rank + 1)]
     )
+    _assert_close("reduce_scatter_tensor", rs_out, exp_rs)
+    print(f"[rank {rank}] reduce_scatter_tensor -> {rs_out.cpu().tolist()} OK")
 
     # --- DDP forward/backward ---
     torch.manual_seed(0)
     model = nn.Sequential(nn.Linear(8, 8), nn.ReLU(), nn.Linear(8, 1)).to(dev)
     ddp = DistributedDataParallel(model)
-    print(
-        f"[rank {rank}] DDP _use_python_reducer={ddp._use_python_reducer} "
-        f"hooks={len(ddp._accum_grad_hooks)}"
-    )
-
     x = torch.randn(16, 8, device=dev)
-    loss = ddp(x).sum()
-    loss.backward()
-    # grads should be identical across ranks after the all_reduce hook
+    ddp(x).sum().backward()
     g0 = next(ddp.parameters()).grad
     gsum = g0.sum().item()
-    print(f"[rank {rank}] DDP backward grad.sum={gsum:.4f} dev={g0.device}")
+    gsum_t = torch.tensor([gsum], device=dev)
+    all_gsum = [torch.zeros(1, device=dev) for _ in range(world_size)]
+    dist.all_gather(all_gsum, gsum_t)
+    grad_values = [value.item() for value in all_gsum]
+    if not all(abs(value - grad_values[0]) < 1e-4 for value in grad_values):
+        raise AssertionError(f"DDP gradients differ across ranks: {grad_values}")
+    print(f"[rank {rank}] DDP backward grad.sum={gsum:.4f} OK")
 
     dist.barrier()
     if rank == 0:
@@ -125,6 +189,16 @@ def worker(rank: int, world_size: int):
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--world-size", type=int, default=2)
+    ap.add_argument("--require-flagcx", action="store_true")
+    ap.add_argument("--force-native", action="store_true")
     args = ap.parse_args()
+    if args.require_flagcx and args.force_native:
+        ap.error("--require-flagcx and --force-native are mutually exclusive")
+    if args.world_size < 2:
+        ap.error("--world-size must be at least 2")
+    if args.require_flagcx:
+        os.environ["FLAGOS_REQUIRE_FLAGCX"] = "1"
+    if args.force_native:
+        os.environ["FLAGOS_FORCE_NATIVE"] = "1"
     mp.set_start_method("spawn", force=True)
     mp.spawn(worker, args=(args.world_size,), nprocs=args.world_size, join=True)

--- a/torch_fl/__init__.py
+++ b/torch_fl/__init__.py
@@ -1388,26 +1388,46 @@ def _patch_ddp_for_flagos():
             h.remove()
         self._accum_grad_hooks.clear()
 
-        def _accum_grad_hook(param, *, ddp_model=self):
-            if not ddp_model.require_backward_grad_sync:
-                return
-            if param.grad is None:
-                return
+        sync_params = [
+            param for param in self._module_parameters if param.requires_grad
+        ]
+        completed_params = set()
+
+        def _sync_completed_grads(ddp_model):
+            """Reduce all gradients in a deterministic order after backward.
+
+            A collective per post-accumulate hook is unsafe: XPU autograd can
+            finish parameters in different orders on different ranks, pairing
+            the all-reduces for different parameters. Waiting until every
+            parameter hook has fired and then using module order keeps the
+            collective sequence identical across ranks.
+            """
             pg = ddp_model.process_group
             if ddp_model._comm_hooks:
-                for hook, state in ddp_model._comm_hooks:
-                    hook(state, (param.grad, param))
+                for param in sync_params:
+                    for hook, state in ddp_model._comm_hooks:
+                        hook(state, (param.grad, param))
             else:
-                param.grad.div_(pg.size())
-                _dist.all_reduce(param.grad, op=_dist.ReduceOp.SUM, group=pg)
+                for param in sync_params:
+                    param.grad.div_(pg.size())
+                    _dist.all_reduce(param.grad, op=_dist.ReduceOp.SUM, group=pg)
 
-        for param in self._module_parameters:
-            if param.requires_grad:
-                self._accum_grad_hooks.append(
-                    param.register_post_accumulate_grad_hook(
-                        functools.partial(_accum_grad_hook, ddp_model=self)
-                    )
+        def _accum_grad_hook(param, *, ddp_model=self):
+            if param.grad is None:
+                return
+            completed_params.add(id(param))
+            if len(completed_params) != len(sync_params):
+                return
+            if ddp_model.require_backward_grad_sync:
+                _sync_completed_grads(ddp_model)
+            completed_params.clear()
+
+        for param in sync_params:
+            self._accum_grad_hooks.append(
+                param.register_post_accumulate_grad_hook(
+                    functools.partial(_accum_grad_hook, ddp_model=self)
                 )
+            )
 
     _DDP.__init__ = _patched_init
 

--- a/torch_fl/comm/process_group.py
+++ b/torch_fl/comm/process_group.py
@@ -284,6 +284,7 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
         super().__init__(rank, world_size)
         self._store = store
         self._timeout = timeout
+        self._inner_backend = None
         self._view_fn = self._build_inner(store, rank, world_size, timeout)
         self._register_inner_backend()
 
@@ -335,12 +336,14 @@ class ProcessGroupFlagOS(dist.ProcessGroup):
         # plain (store, rank, world_size) ctor, so we build the
         # _DistributedBackendOptions the same way c10d does.
         if self._try_build_flagcx(store, rank, world_size, timeout):
+            self._inner_backend = "flagcx"
             return self._resolve_view(prof, vendor, backend="flagcx")
 
         # --- Native vendor backend fallback (NCCL / HCCL) ---
         if prof.native is not None:
             native_fn = getattr(self, prof.native)
             if native_fn(store, rank, world_size, timeout):
+                self._inner_backend = f"native:{prof.native}"
                 return self._resolve_view(prof, vendor, backend="native")
 
         raise RuntimeError(


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code
- **Model**: Claude Opus 5
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Added a fail-closed FlagCX integration skill, made backend selection observable, fixed Kunlun multi-process validation blockers, and validated strict FlagCX and native fallback communication paths on P800.

## Summary
This PR adds the FlagCX integration skill and strengthens the live distributed validation harness so FlagCX selection cannot be confused with a native fallback. It records the selected inner backend in `ProcessGroupFlagOS`, adds strict FlagCX and forced-native modes, and validates collective results against CPU references. It also fixes the Kunlun DDP synchronization issue caused by per-parameter collectives being launched in rank-dependent autograd order, and documents the XPU CUPTI setting required for multi-process validation.

## Change Type
- [x] Bug Fix
- [x] New Feature
- [x] Documentation
- [x] Testing

## Platforms Affected
- [x] Platform-agnostic (all platforms)

Kunlun P800 hardware was used for live validation. The selection metadata and harness are generic; the XPU CUPTI workaround is documented as a measured Kunlun runtime condition.

## Problem Analysis
### What was broken/missing?

FlagCX integration could be imported and registered without proving that `ProcessGroupFlagOS` actually selected FlagCX. The live harness also accepted unchecked collective results and did not distinguish FlagCX from NCCL fallback. On Kunlun P800, strict multi-process runs failed during XPU CUPTI initialization before ProcessGroup construction. After that blocker was bypassed, DDP gradients differed across ranks.

### Why did it happen?

1. `ProcessGroupFlagOS` did not expose which inner backend it selected.
2. Native fallback remained a valid success path during a purported FlagCX test.
3. The harness only printed numerical results instead of raising on mismatches.
4. `XPU_CUPTI_ENABLE_DEVICE` enabled event sampling in each spawned process; the measured XPU-RT stack returned error 17 from `etiEventSamplingSetMode`.
5. The torch-fl DDP patch performed one collective from each parameter's post-accumulate hook. Kunlun autograd can complete parameters in different orders across ranks, so different ranks could issue collectives for different parameters at the same sequence position.

### Investigation process:
1. Read `torch_fl/comm/process_group.py`, `torch_fl/__init__.py`, and `tests/manual/test_flagos_dist_live.py` and traced backend selection, DDP hooks, and child-process startup.
2. Built FlagCX from `https://github.com/FlagOpen/FlagCX.git` with the Kunlun adaptor and verified import, creator registration, and the `flagcx` c10d backend.
3. Tested `XPU_CUPTI_ENABLE_DEVICE` values and reproduced error 17 with explicit device selection; leaving it unset allowed the live process to reach collectives.
4. Added temporary DDP diagnostics and observed rank-dependent gradient hook completion order and unsynchronized final gradients.
5. Changed DDP synchronization to wait for all gradients and reduce them in module parameter order, then reran strict and fallback matrices.

## Solution Design
### Implementation approach:

- Add `_inner_backend` to `ProcessGroupFlagOS` and set it to `flagcx` or `native:<builder>` during construction.
- Add strict and forced-fallback modes to the live harness.
- Make all collective and DDP checks fail closed with CPU-reference assertions.
- Synchronize DDP gradients only after all required parameter gradients are present, using deterministic module order.
- Document the measured Kunlun CUPTI behavior and use `unset XPU_CUPTI_ENABLE_DEVICE` in multi-process examples.
- Extend the skill to fetch and build FlagCX from GitHub when the package is absent.

### Key design decisions:

The strict harness uses mechanical backend-selection proof rather than inferring FlagCX from import success, registration, process-group construction, or collective success. The DDP fix preserves the existing Python reducer path but changes collective ordering to a deterministic sequence, avoiding rank-dependent autograd ordering. The CUPTI workaround is documented as an environment constraint rather than weakening the correctness test or suppressing a runtime failure inside torch-fl.

### Code changes by file:
- `.claude/skills/flagcx-integration/SKILL.md`: documented source fetching/building, fail-closed validation, strict/fallback commands, and Kunlun CUPTI guidance.
- `torch_fl/comm/process_group.py`: records the selected inner backend as `flagcx` or `native:<builder>`.
- `torch_fl/__init__.py`: makes FlagOS DDP gradient all-reduces deterministic across ranks.
- `tests/manual/test_flagos_dist_live.py`: adds strict FlagCX and forced-native modes, backend assertions, CPU-reference checks, DDP gradient checks, and world-size validation.

### Changes by commit:
1. `243dff9` - `feat: add fail-closed FlagCX validation`: adds the integration skill and validation/runtime changes described above.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (Python compilation used; no standalone type checker configured for this change)
- [x] **All relevant tests pass** (routing unit tests and live validation)
- [x] **Manual testing completed** (strict FlagCX and forced-native P800 matrices)
- [x] **No debug/temporary code** (temporary diagnostics were outside the repository)
- [x] **Documentation updated** (FlagCX skill)
- [x] **Commit messages follow conventions**
- [x] **All text in English**

### Linting Results
```text
$ ruff check .
All checks passed!

$ ruff format --check .
173 files already formatted
```

### Test Results
```text
$ pytest tests/unit/test_vendor_routing.py -q
23 passed in 2.58s

$ python -m compileall -q torch_fl tests
PASS
```

The repository's default conda interpreter does not contain torch, so the integration pytest was run with the vendor interpreter and explicit runtime environment. The result above is the actual vendor-environment output.

### Manual Verification
```text
# Strict FlagCX run
$ unset XPU_CUPTI_ENABLE_DEVICE
$ XPU_ENABLE_PROFILER_TRACING=1 ... /flagos/bin/python \
    tests/manual/test_flagos_dist_live.py --world-size 2 --require-flagcx

[rank 0] selected inner backend: flagcx
[rank 1] selected inner backend: flagcx
[rank 0] all_reduce -> 3.0 (expect 3) OK
[rank 1] all_reduce -> 3.0 (expect 3) OK
[rank 0] broadcast -> [0.0, 1.0, 2.0, 3.0] OK
[rank 1] broadcast -> [0.0, 1.0, 2.0, 3.0] OK
[rank 0] all_gather -> [1.0, 2.0] OK
[rank 1] all_gather -> [1.0, 2.0] OK
[rank 0] all_gather_into_tensor -> [0.0, 1.0] OK
[rank 1] all_gather_into_tensor -> [0.0, 1.0] OK
[rank 0] reduce_scatter_tensor -> [0.0, 2.0] OK
[rank 1] reduce_scatter_tensor -> [4.0, 6.0] OK
[rank 0] DDP backward grad.sum=-3.8292 OK
[rank 1] DDP backward grad.sum=-3.8292 OK
=== all collectives + DDP completed ===
exit=0

# Forced native fallback run
$ unset XPU_CUPTI_ENABLE_DEVICE
$ XPU_ENABLE_PROFILER_TRACING=1 ... /flagos/bin/python \
    tests/manual/test_flagos_dist_live.py --world-size 2 --force-native

[rank 0] selected inner backend: native:_try_build_nccl
[rank 1] selected inner backend: native:_try_build_nccl
=== all collectives + DDP completed ===
exit=0
```

## Code Quality Verification
### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions
- [x] Comment density matches surrounding code
- [x] Used existing ProcessGroup and DDP utilities

### Edge Cases Considered
1. Strict FlagCX construction failure or missing package is fatal.
2. Native fallback selection is fatal in strict mode and explicitly asserted in fallback mode.
3. World size below two is rejected.
4. Collective numerical mismatches and cross-rank DDP gradient mismatches return nonzero.
5. Explicit CUPTI device selection and an unset CUPTI device selection were tested.

### Potential Risks
1. The deterministic post-accumulate synchronization waits for all required gradients and may serialize DDP communication more than the stock implementation.
2. Vendor-specific DDP behavior beyond the tested Kunlun/P800 Python-reducer path remains outside this live evidence.

### Rollback Plan
Revert the commit. The previous DDP hook behavior and live harness can be restored independently, while the FlagCX skill and backend diagnostic metadata can also be removed without changing the public distributed API.

## Related Work
- Related to FlagCX source integration and Kunlun P800 distributed validation.
- Depends on the existing `ProcessGroupFlagOS` FlagCX-first routing implementation.

## Explicitly Not Included
- Multi-node FlagCX validation.
- Point-to-point, FSDP2, failure recovery, or performance claims.
- Changes to vendor runtimes, drivers, XPU SDKs, or FlagCX source repositories.
- Changes to operator-support measurements, since no operator routing was changed.

## Human Review Notes
### Areas needing special attention:
1. Review the DDP hook ordering change in `torch_fl/__init__.py` for interaction with custom communication hooks and multiple backward passes.
2. Review the strict harness's monkeypatching and backend metadata as validation-only mechanisms.
3. Review the FlagCX source build instructions and Kunlun-specific CUPTI guidance.

### Questions for reviewer:
1. Should deterministic all-gradient synchronization remain the default for all PrivateUse1 DDP vendors, or should a vendor capability gate be added later?
2. Should `_inner_backend` become a formally supported diagnostic API or remain an internal validation field?

## Additional Context

The FlagCX source was fetched and built from GitHub because no matching package was initially installed. The Kunlun build required staged BKCL headers/library and the `default_dev_api_backend.cc` source. The successful strict run proves FlagCX selection and the tested two-rank collective/DDP scope, but does not claim broader distributed capabilities.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
