### PR TITLE
fix: satisfy Ascend MSPTI process-start requirement in the environment

### DIFF
--- a/.github/configs/ascend.yml
+++ b/.github/configs/ascend.yml
@@ -119,10 +119,12 @@ integration_tests:
   # Byte-identical to every other platform's profiler step. Ascend's extra
   # prerequisite -- the process-start libmspti.so that CANN 9.0 needs for
   # aclrtMemcpy*/aclrtMemset* interposition, which a later dlopen cannot supply
-  # -- is established by set_env_ascend.sh alongside every other Ascend
-  # environment prerequisite, so no vendor detail leaks into the test command.
-  # See docs/architecture/profiler.md.
+  # -- is attached as data to this process by the common integration runner, so
+  # no vendor detail leaks into the command and unrelated Ascend processes do
+  # not inherit CANN 9.0's unstable interposer. See docs/architecture/profiler.md.
   - name: Unified profiler contract
+    environment:
+      LD_PRELOAD: ${ASCEND_MSPTI_PRELOAD}
     command: >-
       python -m pytest tests/integration/test_profiler_contract.py
       -v -m profiler --tb=short

--- a/.github/configs/ascend.yml
+++ b/.github/configs/ascend.yml
@@ -116,6 +116,12 @@ integration_tests:
       python -m pytest tests/integration/test_math_bits_contract.py
       -v -m math_bits --tb=short
 
+  # Byte-identical to every other platform's profiler step. Ascend's extra
+  # prerequisite -- the process-start libmspti.so that CANN 9.0 needs for
+  # aclrtMemcpy*/aclrtMemset* interposition, which a later dlopen cannot supply
+  # -- is established by set_env_ascend.sh alongside every other Ascend
+  # environment prerequisite, so no vendor detail leaks into the test command.
+  # See docs/architecture/profiler.md.
   - name: Unified profiler contract
     command: >-
       python -m pytest tests/integration/test_profiler_contract.py
@@ -123,6 +129,11 @@ integration_tests:
 
   # Device-only contract cases skip through profiler capabilities while the
   # Ascend tracer exposes CPU/Trace records only. CPU/API coverage still runs.
+  # Memset stays off even with MSPTI loaded: torch.zeros() -- the only zeroing
+  # op reachable from the shared profile_result() workload -- routes through the
+  # aclnnInplaceZero kernel, not the allocator's aclrtMemset calls, because that
+  # kernel was measured far faster (12.7us vs 133us at 1 MiB on 910). The
+  # missing gpu_memset record is a consequence of that routing choice.
   # ---------------------------------------------------------------------------
   # Follow-up (not part of first-version acceptance). Tracked here so the
   # upstream gaps not yet covered by CI are not lost:

--- a/.github/scripts/run_integration_tests.py
+++ b/.github/scripts/run_integration_tests.py
@@ -42,6 +42,7 @@ def load_configuration(allow_empty):
             raise SystemExit(f"integration_tests[{index}] must be an object")
         name = test.get("name")
         command = test.get("command")
+        test_environment = test.get("environment", {})
         if (
             not isinstance(name, str)
             or not name.strip()
@@ -55,23 +56,32 @@ def load_configuration(allow_empty):
             raise SystemExit(
                 f"integration_tests[{index}].command must be a non-empty string"
             )
+        validate_environment(
+            test_environment,
+            f"integration_tests[{index}].environment",
+        )
 
+    validate_environment(environment, "integration_environment")
+
+    return tests, environment
+
+
+def validate_environment(environment, field_name):
+    """Validate one integration-test environment mapping."""
     if not isinstance(environment, dict):
-        raise SystemExit("integration_environment must be an object")
+        raise SystemExit(f"{field_name} must be an object")
     for key, value in environment.items():
         if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
-            raise SystemExit(f"invalid environment variable name: {key}")
+            raise SystemExit(
+                f"invalid environment variable name in {field_name}: {key}"
+            )
         if (
             not isinstance(value, str)
             or "\n" in value
             or "\r" in value
             or "\0" in value
         ):
-            raise SystemExit(
-                f"integration_environment[{key}] must be a single-line string"
-            )
-
-    return tests, environment
+            raise SystemExit(f"{field_name}[{key}] must be a single-line string")
 
 
 def main():
@@ -91,10 +101,13 @@ def main():
             f"===== [{index}/{len(tests)}] {test['name']} =====",
             flush=True,
         )
+        test_environment = command_environment.copy()
+        for key, value in test.get("environment", {}).items():
+            test_environment[key] = os.path.expandvars(value)
         result = subprocess.run(
             ["bash", "-c", f"set -euo pipefail\n{test['command']}"],
             check=False,
-            env=command_environment,
+            env=test_environment,
             cwd=workdir,
         )
         if result.returncode:

--- a/.github/scripts/set_env_ascend.sh
+++ b/.github/scripts/set_env_ascend.sh
@@ -135,24 +135,24 @@ export LD_LIBRARY_PATH="$ASCEND_HOME/lib64:$ASCEND_HOME/acllib/lib64${DRIVER_LIB
 # still yields zero memcpy/memset records, while a process-start preload yields
 # real ones. Kernel and runtime activities are unaffected either way.
 #
-# This belongs here, next to every other Ascend prerequisite (CPATH,
-# LD_LIBRARY_PATH, the driver HAL paths), rather than on the profiler test
-# command: the profiler contract is then invoked with the exact same command on
-# every platform, and no CI step has to know a vendor-specific incantation.
-# libmspti.so is inert until a profiler session subscribes, so carrying it for
-# the whole job costs nothing observable.
+# Do NOT export this as LD_PRELOAD for the whole Ascend job. CANN 9.0's
+# interposer is not inert for ordinary operator processes: CI observed sporadic
+# SIGSEGV exits in add, embedding, le, mean, and mm subprocesses when every
+# process inherited it. Keep the prepared value under an inert variable; the
+# integration runner applies it only to the profiler contract process through
+# that test's `environment` mapping. The visible pytest command remains exactly
+# the same on every platform, without destabilizing unrelated Ascend tests.
 #
 # Guarded on the file existing so a CANN image without the profiling tools does
-# not get an LD_PRELOAD that ld.so can only warn about. See
-# docs/architecture/profiler.md.
-# LD_PRELOAD is always exported, empty when MSPTI is absent, because the
-# GITHUB_ENV loop below reads each name with ${!name} under `set -u`.
+# not get an LD_PRELOAD that ld.so can only warn about. The variable is always
+# assigned because the GITHUB_ENV loop reads each name with ${!name} under
+# `set -u`. See docs/architecture/profiler.md.
 ASCEND_MSPTI_LIB="$ASCEND_HOME/tools/mspti/lib64/libmspti.so"
 if [[ -f "$ASCEND_MSPTI_LIB" ]]; then
