### PR TITLE
fix: restore aten::narrow autograd on PrivateUse1

### DIFF
--- a/csrc/aten/register.cc
+++ b/csrc/aten/register.cc
@@ -549,6 +549,25 @@ TORCH_LIBRARY_IMPL(aten, AutogradPrivateUse1, m) {
     return self.clone(memory_format);
   });
 
+  // narrow: same shape of problem as contiguous. aten::narrow is
+  // CompositeImplicitAutograd upstream, and the dispatcher only falls back to
+  // that math kernel for an autograd key when the matching backend slot is
+  // empty. Claiming `narrow` on PrivateUse1 above fills that slot, so
+  // AutogradPrivateUse1 stopped resolving to the composite and landed on
+  // torchgen's Autograd[alias] stub -- "derivative for aten::narrow is not
+  // implemented" -- as soon as the input required grad. The forward view still
+  // worked, so only backward regressed (flagos-ai/Torch-FL#205).
+  //
+  // The same WrapperNarrow body run one key higher fixes it: narrow_symint
+  // normalizes the bounds and calls at::slice_symint, a *dispatched* call that
+  // re-enters autograd from here and records SliceBackward0 -- exactly the graph
+  // PyTorch's composite builds, and the reason `x[:, 1:4]` never had this
+  // problem. slice_backward is itself differentiable, so double backward works.
+  //
+  // No AutoDispatchBelowADInplaceOrView guard here: the inner slice must keep
+  // its ADInplaceOrView kernel so the result carries proper view metadata.
+  m.impl("narrow", WrapperNarrow);
+
   // matmul: on Ascend the fused aclnnMatmul kernel is claimed on plain
   // PrivateUse1 (above), and the generated AutogradPrivateUse1 kernel
   // (csrc/aten/generated/variable_type.cc) sits in front of it to build the

--- a/tests/integration/ops/test_narrow_dispatch.py
+++ b/tests/integration/ops/test_narrow_dispatch.py
@@ -72,6 +72,111 @@ class TestNarrowCorrectness:
         )
 
 