-  export LD_PRELOAD="$ASCEND_MSPTI_LIB${LD_PRELOAD:+:$LD_PRELOAD}"
-  echo "MSPTI interposer preloaded: $ASCEND_MSPTI_LIB"
+  export ASCEND_MSPTI_PRELOAD="$ASCEND_MSPTI_LIB${LD_PRELOAD:+:$LD_PRELOAD}"
+  echo "MSPTI interposer prepared for profiler process: $ASCEND_MSPTI_LIB"
 else
-  export LD_PRELOAD="${LD_PRELOAD:-}"
+  export ASCEND_MSPTI_PRELOAD="${LD_PRELOAD:-}"
   echo "::warning::libmspti.so not found at $ASCEND_MSPTI_LIB; profiler memcpy/memset activity will be unavailable"
 fi
 
@@ -238,7 +238,7 @@ if [[ -n "${GITHUB_ENV:-}" ]]; then
     PATH VIRTUAL_ENV PYTHONNOUSERSITE PYTHONPATH ACCELERATOR ASCEND_HOME \
     FLAGOS_DISABLE_CUDA_ASSETS FLAGOS_USE_FLAGGEMS FLAGOS_USE_FLAGGEMS_CPP \
     FLAGGEMS_KERNEL FLAGGEMS_PYTHON PIP_INDEX_URL PIP_DEFAULT_TIMEOUT PIP_RETRIES \
-    CPATH LIBRARY_PATH LD_LIBRARY_PATH LD_PRELOAD; do
+    CPATH LIBRARY_PATH LD_LIBRARY_PATH ASCEND_MSPTI_PRELOAD; do
     printf '%s=%s\n' "$name" "${!name}" >> "$GITHUB_ENV"
   done
 fi

--- a/.github/scripts/set_env_ascend.sh
+++ b/.github/scripts/set_env_ascend.sh
@@ -127,6 +127,35 @@ export CPATH="$ASCEND_HOME/include${CPATH:+:$CPATH}"
 export LIBRARY_PATH="$ASCEND_HOME/lib64:$ASCEND_HOME/acllib/lib64${DRIVER_LIBS:+:$DRIVER_LIBS}${LIBRARY_PATH:+:$LIBRARY_PATH}"
 export LD_LIBRARY_PATH="$ASCEND_HOME/lib64:$ASCEND_HOME/acllib/lib64${DRIVER_LIBS:+:$DRIVER_LIBS}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
+# --- MSPTI profiler interposer -----------------------------------------------
+# CANN intercepts aclrtMemcpy*/aclrtMemset* by symbol interposition, so
+# libmspti.so must already be in the ELF link map when libascendcl.so resolves
+# those calls. The tracer's own dlopen at profiler-session start is too late:
+# measured with a standalone C program, dlopen'ing libmspti before libascendcl
+# still yields zero memcpy/memset records, while a process-start preload yields
+# real ones. Kernel and runtime activities are unaffected either way.
+#
+# This belongs here, next to every other Ascend prerequisite (CPATH,
+# LD_LIBRARY_PATH, the driver HAL paths), rather than on the profiler test
+# command: the profiler contract is then invoked with the exact same command on
+# every platform, and no CI step has to know a vendor-specific incantation.
+# libmspti.so is inert until a profiler session subscribes, so carrying it for
+# the whole job costs nothing observable.
+#
+# Guarded on the file existing so a CANN image without the profiling tools does
+# not get an LD_PRELOAD that ld.so can only warn about. See
+# docs/architecture/profiler.md.
+# LD_PRELOAD is always exported, empty when MSPTI is absent, because the
+# GITHUB_ENV loop below reads each name with ${!name} under `set -u`.
+ASCEND_MSPTI_LIB="$ASCEND_HOME/tools/mspti/lib64/libmspti.so"
+if [[ -f "$ASCEND_MSPTI_LIB" ]]; then
+  export LD_PRELOAD="$ASCEND_MSPTI_LIB${LD_PRELOAD:+:$LD_PRELOAD}"
+  echo "MSPTI interposer preloaded: $ASCEND_MSPTI_LIB"
+else
+  export LD_PRELOAD="${LD_PRELOAD:-}"
+  echo "::warning::libmspti.so not found at $ASCEND_MSPTI_LIB; profiler memcpy/memset activity will be unavailable"
+fi
+
 # --- Build Python / CPU torch ------------------------------------------------
 # The CANN image's system Python is used only to bootstrap a venv; it does NOT
 # need torch pre-installed. CPU torch (2.10.0+cpu) is installed into the venv
@@ -209,7 +238,7 @@ if [[ -n "${GITHUB_ENV:-}" ]]; then
     PATH VIRTUAL_ENV PYTHONNOUSERSITE PYTHONPATH ACCELERATOR ASCEND_HOME \
     FLAGOS_DISABLE_CUDA_ASSETS FLAGOS_USE_FLAGGEMS FLAGOS_USE_FLAGGEMS_CPP \
     FLAGGEMS_KERNEL FLAGGEMS_PYTHON PIP_INDEX_URL PIP_DEFAULT_TIMEOUT PIP_RETRIES \
-    CPATH LIBRARY_PATH LD_LIBRARY_PATH; do
+    CPATH LIBRARY_PATH LD_LIBRARY_PATH LD_PRELOAD; do
     printf '%s=%s\n' "$name" "${!name}" >> "$GITHUB_ENV"
   done
 fi

--- a/docs/architecture/profiler.md
+++ b/docs/architecture/profiler.md
@@ -404,11 +404,46 @@ regressing into dangling halves is precisely the bug it guards against.
 
 Ascend profiling is implemented in `csrc/profiler/cann_device_tracer.cc` using CANN's public MSPTI activity API. It does not import `torch_npu`, parse file-oriented `msprof` output, or add CANN types to the generic Kineto adapter. MSPTI supplies epoch-nanosecond kernel, runtime/API, memcpy, and external-correlation records through asynchronous activity buffers; the tracer also decodes memset records when a CANN release emits them.
 