+class TestNarrowAutograd:
+    """narrow must stay differentiable (flagos-ai/Torch-FL#205).
+
+    Claiming ``narrow`` on PrivateUse1 fills the backend slot that the
+    CompositeImplicitAutograd fallback checks, so ``AutogradPrivateUse1`` stopped
+    decomposing it and hit torchgen's "derivative for aten::narrow is not
+    implemented" stub. Forward still worked, so only backward regressed. The
+    AutogradPrivateUse1 registration re-runs the composite above autograd, which
+    records SliceBackward0 through the dispatched ``at::slice`` inside.
+    """
+
+    @pytest.mark.anyplatform
+    def test_narrow_backward(self):
+        x_cpu = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+        x_fl = x_cpu.to(DEVICE).detach().requires_grad_(True)
+        x_ref = x_cpu.clone().detach().requires_grad_(True)
+
+        torch.narrow(x_fl, 1, 1, 3).square().sum().backward()
+        torch.narrow(x_ref, 1, 1, 3).square().sum().backward()
+
+        assert x_fl.grad is not None
+        torch.testing.assert_close(x_fl.grad.cpu(), x_ref.grad)
+
+    @pytest.mark.anyplatform
+    def test_narrow_backward_records_grad_fn(self):
+        x = torch.randn(4, 8, device=DEVICE, requires_grad=True)
+        y = torch.narrow(x, 1, 1, 5)
+        # The composite decomposes to slice, so the recorded node is SliceBackward0
+        # -- the same one x[:, 1:6] produces.
+        assert y.grad_fn is not None
+        assert y.requires_grad
+
+    @pytest.mark.anyplatform
+    @pytest.mark.parametrize(
+        "dim,start,length",
+        [
+            (-1, 1, 5),  # negative dim
+            (1, -3, 2),  # negative start counts from the end
+            (1, 2, 0),  # zero length
+            (0, 0, 4),  # full length along dim 0
+        ],
+    )
+    def test_narrow_backward_edge_cases(self, dim, start, length):
+        torch.manual_seed(0)
+        base = torch.randn(4, 8)
+        x_fl = base.to(DEVICE).detach().requires_grad_(True)
+        x_ref = base.clone().detach().requires_grad_(True)
+
+        torch.narrow(x_fl, dim, start, length).square().sum().backward()
+        torch.narrow(x_ref, dim, start, length).square().sum().backward()
+
+        torch.testing.assert_close(x_fl.grad.cpu(), x_ref.grad)
+
+    @pytest.mark.anyplatform
+    def test_narrow_backward_non_contiguous(self):
+        torch.manual_seed(0)
+        base = torch.randn(4, 8)
+        x_fl = base.to(DEVICE).detach().requires_grad_(True)
+        x_ref = base.clone().detach().requires_grad_(True)
+
+        torch.narrow(x_fl.t(), 0, 1, 5).square().sum().backward()
+        torch.narrow(x_ref.t(), 0, 1, 5).square().sum().backward()
+
+        torch.testing.assert_close(x_fl.grad.cpu(), x_ref.grad)
+
+    @pytest.mark.anyplatform
+    def test_narrow_second_order_grad(self):
+        # slice_backward is itself differentiable, so double backward must work.
+        torch.manual_seed(0)
+        base = torch.randn(4, 8)
+        x_fl = base.to(DEVICE).detach().requires_grad_(True)
+        x_ref = base.clone().detach().requires_grad_(True)
+
+        def double_grad(x):
+            (g,) = torch.autograd.grad(
+                torch.narrow(x, 1, 1, 5).pow(3).sum(), x, create_graph=True
+            )
+            return torch.autograd.grad(g.sum(), x)[0]
+
+        torch.testing.assert_close(double_grad(x_fl).cpu(), double_grad(x_ref))
+
+    @pytest.mark.anyplatform
+    def test_narrow_matches_slice_backward(self):
+        # The `slice` control from the issue: both must produce the same grad.
+        torch.manual_seed(0)
+        base = torch.randn(4, 6)
+        x_narrow = base.to(DEVICE).detach().requires_grad_(True)
+        x_slice = base.to(DEVICE).detach().requires_grad_(True)
+
+        torch.narrow(x_narrow, 1, 1, 3).square().sum().backward()
+        x_slice[:, 1:4].square().sum().backward()
+
+        torch.testing.assert_close(x_narrow.grad.cpu(), x_slice.grad.cpu())
+
+    @pytest.mark.anyplatform
+    def test_narrow_no_grad_still_forward_only(self):
+        # The ESM-2 backward trace hits narrow with requires_grad=False; that path
+        # must stay a plain view with no grad_fn.
+        x = torch.arange(24, dtype=torch.float32, device=DEVICE).reshape(4, 6)
+        y = torch.narrow(x, 1, 1, 3)
+        assert y.grad_fn is None
+        assert not y.requires_grad
+        torch.testing.assert_close(y.cpu(), torch.narrow(x.cpu(), 1, 1, 3))
+
+
 class TestDiffCorrectness:
     """torch.diff decomposes into narrow; must not segfault."""
 


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @lvyufeng
- **Session Summary**: The user asked to update to latest `main` and fix issue #205 (`aten::narrow` backward failing on flagos). I diagnosed the dispatcher-level root cause, applied a one-line registration fix, and extended the existing regression test file with autograd coverage.