-`torch_fl` does not load `libmspti.so` during import. The C++ tracer resolves it lazily when a profiler session starts, so ordinary Ascend operator processes do not install the CANN interposer or pay its lifecycle cost. CANN 9.0 additionally checks the ELF process-start `LD_PRELOAD` state for memcpy and memset interception. A later `dlopen` cannot replace that requirement, so the memory-activity test is run with `LD_PRELOAD=/usr/local/Ascend/cann-9.0.0/tools/mspti/lib64/libmspti.so`. Without that process-start preload, the tracer degrades to kernel/runtime profiling and reports no memcpy/memset records. The library is optional: if it is absent, another MSPTI subscriber already owns the process, or activation fails, CPU profiling continues normally. MSPTI shutdown follows the measured order: unsubscribe first, then flush pending activity buffers; the tracer deliberately keeps the process-level MSPTI library loaded until process exit because CANN may retain interposed ACL function pointers.
+`torch_fl` does not load `libmspti.so` during import. The C++ tracer resolves it lazily when a profiler session starts, so ordinary Ascend operator processes do not install the CANN interposer or pay its lifecycle cost. Kernel and runtime/API records work under that lazy load.
+
+**Memcpy and memset are different**: CANN implements them by symbol interposition, so `libmspti.so` must already be in the ELF link map when `libascendcl.so` resolves those calls. A later `dlopen` cannot substitute, no matter how early it runs — measured with a standalone C program (no torch involved):
+
+```text
+no LD_PRELOAD, dlopen(mspti) then dlopen(ascendcl):  gpu_memcpy=0 gpu_memset=0
+LD_PRELOAD=libmspti.so:                              gpu_memcpy=3 gpu_memset=3
+```
+
+This is a *process startup* requirement, so it is satisfied where every other Ascend startup requirement already lives: `.github/scripts/set_env_ascend.sh`, next to `CPATH`, `LIBRARY_PATH`, `LD_LIBRARY_PATH`, and the driver HAL paths. The profiler contract is therefore invoked with the identical command on every platform:
+
+```bash
+python -m pytest tests/integration/test_profiler_contract.py -v -m profiler
+```
+
+No CI step and no user command carries a vendor-specific preload prefix. Outside CI, exporting the same variable before starting Python has the same effect:
+
+```bash
+export LD_PRELOAD="$ASCEND_HOME/tools/mspti/lib64/libmspti.so${LD_PRELOAD:+:$LD_PRELOAD}"
+```
+
+The preload is applied for the whole Ascend job rather than one step. `libmspti.so` is inert until a profiler session subscribes, so this costs nothing observable, and scoping it to a single command would put an Ascend-only incantation back into the test invocation — the thing this design removes. The environment script skips the export when the file is absent, so a CANN image without the profiling tools does not get an `LD_PRELOAD` that `ld.so` can only warn about.
+
+If the library is absent, another MSPTI subscriber already owns the process, or activation fails, CPU profiling continues normally. MSPTI shutdown follows the measured order: unsubscribe first, then flush pending activity buffers; the tracer deliberately keeps the process-level MSPTI library loaded until process exit because CANN may retain interposed ACL function pointers.
 
 MSPTI correlation IDs are remapped to nonzero 32-bit IDs for Kineto flow arrows. External-correlation records retain torch's profiler correlation ID separately, which enables linked ATen device-time attribution. Runtime records are coalesced per device correlation, preferring launch APIs for kernels and the corresponding copy/set API for transfers. Physical CANN device IDs are mapped to logical ordinals through `ASCEND_RT_VISIBLE_DEVICES` when set.
 
-The public CANN kernel record has no CUDA grid/block/occupancy fields; those fields are omitted rather than fabricated. CANN 9.0 declares `MSPTI_ACTIVITY_KIND_MEMSET` and emits real device records when the ACL memset symbols are resolved through the process-start MSPTI interposer. A direct global-symbol probe using `ctypes.CDLL(None)` produced positive-duration records for both `aclrtMemset` and `aclrtMemsetAsync`, including byte count, fill value, async flag, stream, device, and correlation metadata. A prior probe that called symbols through a separately loaded `libascendcl.so` handle bypassed the interposer and produced a false negative; it is not a valid capability test. Official Huawei MSPTI samples use the same process-start `LD_PRELOAD=libmspti.so` requirement. torch-fl therefore treats process-start preload as required for real memcpy/memset collection and verifies both memset variants in the Ascend integration gate. The implementation was measured on Ascend 910 hardware with CANN 9.0. Other CANN releases may remain unavailable until their MSPTI headers and runtime behavior are validated. Structural Ascend tests check real named positive-duration kernel/runtime/memcpy/memset activities, paired `ac2g` flows, external-correlation linkage, Chrome trace JSON, and repeated sessions.
+The public CANN kernel record has no CUDA grid/block/occupancy fields; those fields are omitted rather than fabricated. CANN 9.0 declares `MSPTI_ACTIVITY_KIND_MEMSET` and emits real device records when the ACL memset symbols are resolved through the process-start MSPTI interposer. A direct global-symbol probe using `ctypes.CDLL(None)` produced positive-duration records for both `aclrtMemset` and `aclrtMemsetAsync`, including byte count, fill value, async flag, stream, device, and correlation metadata. A prior probe that called symbols through a separately loaded `libascendcl.so` handle bypassed the interposer and produced a false negative; it is not a valid capability test. Other CANN releases may remain unavailable until their MSPTI headers and runtime behavior are validated.
+
+The shared cross-backend profiler contract (`tests/integration/test_profiler_contract.py` and `tests/integration/profiler_support.py`) exercises this on Ascend, but its memcpy and memset assertions are not symmetric. Both were measured on hardware against the same shared `profile_result()` workload (a small matmul+relu loop, a sort, and a host-to-device copy):
+
+- `test_profiler_memcpy_events` is gated on `mspti_preload_active()`, which checks `/proc/self/maps` for the actually loaded `libmspti.so` rather than trusting the `LD_PRELOAD` string. When the environment script has made the library available before process start, the workload's host-to-device copy produces a real positive-duration `gpu_memcpy` record; a missing or invalid library causes the test to skip explicitly instead of claiming a capability it does not have. The link map is sampled once at `profiler_support` import, which is the only moment that answers the question: the module is loaded as a pytest plugin before anything starts a profiler session, so a hit there can only come from a process-start preload. Sampling later would also see the lazy `dlopen` in `CannDeviceTracer::start()`, which does *not* enable interposition — measured on 910, a late check reports "preloaded" and then the memcpy assertion fails on a workload that produced no records.
+- `test_profiler_memset_events` stays disabled for Ascend regardless of preload. The direct `ctypes` probe above proves the CANN interception path itself works: `aclrtMemset`/`aclrtMemsetAsync` produce real `gpu_memset` records when called explicitly under preload. But nothing reachable from the shared workload calls that allocator path. `torch.zeros()` -- the only zeroing op the workload exercises -- routes to the `aclnnInplaceZero` kernel (`csrc/aten/backends/ascend/generated/ascend_kernels.cc`), not to the allocator's `aclrtMemset`/`aclrtMemsetAsync` calls in `csrc/runtime/accelerator/ascend/memory.cc`. Switching it only to make a profiler record appear would regress measured 910 latency from 12.7us to 133us at 1 MiB and from 17.4us to 9080us at 64 MiB (`aclrtMemsetAsync` is slower still). The high-performance kernel routing is therefore intentional, and the absent `gpu_memset` record is a correct-by-design capability difference.
+
+Every CI backend runs this contract with the same command; `.github/configs/ascend.yml` carries no platform-specific `LD_PRELOAD` prefix, because the preload is established job-wide by `.github/scripts/set_env_ascend.sh` together with the rest of the Ascend environment.
+
+`import torch_fl` deliberately does not re-exec the process to install the preload. Doing so would disturb file descriptors, multiprocessing, `torchrun`, and debuggers, and it would make every Ascend process pay for a capability only profiling sessions use. The environment is the correct place to express a process-start requirement.
+
+For hardware support reporting, the Ascend memcpy capability is measured only when MSPTI was actually loaded. An `LD_PRELOAD` environment variable by itself is not evidence of that; `ld.so` warns and continues for nonexistent paths.
+
 
 ## MUSA MUPTI integration
 

--- a/docs/architecture/profiler.md
+++ b/docs/architecture/profiler.md
@@ -413,19 +413,22 @@ no LD_PRELOAD, dlopen(mspti) then dlopen(ascendcl):  gpu_memcpy=0 gpu_memset=0
 LD_PRELOAD=libmspti.so:                              gpu_memcpy=3 gpu_memset=3
 ```
 
-This is a *process startup* requirement, so it is satisfied where every other Ascend startup requirement already lives: `.github/scripts/set_env_ascend.sh`, next to `CPATH`, `LIBRARY_PATH`, `LD_LIBRARY_PATH`, and the driver HAL paths. The profiler contract is therefore invoked with the identical command on every platform:
+This is a *process startup* requirement. `.github/scripts/set_env_ascend.sh` therefore discovers the library next to every other Ascend startup prerequisite, but stores the prepared preload under the inert `ASCEND_MSPTI_PRELOAD` variable. The common integration runner supports a per-test `environment` mapping and expands that value into `LD_PRELOAD` only for the profiler contract process. The contract is still invoked with the identical command on every platform:
 
 ```bash
 python -m pytest tests/integration/test_profiler_contract.py -v -m profiler
 ```
 
-No CI step and no user command carries a vendor-specific preload prefix. Outside CI, exporting the same variable before starting Python has the same effect:
+This narrow scope is required for correctness, not merely tidiness. A CI run that exported MSPTI job-wide produced sporadic `SIGSEGV` (`-11`) exits in otherwise healthy add, embedding, le, mean, and mm subprocesses before the profiler test was reached. CANN 9.0's interposer is therefore not safe to impose on arbitrary operator processes. Attaching the prerequisite as structured per-test environment data preserves the uniform command without destabilizing unrelated tests.
+
+Outside CI, the equivalent remains an environment export before starting the profiled Python process:
 
 ```bash
 export LD_PRELOAD="$ASCEND_HOME/tools/mspti/lib64/libmspti.so${LD_PRELOAD:+:$LD_PRELOAD}"
+python workload.py
 ```
 
-The preload is applied for the whole Ascend job rather than one step. `libmspti.so` is inert until a profiler session subscribes, so this costs nothing observable, and scoping it to a single command would put an Ascend-only incantation back into the test invocation — the thing this design removes. The environment script skips the export when the file is absent, so a CANN image without the profiling tools does not get an `LD_PRELOAD` that `ld.so` can only warn about.
+The environment script skips the prepared preload when the file is absent, so a CANN image without the profiling tools does not get an `LD_PRELOAD` that `ld.so` can only warn about.
 
 If the library is absent, another MSPTI subscriber already owns the process, or activation fails, CPU profiling continues normally. MSPTI shutdown follows the measured order: unsubscribe first, then flush pending activity buffers; the tracer deliberately keeps the process-level MSPTI library loaded until process exit because CANN may retain interposed ACL function pointers.
 
@@ -438,9 +441,9 @@ The shared cross-backend profiler contract (`tests/integration/test_profiler_con
 - `test_profiler_memcpy_events` is gated on `mspti_preload_active()`, which checks `/proc/self/maps` for the actually loaded `libmspti.so` rather than trusting the `LD_PRELOAD` string. When the environment script has made the library available before process start, the workload's host-to-device copy produces a real positive-duration `gpu_memcpy` record; a missing or invalid library causes the test to skip explicitly instead of claiming a capability it does not have. The link map is sampled once at `profiler_support` import, which is the only moment that answers the question: the module is loaded as a pytest plugin before anything starts a profiler session, so a hit there can only come from a process-start preload. Sampling later would also see the lazy `dlopen` in `CannDeviceTracer::start()`, which does *not* enable interposition — measured on 910, a late check reports "preloaded" and then the memcpy assertion fails on a workload that produced no records.
 - `test_profiler_memset_events` stays disabled for Ascend regardless of preload. The direct `ctypes` probe above proves the CANN interception path itself works: `aclrtMemset`/`aclrtMemsetAsync` produce real `gpu_memset` records when called explicitly under preload. But nothing reachable from the shared workload calls that allocator path. `torch.zeros()` -- the only zeroing op the workload exercises -- routes to the `aclnnInplaceZero` kernel (`csrc/aten/backends/ascend/generated/ascend_kernels.cc`), not to the allocator's `aclrtMemset`/`aclrtMemsetAsync` calls in `csrc/runtime/accelerator/ascend/memory.cc`. Switching it only to make a profiler record appear would regress measured 910 latency from 12.7us to 133us at 1 MiB and from 17.4us to 9080us at 64 MiB (`aclrtMemsetAsync` is slower still). The high-performance kernel routing is therefore intentional, and the absent `gpu_memset` record is a correct-by-design capability difference.
 
-Every CI backend runs this contract with the same command; `.github/configs/ascend.yml` carries no platform-specific `LD_PRELOAD` prefix, because the preload is established job-wide by `.github/scripts/set_env_ascend.sh` together with the rest of the Ascend environment.
+Every CI backend runs this contract with the same command. `.github/configs/ascend.yml` carries no shell prefix; its structured `environment` field scopes the prepared preload to this process, and `.github/scripts/run_integration_tests.py` applies it without changing the command string.
 
-`import torch_fl` deliberately does not re-exec the process to install the preload. Doing so would disturb file descriptors, multiprocessing, `torchrun`, and debuggers, and it would make every Ascend process pay for a capability only profiling sessions use. The environment is the correct place to express a process-start requirement.
+`import torch_fl` deliberately does not re-exec the process to install the preload. Doing so would disturb file descriptors, multiprocessing, `torchrun`, and debuggers, and exporting the interposer job-wide demonstrably destabilizes unrelated CANN operator processes. Per-process integration environment data is the safe boundary at which to express this startup requirement.
 
 For hardware support reporting, the Ascend memcpy capability is measured only when MSPTI was actually loaded. An `LD_PRELOAD` environment variable by itself is not evidence of that; `ld.so` warns and continues for nonexistent paths.
 