## Summary
`torch.narrow` on a `flagos` tensor that requires grad succeeded in forward but raised
`RuntimeError: derivative for aten::narrow is not implemented` during `backward()`, while
the equivalent `x[:, 1:4]` slice worked. The cause is a dispatcher interaction: claiming
`narrow` on `PrivateUse1` fills the backend slot that PyTorch's `CompositeImplicitAutograd`
fallback checks, so `AutogradPrivateUse1` stopped resolving to the composite and landed on
torchgen's `Autograd[alias]` stub instead. Registering the same wrapper on
`AutogradPrivateUse1` runs the composite body one key higher, restoring the
`SliceBackward0` graph PyTorch builds natively. This unblocks training models that call
`Tensor.narrow()` on differentiable activations in forward.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [x] Platform-agnostic (all platforms)

The fix is in the shared `PrivateUse1`/`AutogradPrivateUse1` registration in
`csrc/aten/register.cc`, with no vendor-specific code path and no vendor kernel involved, so
every platform gets it. It was reproduced and verified on Hygon DCU, which is where the
issue was filed.

## Problem Analysis

### What was broken/missing?
`aten::narrow` had no working derivative on `AutogradPrivateUse1`. Forward produced a correct
view, but as soon as the input required grad, `backward()` raised:

```text
RuntimeError: derivative for aten::narrow is not implemented
```

`tests/integration/ops/test_narrow_dispatch.py` covered forward semantics and `torch.diff`
only, so no test caught it.

### Why did it happen?
`aten::narrow` is `CompositeImplicitAutograd` upstream. The dispatcher only falls back to
that math kernel for an autograd key **when the matching backend slot is empty**.
`csrc/aten/register.cc` claims `narrow` on `PrivateUse1` (added in 7603af6, so the view has
a concrete stride kernel rather than an uninitialized tensor), which fills that slot. With
`AutogradPrivateUse1` registered as a fallthrough, dispatch for a grad-requiring input
therefore resolved to torchgen's `Autograd[alias]` "derivative not implemented" stub instead
of the composite decomposition.

Two observations from the issue confirm this reading:
- `x[:, 1:4]` worked, because `aten::slice.Tensor` has a real derivative formula
  (`SliceBackward0`) rather than relying on a composite decomposition.
- `narrow` inside backward with `requires_grad=False` worked, because no derivative of
  `narrow` was ever requested.