--- a/tests/integration/profiler_support.py
+++ b/tests/integration/profiler_support.py
@@ -51,6 +51,44 @@ def _torch_module():
     return torch
 
 
+def _mspti_in_link_map() -> bool:
+    """Whether libmspti.so is mapped into this process right now."""
+    try:
+        maps = Path("/proc/self/maps").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return "libmspti.so" in maps
+
+
+# Sampled at import, which is the only moment that answers the question being
+# asked. This module is loaded as a pytest plugin before torch_fl preloads its
+# device assets, so nothing has run a profiler session yet -- meaning a hit here
+# can only come from a process-start preload. Sampling later would also see the
+# lazy dlopen that CannDeviceTracer::start() performs, which does *not* enable
+# interposition; measured on 910, a late check reports "preloaded" and then the
+# memcpy assertion fails on a workload that produced no records.
+_MSPTI_PRELOADED_AT_STARTUP = _mspti_in_link_map()
+
+
+def mspti_preload_active() -> bool:
+    """Whether CANN's process-start MSPTI interposer was loaded at startup.
+
+    CANN 9.0 intercepts ``aclrtMemcpy*``/``aclrtMemset*`` by symbol
+    interposition, so ``libmspti.so`` must already be in the ELF link map when
+    ``libascendcl.so`` resolves those calls; a later ``dlopen`` cannot
+    substitute, even when it happens before the first ACL call. CI establishes
+    this in ``.github/scripts/set_env_ascend.sh``, alongside the other Ascend
+    environment prerequisites, so the profiler contract is invoked with the same
+    command on every platform.
+
+    This reads the link map rather than ``LD_PRELOAD`` on purpose: ``ld.so``
+    only warns and continues when a preloaded path does not exist, so a mistyped
+    ``LD_PRELOAD`` yields the env string without the library, and an env-based
+    check would claim a capability the process does not have.
+    """
+    return _MSPTI_PRELOADED_AT_STARTUP
+
+
 def capabilities_for_platform(platform: str) -> ProfilerCapabilities:
     """Describe public profiler features currently emitted by each tracer.
 
@@ -60,12 +98,34 @@ def capabilities_for_platform(platform: str) -> ProfilerCapabilities:
     """
     device = platform != "ascend"
     runtime = device
+    # Ascend memcpy interception is gated on process-start LD_PRELOAD rather
+    # than on `device` above: measured on Ascend 910 with CANN 9.0, the shared
+    # profile_result() workload produces a real positive-duration gpu_memcpy
+    # record when libmspti.so is preloaded at process start, and none at all
+    # otherwise. Treat that as the sole memcpy capability signal for ascend so
+    # the memcpy test skips (rather than silently passing or failing) when the
+    # prerequisite is absent.
+    ascend_memcpy = platform == "ascend" and mspti_preload_active()
     return ProfilerCapabilities(
         platform=platform,
         device=device,
         kernel=device,
         runtime=runtime,
-        memcpy=device and platform in {"cuda", "metax", "ppu", "musa"},
+        memcpy=(device and platform in {"cuda", "metax", "ppu", "musa"})
+        or ascend_memcpy,
+        # Ascend memset stays off even with the MSPTI preload present, and this
+        # is a deliberate backend property rather than a gap to close. A direct
+        # ctypes probe of aclrtMemset/aclrtMemsetAsync under process-start
+        # preload does produce real positive-duration, positive-byte memset
+        # records, so the CANN interception itself works. But torch.zeros() --
+        # the only zeroing op the shared profile_result() workload and any
+        # current Ascend op registration reach -- routes through the
+        # aclnnInplaceZero kernel, not the allocator's aclrtMemset calls in
+        # csrc/runtime/accelerator/ascend/memory.cc. Rerouting it to match the
+        # MetaX allocator-memset path would make this record appear, and was
+        # measured on Ascend 910 to cost 12.7us -> 133us at 1 MiB and
+        # 17.4us -> 9080us at 64 MiB (aclrtMemsetAsync is worse still), so the
+        # kernel routing stays and the capability stays off.
         memset=device and platform in {"cuda", "metax"},
         flow=device,
         linkage=device,

--- a/tests/unit/test_run_integration_tests.py
+++ b/tests/unit/test_run_integration_tests.py
@@ -1,0 +1,82 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the data-driven integration test runner."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+_RUNNER_PATH = (
+    Path(__file__).resolve().parents[2] / ".github/scripts/run_integration_tests.py"
+)
+_SPEC = importlib.util.spec_from_file_location("run_integration_tests", _RUNNER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_RUNNER = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_RUNNER)
+
+
+def test_per_test_environment_is_expanded_and_scoped(monkeypatch, tmp_path):
+    tests = [
+        {
+            "name": "profiled",
+            "environment": {"LD_PRELOAD": "${ASCEND_MSPTI_PRELOAD}"},
+            "command": (
+                "printf '%s' \"${LD_PRELOAD-<unset>}\" > profiled.txt; "
+                "printf '%s' \"$SHARED\" > shared.txt"
+            ),
+        },
+        {
+            "name": "ordinary",
+            "command": "printf '%s' \"${LD_PRELOAD-<unset>}\" > ordinary.txt",
+        },
+    ]
+    monkeypatch.setenv("INTEGRATION_TESTS", json.dumps(tests))
+    monkeypatch.setenv("INTEGRATION_ENVIRONMENT", json.dumps({"SHARED": "value"}))
+    monkeypatch.setenv("INTEGRATION_WORKDIR", str(tmp_path))
+    monkeypatch.setenv("ASCEND_MSPTI_PRELOAD", "/opt/cann/libmspti.so:/opt/base.so")
+    monkeypatch.delenv("LD_PRELOAD", raising=False)
+
+    class Args:
+        validate_only = False
+        allow_empty = False
+
+    monkeypatch.setattr(_RUNNER, "parse_args", lambda: Args())
+
+    assert _RUNNER.main() == 0
+    assert (tmp_path / "profiled.txt").read_text() == (
+        "/opt/cann/libmspti.so:/opt/base.so"
+    )
+    assert (tmp_path / "ordinary.txt").read_text() == "<unset>"
+    assert (tmp_path / "shared.txt").read_text() == "value"
+
+
+@pytest.mark.parametrize(
+    ("environment", "message"),
+    [
+        ([], "must be an object"),
+        ({"NOT-VALID": "value"}, "invalid environment variable name"),
+        ({"VALID": "line one\nline two"}, "must be a single-line string"),
+    ],
+)
+def test_per_test_environment_validation(monkeypatch, environment, message):
+    tests = [{"name": "test", "command": "true", "environment": environment}]
+    monkeypatch.setenv("INTEGRATION_TESTS", json.dumps(tests))
+    monkeypatch.setenv("INTEGRATION_ENVIRONMENT", "{}")
+
+    with pytest.raises(SystemExit, match=message):
+        _RUNNER.load_configuration(allow_empty=False)


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Investigated why the Ascend profiler contract produced no memcpy records, established that CANN's interception requires a process-start library, and scoped that prerequisite to the profiler process after CI proved that a job-wide preload destabilizes ordinary CANN operator subprocesses.