### Investigation process
1. Fetched `flagos/main` and fast-forwarded local `main` to `b609f97`, then branched
   `fix/narrow-autograd`. The issue reported reproducing against `4b950cf` and inspecting
   `b3e7c96`; the registration and forward-only coverage were unchanged. The branch was
   later rebased onto `be73add` (#211, backend copy paths) and rebuilt and re-verified there,
   since that PR touches adjacent code.
2. Read `csrc/aten/register.cc:438` (`m.impl("narrow", WrapperNarrow)`) and
   `csrc/aten/strided_ops.cc:67` (`at::native::narrow_symint`), plus the pre-existing
   `AutogradPrivateUse1` block at the bottom of `register.cc`, which already carries a
   `contiguous` registration fixing the exact same class of bug (`grad_fn=None` because
   `PrivateUse1` bypassed autograd recording).
3. Dumped the dispatch table to confirm the mechanism rather than infer it:
   ```text
   $ python -c "import torch; print(torch._C._dispatch_dump('aten::narrow'))"
   Autograd[alias]: registered at .../VariableType_0.cpp:18919 :: (none) [ boxed ]
   CompositeImplicitAutograd[alias]: registered at .../RegisterCompositeImplicitAutograd_0.cpp:7401
   ```
   With `torch_fl` imported, `PrivateUse1` was occupied and no `AutogradPrivateUse1` entry
   existed, so `Autograd[alias]` won.
4. Reproduced the failure with the issue's exact snippet, and confirmed the contrast with a
   control op: `torch.split` (also `CompositeImplicitAutograd`, but **not** claimed on
   `PrivateUse1`) backward succeeded in the same process. This isolated the claimed-slot
   mechanism from any DCU-specific problem.
5. Hypothesis tested and rejected: adding a generated `AutogradPrivateUse1` kernel via
   `scripts/codegen_autograd.py` (the `matmul`/Ascend approach). That machinery exists to
   let a *fused backend kernel* run while autograd records a graph, and it binds a
   `*_backward` op. `narrow` has no fused kernel and no `narrow_backward` op to bind, so a
   plain re-dispatch of the composite is both correct and far smaller.

## Solution Design

### Implementation approach
Register the existing `WrapperNarrow` on `AutogradPrivateUse1` in addition to `PrivateUse1`.
Running the same body one key higher means `at::native::narrow_symint` normalizes the bounds
and calls `at::slice_symint` — a *dispatched* call that re-enters autograd from above and
records `SliceBackward0`. That is exactly the graph PyTorch's own composite builds, and the
reason the `slice` spelling never had this problem.

### Key design decisions
- **Reuse the same wrapper on both keys, not a second function.** My first draft added a
  separate `narrow_autograd` in `strided_ops.cc`/`.h`, but the body was byte-identical to
  `narrow`. The distinction is which dispatch key it is registered on, not what it computes,
  so a duplicate function was noise. Final diff touches one file.
- **No `AutoDispatchBelowADInplaceOrView` guard.** The inner `at::slice` must keep its
  `ADInplaceOrView` kernel so the returned view carries correct view metadata. Guarding here
  would strip that.
- **Placed next to the existing `contiguous` registration**, which fixed the same class of
  bug, with a comment explaining the shared mechanism so the next person hitting this on a
  different composite op finds the reasoning.
- **Second-order gradients come for free**: `slice_backward` is itself differentiable, so no
  extra work was needed — but it is tested rather than assumed.
- **Rejected** decomposing to an explicit `at::slice` call in the wrapper: `narrow_symint`
  already does exactly that, including the negative-`start` and bounds normalization, so
  reimplementing it would duplicate upstream logic that can drift.

### Code changes by file
- `csrc/aten/register.cc` (lines 541-559, inside `TORCH_LIBRARY_IMPL(aten, AutogradPrivateUse1, m)`):
  added `m.impl("narrow", WrapperNarrow);` with a comment explaining why the composite
  fallback stopped applying and why re-dispatching above autograd restores it.
- `tests/integration/ops/test_narrow_dispatch.py` (new `TestNarrowAutograd` class, 105 lines):
  autograd regression coverage; the file's existing forward and `torch.diff` tests are
  unchanged.

### Changes by commit
1. `e7f3651` - `fix: restore aten::narrow autograd on PrivateUse1`: the registration fix and
   its regression tests, kept as a single commit since the test is meaningless without the
   fix and vice versa.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (if applicable) — no Python type checker configured in this repo
- [x] **All tests pass** (unit + integration)
- [x] **Manual testing completed** (include reproduction of original issue)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [x] **Documentation updated** — no doc change required; see "Explicitly Not Included"
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ ruff check
All checks passed!

$ ruff format --check
200 files already formatted
```

### Test Results
```bash
# Command:
ACCELERATOR=dcu FLAGGEMS_PYTHON=0 pytest tests/integration/ops/test_narrow_dispatch.py -v

# Output:
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-9.1.0, pluggy-1.6.0 -- /usr/bin/python3
collecting ... collected 17 items

tests/integration/ops/test_narrow_dispatch.py::TestNarrowCorrectness::test_narrow_basic PASSED [  5%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowCorrectness::test_narrow_negative_dim PASSED [ 11%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowCorrectness::test_narrow_full_length PASSED [ 17%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowCorrectness::test_narrow_matches_cpu_2d PASSED [ 23%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_backward PASSED [ 29%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_backward_records_grad_fn PASSED [ 35%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_backward_edge_cases[-1-1-5] PASSED [ 41%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_backward_edge_cases[1--3-2] PASSED [ 47%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_backward_edge_cases[1-2-0] PASSED [ 52%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_backward_edge_cases[0-0-4] PASSED [ 58%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_backward_non_contiguous PASSED [ 64%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_second_order_grad PASSED [ 70%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_matches_slice_backward PASSED [ 76%]
tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_no_grad_still_forward_only PASSED [ 82%]
tests/integration/ops/test_narrow_dispatch.py::TestDiffCorrectness::test_diff_basic PASSED [ 88%]
tests/integration/ops/test_narrow_dispatch.py::TestDiffCorrectness::test_diff_with_prepend PASSED [ 94%]
tests/integration/ops/test_narrow_dispatch.py::TestDiffCorrectness::test_diff_then_cumsum PASSED [100%]

============================== 17 passed in 0.32s ==============================
```

Regression sweep on neighbouring op suites, each run **both** against the pre-fix installed
build and the post-fix build. Failure counts are identical on both sides, so these are
baseline, not regressions:

| Test file | Before fix | After fix |
|---|---|---|
| `test_cat_dispatch.py` | 1 failed, 34 passed, 3 skipped | 1 failed, 34 passed, 3 skipped |
| `test_bmm_dispatch.py` | 2 failed, 10 passed, 5 skipped | 2 failed, 10 passed, 5 skipped |
| `test_embedding_dense_backward_dispatch.py` | 1 failed, 4 passed, 1 skipped | 1 failed, 4 passed, 1 skipped |
| `test_constant_pad_nd_dispatch.py` | 1 failed, 7 passed, 1 skipped | 1 failed, 7 passed, 1 skipped |

The unit suite behaves the same way — identical before and after:

```bash
$ ACCELERATOR=dcu FLAGGEMS_PYTHON=0 pytest tests/unit/ -q
4 failed, 174 passed, 31 skipped, 61 warnings in 34.52s

FAILED tests/unit/bpu/test_x86_env.py::test_env_carries_library_path_and_stubs
FAILED tests/unit/test_compile_platform_profile.py::test_benchmarker_patch_translates_triton_device_name
FAILED tests/unit/test_compile_platform_profile.py::test_publish_on_device_module_is_a_noop_without_cpp_wrapper
FAILED tests/unit/test_profiler_privateuse1.py::test_guard_stream_is_real_not_synthetic
```

The same 4 fail on the pre-fix build (`4 failed, 174 passed, 31 skipped`). They concern BPU
x86 env stubs, torch.compile platform profiles and the profiler stream guard — none touch
`narrow` or view autograd.

The op-suite failures are a pre-existing DCU interpreter-teardown abort (`double free or
corruption (!prev)`, subprocess exit -6/139). Verified unrelated to `narrow`: the failing
`test_dispatch_log_cuda_override` assertion content actually succeeds
(`[flagos dispatch] cat -> cuda` is logged and `torch.cat` returns the right shape); the
process only aborts at exit. The same snippet crashes identically on the pre-fix build.

### Manual Verification
```bash
# Command to reproduce original issue (verbatim from the issue report):
ACCELERATOR=dcu FLAGGEMS_PYTHON=0 python repro.py
#   x = torch.arange(24, dtype=torch.float32, device="flagos").reshape(4, 6)
#         .detach().requires_grad_(True)
#   y = torch.narrow(x, dim=1, start=1, length=3)
#   y.square().sum().backward()

# Output BEFORE fix:
forward ok: (4, 3) flagos:0
BACKWARD FAILED: RuntimeError derivative for aten::narrow is not implemented

# Output AFTER fix:
forward ok: (4, 3) flagos:0
backward ok
 tensor([[ 0.,  2.,  4.,  6.,  0.,  0.],
        [ 0., 14., 16., 18.,  0.,  0.],
        [ 0., 26., 28., 30.,  0.,  0.],
        [ 0., 38., 40., 42.,  0.,  0.]])
```

This matches the "Expected gradient" in the issue exactly, including the zero columns
outside the narrowed range.

Dispatch table after the fix confirms `AutogradPrivateUse1` now wins over the stub:

```text
PrivateUse1: registered at csrc/aten/register.cc:422 :: (Tensor _0, int _1, int _2, int _3) -> Tensor _0
AutogradPrivateUse1: registered at csrc/aten/register.cc:541 :: (Tensor _0, int _1, int _2, int _3) -> Tensor _0
Autograd[alias]: registered at .../VariableType_0.cpp:18919 :: (none) [ boxed ]
```

**Test environment**: Hygon DCU, DTK 26.04, HIP 6.3.26113,
`torch 2.10.0+das.opt1.dtk2604.2606151054.g98b1a8`, Python 3.10.12, `ACCELERATOR=dcu`,
`FLAGGEMS_PYTHON=0 FLAGGEMS_KERNEL=0 CUDA_KERNEL=0`, pure boxing via
`torch_fl/configs/backends_cuda.conf` — the same configuration as the issue report.

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (no reinventing)

The registration sits in the existing `TORCH_LIBRARY_IMPL(aten, AutogradPrivateUse1, m)`
block and reuses the already-defined `WrapperNarrow`. The explanatory comment matches the
density of the neighbouring `contiguous` and `matmul` comments in that block, which document
the same dispatch-key reasoning.

### Edge Cases Considered
1. **Negative `dim`** (`dim=-1`) — gradient compared against CPU.
2. **Negative `start`** (`start=-3`, counts from the end) — `narrow_symint` normalizes it
   before slicing; gradient compared against CPU.
3. **Zero `length`** — empty output must still backward cleanly and leave an all-zero grad.
4. **Full length along a dim** — the degenerate no-op narrow that triggered the earlier
   recursion bug in this same op.
5. **Non-contiguous input** (`narrow(x.t(), ...)`) — the view composes with a transposed
   base and the gradient must land on the original layout.
6. **Second-order gradients** — `create_graph=True` then a second `autograd.grad`, verifying
   `slice_backward` is itself differentiable.
7. **`requires_grad=False`** — the ESM-2 backward-trace case from the issue; must remain a
   plain view with `grad_fn is None` and must not start recording a graph.
8. **Parity with the `slice` spelling** — `narrow(x, 1, 1, 3)` and `x[:, 1:4]` must produce
   identical gradients, which is the invariant the fix relies on.

### Potential Risks
1. **Extra dispatcher hop for `narrow`.** Grad-requiring calls now pass through
   `AutogradPrivateUse1` before reaching the stride kernel. `narrow` is pure metadata, so
   this is a small constant CPU overhead with no device work; the inference path
   (`requires_grad=False`) is unchanged in behaviour and is covered by
   `test_narrow_no_grad_still_forward_only`.
2. **`narrow` now records a graph where it previously raised.** Any caller that relied on the
   exception (unlikely, but it was the observable behaviour) would change. Matching CPU and
   CUDA semantics is the intended outcome.
3. **Only exercised on DCU.** The change is platform-agnostic C++ with no vendor branch, but
   I could not run it on Ascend, MetaX, GCU, MUSA, PPU or NVIDIA CUDA hardware in this
   session. Ascend is worth a reviewer's attention because it routes `slice.Tensor` through
   its own backend (`backends_ascend.conf`) rather than a generic boxing kernel, so the
   decomposition target there is a vendor kernel rather than a CUDA-boxed one.

### Rollback Plan
Revert `e7f3651`, or delete the single `m.impl("narrow", WrapperNarrow);` line from the
`AutogradPrivateUse1` block in `csrc/aten/register.cc` and rebuild. Behaviour returns
exactly to today's: `narrow` forward works, `narrow` backward raises. No data format, ABI,
config file or generated artifact is touched, so there is no migration or state to unwind.

## Related Work
- Fixes flagos-ai/Torch-FL#205
- Related to 7603af6 (`Migrate CUDA backend to schema codegen`), which introduced the
  `PrivateUse1` `narrow` registration that inadvertently displaced the composite fallback
- Related to the existing `contiguous` `AutogradPrivateUse1` registration in the same block,
  which fixed the same class of bug for a different op

## Explicitly Not Included
- **A codegen-based `AutogradPrivateUse1` kernel** via `scripts/codegen_autograd.py`. That
  path exists so a *fused backend kernel* can run while autograd records a graph, and it
  binds a `*_backward` op. `narrow` has neither, so re-dispatching the composite is the
  correct and much smaller fix.
- **An audit of every other `CompositeImplicitAutograd` op claimed on `PrivateUse1`.** The
  same mechanism could in principle affect others, but sweeping the whole registration
  surface is out of scope for this bug fix and deserves its own issue. `torch.split`,
  `torch.diff` and the `slice` family were checked in passing and are fine — `split` is not
  claimed on `PrivateUse1`, and `slice` has a real derivative formula.
- **`docs/reference/operator-support.md` update and a `flaggems_overload_survey.py` rerun.**
  CLAUDE.md requires those when a change adds, enables, removes, disables or reroutes an
  operator through a vendor-native backend or FlagGems. This change does none of those: it
  adds an autograd-key registration for an op that was already claimed on `PrivateUse1`, and
  the routing configuration and FlagGems coverage are untouched. Happy to add a note if the
  maintainer reads the policy as covering autograd registrations too.
- **The pre-existing DCU teardown abort** (`double free or corruption`) surfaced by the
  regression sweep. It is unrelated to `narrow`, reproduces on unmodified `main`, and needs
  its own investigation.
- **`narrow.Tensor` and `narrow_copy`.** `narrow.Tensor` is not claimed on `PrivateUse1`
  (its only kernel is the `CompositeImplicitAutograd` one), so it was never affected;
  `narrow_copy` is a normal non-view op with its own derivative.

## Human Review Notes

### Areas needing special attention
1. **Whether re-dispatching the composite above autograd is the house style here**, versus
   generating a proper `VariableType` kernel. I followed the precedent set by the
   `contiguous` registration a few lines above, but the `matmul` comment in the same block
   documents the codegen approach for a different situation, so it is worth confirming I
   picked the right one of the two.
2. **Ascend behaviour.** Ascend routes `slice.Tensor` to a vendor kernel via
   `backends_ascend.conf`, so the decomposition lands somewhere different than on the
   CUDA-boxing platforms. I could not test it. `csrc/aten/backends/ascend/split.cc` builds
   its views from `at::narrow`, which is the path most likely to notice a change.
3. **The absence of an `AutoDispatchBelowADInplaceOrView` guard**, which is deliberate so
   the inner `slice` keeps its view metadata, but is the kind of thing worth a second pair
   of eyes since guards are common in this area of code.

### Questions for reviewer
1. Should I file a follow-up issue to audit the other `CompositeImplicitAutograd` ops
   claimed on `PrivateUse1` for the same displaced-fallback problem? I suspect `narrow` is
   not the only one, and a systematic check would be more valuable than fixing them as they
   are reported.
2. Does the `docs/reference/operator-support.md` policy apply to an autograd-key
   registration like this? I read it as not applying, since no vendor-native or FlagGems
   route changes, but I would rather confirm than skip it silently.

## Additional Context
The issue reporter's diagnosis was essentially correct — they identified the
`m.impl("narrow", WrapperNarrow)` registration and the missing `AutogradPrivateUse1`
derivative, and suggested preserving or decomposing through the differentiable `slice` path.
This PR implements that suggested direction; the dispatch-table dump above is the mechanism
that explains why the composite stopped being reached. Their regression test sketch and
every additional case they listed (negative `dim`, negative `start`, zero `length`,
non-contiguous input, second-order gradients, CPU parity) are covered in `TestNarrowAutograd`.

CPU parity is asserted directly in the tests. Parity against DAS PyTorch CUDA/HIP is covered
transitively: the issue shows the DAS `cuda` path producing the same gradient this fix now
produces on `flagos`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