## Summary

CANN 9.0 intercepts `aclrtMemcpy*` and `aclrtMemset*` by symbol interposition, so `libmspti.so` must already be in the ELF link map when `libascendcl.so` resolves those calls; the tracer's lazy `dlopen` at profiler-session start cannot supply that. This PR discovers the library in `.github/scripts/set_env_ascend.sh` and adds a validated per-test `environment` mapping to the common integration runner, which applies `LD_PRELOAD` only to the Ascend profiler process. The profiler contract keeps a byte-identical command across CUDA, MetaX, DCU, and Ascend, while unrelated Ascend processes do not inherit the CANN 9.0 interposer that caused six CI subprocesses to exit with `SIGSEGV`. Capability gating reads the actual startup link map instead of the `LD_PRELOAD` string, so missing or invalid libraries skip rather than falsely failing.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [x] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [x] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)

## Problem Analysis

### What was broken/missing?

Three separate defects:

1. **No memcpy/memset device records on Ascend.** The profiler contract's `test_profiler_memcpy_events` could never observe a `gpu_memcpy` record, because CANN's interception of the ACL copy and set symbols was never armed.
2. **A missing library produced a failure, not a skip.** `mspti_preload_active()` consulted the environment/late link map, so a run without the interposer asserted on records that could not exist.
3. **Inconsistent usage across chips.** Making Ascend work required an Ascend-only `LD_PRELOAD` prefix on the profiler test command, so the same contract was invoked differently per platform, and a user profiling on Ascend needed a vendor incantation that CUDA users do not.

### Why did it happen?

`libmspti.so` interposes on `aclrtMemcpy`/`aclrtMemcpyAsync`/`aclrtMemset`/`aclrtMemsetAsync`. Symbol interposition is resolved by the dynamic loader against the link map that exists when the resolving object (`libascendcl.so`) is loaded. `CannDeviceTracer::start()` loads MSPTI lazily so ordinary Ascend operator processes pay nothing for profiling support — correct for kernel and runtime/API activity, which arrive through `msptiSubscribe` and do not depend on interposition, but structurally too late for the interposed symbols. No ordering of `dlopen` calls can fix this; it is a process-startup property.

The gating defect had a different cause: `ld.so` only prints a warning and continues when a preloaded path does not exist, so the presence of `LD_PRELOAD` is not evidence that anything loaded. Reading `/proc/self/maps` lazily is also wrong, because by then the tracer's own `dlopen` has mapped MSPTI without enabling interposition.

### Investigation process:

1. Read `csrc/profiler/cann_device_tracer.cc` and confirmed MSPTI is resolved lazily inside the session start path, and that `MSPTI_ACTIVITY_KIND_MEMCPY`/`MEMSET` decoding is present, so the tracer side was not the gap.
2. Wrote a standalone C program with no torch involvement, subscribing to MSPTI and issuing `aclrtMemcpy`/`aclrtMemset` calls, to separate "CANN cannot do this" from "torch_fl arms it too late":
   ```text
   dlopen(libmspti) then dlopen(libascendcl):   gpu_memcpy=0  gpu_memset=0
   LD_PRELOAD=libmspti.so (process start):      gpu_memcpy=3  gpu_memset=3
   ```
   This is the decisive measurement: ordering `dlopen` earlier does not help, so the fix must be at process start.
3. Traced `torch.zeros()` on Ascend through `csrc/aten/backends/ascend/generated/ascend_kernels.cc` and found it lowers to `at::empty` + `zero_()` → `aclnnInplaceZero`, never touching the allocator's `aclrtMemset` in `csrc/runtime/accelerator/ascend/memory.cc`. That explains why memset stays unobservable even with MSPTI loaded.
4. Benchmarked the alternative of rerouting zeroing through the allocator memset so a record would appear (see Performance Impact) and rejected it.
5. Ran the contract without any preload and observed the memcpy test *fail* rather than skip, then confirmed that a late `/proc/self/maps` read already contained `libmspti.so` from the tracer's own `dlopen`.
6. Compared `.github/configs/ascend.yml` with `cuda.yml`, `metax.yml`, and `dcu.yml`, and reviewed what `set_env_ascend.sh` already establishes (`CPATH`, `LIBRARY_PATH`, `LD_LIBRARY_PATH`, driver HAL paths) to decide where the prerequisite belongs.
7. Verified the `GITHUB_ENV` export loop uses `${!name}` under `set -euo pipefail`, which fails with "unbound variable" if a listed variable is never assigned, and tested the shell block in an isolated `env -i` shell for all three discovery cases.
8. Inspected the first PR CI run after the job-wide implementation. Six operator tests (`add`, `embedding`, `le`, `mean`, and `mm`) failed because their Python subprocesses exited with `SIGSEGV` (`-11`) before the profiler step. This falsified the assumption that MSPTI is inert when no session subscribes and required per-process scoping.

## Solution Design

### Implementation approach:

Treat the MSPTI interposer as a process-start prerequisite, but not a job-wide one. `set_env_ascend.sh` discovers `$ASCEND_HOME/tools/mspti/lib64/libmspti.so` and exports the prepared value as `ASCEND_MSPTI_PRELOAD`, an inert variable that ordinary subprocesses ignore. The common integration runner now accepts an optional validated `environment` mapping on each test. `.github/configs/ascend.yml` maps `LD_PRELOAD: ${ASCEND_MSPTI_PRELOAD}` only on the profiler contract, and the runner expands it into that child process's environment.

The visible command remains exactly what every other platform uses:

```bash
python -m pytest tests/integration/test_profiler_contract.py -v -m profiler --tb=short
```

Capability gating measures reality: `profiler_support` samples `/proc/self/maps` once at import — before any profiler session can have run — and Ascend memcpy is reported only if MSPTI was actually mapped at startup.

### Key design decisions:

- **Environment script, not a launcher module.** An earlier revision of this PR added a `python -m torch_fl_profiler -- ...` wrapper. That was rejected: it introduces a new public entry point and a second way to start Python, and a uniform experience across chips is better served by leaving the command alone than by changing it everywhere. Platform prerequisites already live in the platform's setup script; nothing new needs to exist.
- **Per-process structured environment, not job-wide or a shell prefix.** The first CI run proved that job-wide MSPTI causes sporadic CANN operator subprocess segfaults. A per-test mapping keeps ordinary processes clean while the command string remains identical on every platform.
- **No `import torch_fl` re-exec.** Satisfying the requirement by re-executing the interpreter during import would disturb file descriptors, multiprocessing, `torchrun`, and debuggers, and would impose it on every Ascend process rather than profiling runs.
- **Guard on file existence, and always assign the inert variable.** A CANN image without the profiling tools must not receive an `LD_PRELOAD` that `ld.so` can only warn about. The `else` branch still assigns `ASCEND_MSPTI_PRELOAD`, because the `GITHUB_ENV` loop dereferences every listed name with `${!name}` under `set -u`.
- **Validate per-test environments like the global environment.** Names must be shell environment identifiers and values must be single-line strings without NULs. Expansion happens only when constructing the child environment.
- **Link map, not environment string.** `LD_PRELOAD` can name a path that failed to load; `/proc/self/maps` cannot.
- **Sample at import time.** This is the only moment that answers the question asked. A later read sees the tracer's lazy `dlopen`, which maps the library without enabling interposition, and produces a "preloaded" verdict followed by a failing assertion.
- **Ascend memset capability stays off.** It is a correct backend property, not a gap. See Performance Impact.

### Code changes by file:

- `.github/scripts/set_env_ascend.sh` (lines 130-158): discover the MSPTI interposer after the library-path setup, preserve any existing preload suffix, and export the result under inert `ASCEND_MSPTI_PRELOAD`; warn and assign an empty value when the profiling tools are absent. Export the prepared value through `GITHUB_ENV`.
- `.github/scripts/run_integration_tests.py` (lines 40-112): accept and validate an optional `environment` object per configured test, expand references from the runner environment, and apply the resulting variables only to that subprocess.
- `.github/configs/ascend.yml` (profiler contract): map `LD_PRELOAD` to `${ASCEND_MSPTI_PRELOAD}` as structured data on the profiler test only. The command itself remains unchanged and identical to the other platforms.
- `tests/unit/test_run_integration_tests.py`: verify expansion and per-test isolation, preservation of the global integration environment, and rejection of invalid mappings, names, and multiline values.
- `tests/integration/profiler_support.py` (lines 54-129): add `_mspti_in_link_map()`, snapshot it into `_MSPTI_PRELOADED_AT_STARTUP` at module import, rewrite `mspti_preload_active()` to return that snapshot with the reasoning documented, and gate Ascend `memcpy` on it while leaving `memset` off.
- `docs/architecture/profiler.md` (Ascend MSPTI section): document the interposition requirement, the standalone-C measurement, the CI-discovered job-wide segfaults, per-process scoping, the identical cross-platform command, import-time link-map sampling, and the memset routing decision.

### Changes by commit:

1. `ebfef4c` - `fix: satisfy Ascend MSPTI process-start requirement in the environment`: establish the measured process-start requirement and capability gating.
2. `21ad0b1` - `fix: scope Ascend MSPTI preload to profiler tests`: correct the job-wide scope after CI exposed operator-process segfaults; add per-test environment support and unit tests.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [ ] **Type checking passed** (if applicable) — no type checker is configured in this repository
- [x] **All tests pass** (unit + integration)
- [x] **Manual testing completed** (include reproduction of original issue)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [x] **Documentation updated** (README, CLAUDE.md, docstrings as needed)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ python -m ruff check .
All checks passed!

$ python -m ruff format --check .
224 files already formatted

$ bash -n .github/scripts/set_env_ascend.sh
set_env_ascend.sh OK

$ python -c "import yaml; yaml.safe_load(open('.github/configs/ascend.yml'))"
ascend.yml OK
```

### Test Results

Hardware: real Ascend 910 (CANN 9.0.0, aarch64), torch 2.10.0, Python 3.10.

```bash
# Command (Ascend job equivalent, MSPTI preloaded as set_env_ascend.sh does):
LD_PRELOAD=$ASCEND_HOME/tools/mspti/lib64/libmspti.so \
  python -m pytest tests/integration/test_profiler_contract.py -m profiler --tb=short -q

# Output:
.sssss.sssss                                                             [100%]
2 passed, 10 skipped, 1 warning in 0.58s
```

```bash
# Command:
python -m pytest tests/unit/ -q

# Output:
213 passed, 97 skipped, 48 warnings in 11.21s
```

```bash
# Per-test environment runner coverage:
python -m pytest tests/unit/test_run_integration_tests.py -q

# Output:
4 passed in 0.07s
```

```text
# All platform configuration files validated through the updated runner:
ascend.yml: 7 tests     cuda.yml: 13 tests     dcu.yml: 10 tests
gcu.yml: 7 tests        metax.yml: 10 tests    musa.yml: 8 tests
ppu.yml: 8 tests
```

### Manual Verification

```bash
# Command to reproduce original issue (no process-start interposer):
$ python -m pytest tests/integration/test_profiler_contract.py -m profiler --tb=short -q

# Output BEFORE fix (memcpy asserted on records that cannot exist):
FAILED tests/integration/test_profiler_contract.py::test_profiler_memcpy_events
E       AssertionError: no gpu_memcpy events captured

# Output AFTER fix (correctly reported as unavailable, not failed):
.sssssssssss                                                             [100%]
1 passed, 11 skipped, 1 warning in 0.61s
```

```bash
# With the prerequisite established, as set_env_ascend.sh does in CI:
$ LD_PRELOAD=$ASCEND_HOME/tools/mspti/lib64/libmspti.so \
    python -m pytest tests/integration/test_profiler_contract.py -m profiler --tb=short -q
.sssss.sssss                                                             [100%]
2 passed, 10 skipped, 1 warning in 0.58s
# test_profiler_memcpy_events now passes on a real positive-duration gpu_memcpy record.

# A preload path that does not exist must not claim a capability:
$ LD_PRELOAD=/nonexistent/libmspti.so \
    python -m pytest tests/integration/test_profiler_contract.py -m profiler --tb=short -q
.sssssssssss                                                             [100%]
1 passed, 11 skipped, 1 warning in 0.61s
```

The discovery block and per-test runner were also exercised independently:

```text
case 1  real CANN, no prior preload  -> ASCEND_MSPTI_PRELOAD=<mspti>
case 2  prior preload present        -> ASCEND_MSPTI_PRELOAD=<mspti>:/opt/libfoo.so
case 3  no profiling tools installed -> ::warning:: emitted, prepared value empty
runner profiled child                -> LD_PRELOAD=<prepared value>
runner following ordinary child      -> LD_PRELOAD unset (no environment leakage)
```

## Performance Impact

<details>
<summary>Click to expand benchmark results</summary>

**Benchmark setup:**
- Hardware: Ascend 910, CANN 9.0.0
- Workload: zeroing a device buffer at three sizes, comparing the current `aclnnInplaceZero` kernel path against the allocator memset path that would make a `gpu_memset` profiler record appear
- Measurement method: warmed loop, per-call latency after stream synchronization

**Results:**
| Metric | Before (`aclnnInplaceZero`) | After (`aclrtMemset`) | Change |
|--------|--------|-------|--------|
| 16 KiB | 12.3 us | 23.5 us | 1.9x slower |
| 1 MiB | 12.7 us | 133.1 us | 10.5x slower |
| 64 MiB | 17.4 us | 9079.6 us | 522x slower |
| 64 MiB (`aclrtMemsetAsync`) | 17.4 us | 16003.9 us | 920x slower |

This is why the Ascend `memset` capability stays off. Rerouting zeroing to make a profiler record observable would be a large regression on a hot path; the absent record is a consequence of a deliberate performance decision.

The first PR CI run disproved the assumption that carrying `libmspti.so` job-wide is inert: six ordinary operator subprocesses exited with `SIGSEGV`. The final implementation therefore introduces no steady-state performance or stability cost for non-profiler processes; only the profiler contract child receives the interposer.

</details>

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (no reinventing)

The `set_env_ascend.sh` block follows the file's existing `# --- Section ---` banner convention, its guarded-export idiom (`${VAR:+:$VAR}`), and its `::warning::` reporting style. `profiler_support.py` keeps the existing capability-table shape.

### Edge Cases Considered
1. **CANN image without profiling tools.** `libmspti.so` absent: the prepared value remains empty, a `::warning::` is emitted, and the contract skips the memcpy case. Verified as case 3 above.
2. **`LD_PRELOAD` already set by the runner or image.** The existing value is preserved after MSPTI in `ASCEND_MSPTI_PRELOAD`, not replaced. Verified as case 2 above.
3. **`set -u` with no existing preload.** The `GITHUB_ENV` loop dereferences `${!name}`; both discovery branches assign `ASCEND_MSPTI_PRELOAD`, so the script cannot abort.
4. **No environment leakage between integration tests.** Each subprocess receives a fresh copy of the common environment before its own mapping is applied; unit coverage proves the following ordinary child has no `LD_PRELOAD`.
5. **Nonexistent preload path (typo, moved SDK).** `ld.so` warns and continues, so the environment string lies. The link-map check reports no capability and the test skips. Verified above.
6. **Late link-map sampling.** The tracer's own `dlopen` maps MSPTI without interposition; sampling at import avoids reporting a capability the process does not have. This was an actual observed failure, not a hypothetical.
7. **Non-Ascend platforms.** `mspti_preload_active()` is consulted only for `platform == "ascend"`; CUDA, MetaX, DCU, PPU, and MUSA capability rows and commands are untouched. All platform configs validate against the runner's extended schema.
8. **Upstream MUSA memcpy capability.** Preserved: the memcpy set remains `{cuda, metax, ppu, musa}` with the Ascend clause added disjunctively.

### Potential Risks
1. **`os.path.expandvars` expands every `$NAME` in a configured per-test value.** The field is intended for environment composition and is validated as a single-line string; literal dollar signs would need escaping at configuration authoring time. Current configs use only `${ASCEND_MSPTI_PRELOAD}`.
2. **The MSPTI path is hardcoded relative to `ASCEND_HOME`.** If a future CANN layout moves `tools/mspti/lib64`, the guard turns it into a warning and a skip rather than a crash, but the capability silently disappears. The `::warning::` in the job log is the signal.
3. **The CANN interposer may still destabilize the profiler workload itself.** Hardware verification passed that exact workload with MSPTI; scoping ensures any future regression cannot affect unrelated operator tests.

### Rollback Plan

Revert `21ad0b1` and `ebfef4c`. The changes are confined to CI environment setup, the generic integration runner and its unit test, one test-support module, and documentation; no runtime or kernel code is touched.

## Related Work
- Fixes #193
- Related to #184
- Depends on: none

## Explicitly Not Included
- **Making `gpu_memset` observable on Ascend.** Would require rerouting `torch.zeros()` from `aclnnInplaceZero` to the allocator memset, measured 10x-900x slower. Deliberately excluded.
- **Loading MSPTI from inside `import torch_fl`.** Would need an interpreter re-exec, with the file-descriptor, multiprocessing, `torchrun`, and debugger consequences described above.
- **A `torch_fl_profiler` launcher module or console script.** Considered and dropped in favor of not changing the command users type.
- **The kernel External-ID off-by-one on Ascend**, where a kernel correlates to the following `aten::empty` rather than the `aten::matmul`/`aten::relu` that launched it. Real, separate from this fix, and needs its own investigation.
- **The CANN 9.0.0 callback `correlationId` vendor defect** tracked in #195, which is a vendor bug with no fix available here.
- **Grid/block/occupancy kernel fields.** Not present in the public CANN kernel record; omitted rather than fabricated.

## Human Review Notes

### Areas needing special attention:
1. **The generic per-test `environment` extension in `run_integration_tests.py`.** Confirm that copying the common environment, expanding each configured value, and applying it only to one subprocess is the desired reusable contract.
2. **The import-time link-map snapshot in `profiler_support.py`.** Correctness depends on the module being imported before any profiler session starts. It is loaded as a pytest plugin, which holds today; a future reorganization that imports it later would silently weaken the gate.
3. **The distinction between `ASCEND_MSPTI_PRELOAD` and `LD_PRELOAD`.** The former is intentionally inert job-wide; only the profiler test's structured mapping turns it into the latter.

### Questions for reviewer:
1. Should the Ascend `memset` capability difference be recorded in `docs/reference/operator-support.md` as well, or is `docs/architecture/profiler.md` the right and only home for it?
2. Should the `::warning::` for a missing `libmspti.so` be escalated to a hard failure on the self-hosted 910C runner, where the profiling tools are expected to be present?

## Additional Context

The decisive evidence is the standalone C measurement, which removes torch from the question entirely:

```text
no LD_PRELOAD, dlopen(mspti) then dlopen(ascendcl):  gpu_memcpy=0 gpu_memset=0
LD_PRELOAD=libmspti.so:                              gpu_memcpy=3 gpu_memset=3
```

Kernel and runtime/API activity are unaffected by this, because they arrive through `msptiSubscribe` rather than interposition. The Ascend profiler was never fully dark without the preload — only the copy and set records were missing.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

