### PR TITLE
fix: install lib/flagos_platform marker for Ascend builds

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -535,12 +535,19 @@ install(TARGETS ${LIBRARY_NAME}
 )
 
 if(ACCELERATOR STREQUAL "gcu" OR ACCELERATOR STREQUAL "musa"
-   OR ACCELERATOR STREQUAL "bpu")
+   OR ACCELERATOR STREQUAL "bpu" OR ACCELERATOR STREQUAL "ascend")
   # torch_fl/__init__.py pins backends_cuda.conf by default, which on
-  # GCU/MUSA/BPU would route every op to the (absent) CUDA kernels. Record the
-  # platform next to the libs so the Python side can pick
+  # GCU/MUSA/BPU/Ascend would route every op to the (absent) CUDA kernels.
+  # Record the platform next to the libs so the Python side can pick
   # backends_<platform>.conf instead. BPU additionally uses the marker to decide
-  # whether to register the "bpu" torch.compile backend.
+  # whether to register the "bpu" torch.compile backend. Ascend previously
+  # relied on runtime /dev/davinci* detection in torch_fl/__init__.py instead of
+  # this marker (see _select_backend_config()); that detection can silently
+  # fall through on a build/host where /dev is not enumerable, which also
+  # makes tests/integration/platform_support.py misclassify the platform as
+  # "cuda". Writing the marker makes Ascend identification explicit, matching
+  # the other native platforms, while the davinci-based detection stays as a
+  # fallback for wheels built before this change.
   set(_flagos_platform_marker "${CMAKE_CURRENT_BINARY_DIR}/flagos_platform")
   file(WRITE "${_flagos_platform_marker}" "${ACCELERATOR}\n")
   install(FILES "${_flagos_platform_marker}"

--- a/tests/unit/test_ascend_platform_marker.py
+++ b/tests/unit/test_ascend_platform_marker.py
@@ -1,0 +1,103 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit coverage for the Ascend lib/flagos_platform marker.
+
+csrc/CMakeLists.txt now writes lib/flagos_platform for Ascend builds too (it
+previously only did so for gcu/musa/bpu), so
+tests/integration/platform_support.py::detect_platform() can identify Ascend
+from the installed marker instead of relying solely on the /dev/davinci*
+runtime probe in torch_fl/__init__.py -- a probe that silently falls back to
+the CUDA config if /dev enumeration fails for any reason (permissions, a
+sandboxed container, etc). See issue #192.
+
+These tests exercise torch_fl._select_backend_config() directly against a
+fake install tree (no real ACL device needed), and pin the exact regression
+this fix must not reintroduce: the marker branch runs *before* the
+/dev/davinci* branch, so it must special-case the Ascend FlagGems opt-in
+(FLAGOS_USE_FLAGGEMS=1 -> backends_ascend_flagos_py.conf) itself, the same way
+it already does for MUSA. Without that, installing the marker would silently
+shadow the FlagGems opt-in on real Ascend hardware.
+"""
+
+import os
+
+import pytest
+
+import torch_fl
+
+
+@pytest.fixture
+def fake_ascend_install(tmp_path, monkeypatch):
+    """Point torch_fl.__file__ at a scratch tree with an Ascend marker + confs."""
+    lib_dir = tmp_path / "lib"
+    conf_dir = tmp_path / "configs"
+    lib_dir.mkdir()
+    conf_dir.mkdir()
+    (lib_dir / "flagos_platform").write_text("ascend\n")
+    (conf_dir / "backends_ascend.conf").write_text("")
+    (conf_dir / "backends_ascend_flagos_py.conf").write_text("")
+
+    monkeypatch.setattr(torch_fl, "__file__", str(tmp_path / "__init__.py"))
+    monkeypatch.delenv("FLAGOS_BACKEND_CONFIG", raising=False)
+    monkeypatch.delenv("FLAGOS_USE_FLAGGEMS", raising=False)
+    monkeypatch.delenv("FLAGOS_USE_FLAGGEMS_CPP", raising=False)
+    monkeypatch.delenv("FLAGOS_USE_TILEOPS", raising=False)
+    monkeypatch.delenv("FLAGOS_METAX_BOXING", raising=False)
+    return conf_dir
+
+
+def test_ascend_marker_selects_native_conf_by_default(fake_ascend_install):
+    conf_dir = fake_ascend_install
+    torch_fl._select_backend_config()
+    assert os.environ["FLAGOS_BACKEND_CONFIG"] == str(conf_dir / "backends_ascend.conf")
+
+
+def test_ascend_marker_honors_flaggems_opt_in(monkeypatch, fake_ascend_install):
+    """Regression guard: the marker branch must not shadow the Ascend FlagGems
+    conf that the /dev/davinci* branch would otherwise pick."""
+    conf_dir = fake_ascend_install
+    monkeypatch.setenv("FLAGOS_USE_FLAGGEMS", "1")
+    torch_fl._select_backend_config()
+    assert os.environ["FLAGOS_BACKEND_CONFIG"] == str(
+        conf_dir / "backends_ascend_flagos_py.conf"
+    )
+
+
+def test_ascend_marker_falls_back_to_native_conf_if_flaggems_conf_missing(
+    monkeypatch, tmp_path
+):
+    """If a wheel ships the marker but not the flagos_py conf (old install
+    layout), the native conf must still be usable rather than raising."""
+    lib_dir = tmp_path / "lib"
+    conf_dir = tmp_path / "configs"
+    lib_dir.mkdir()
+    conf_dir.mkdir()
+    (lib_dir / "flagos_platform").write_text("ascend\n")
+    (conf_dir / "backends_ascend.conf").write_text("")
+
+    monkeypatch.setattr(torch_fl, "__file__", str(tmp_path / "__init__.py"))
+    monkeypatch.delenv("FLAGOS_BACKEND_CONFIG", raising=False)
+    monkeypatch.setenv("FLAGOS_USE_FLAGGEMS", "1")
+
+    torch_fl._select_backend_config()
+    assert os.environ["FLAGOS_BACKEND_CONFIG"] == str(conf_dir / "backends_ascend.conf")
+
+
+def test_explicit_backend_config_overrides_the_marker(monkeypatch, fake_ascend_install):
+    """FLAGOS_BACKEND_CONFIG is documented as always winning (advanced/testing
+    use); the marker must not override an explicit choice."""
+    monkeypatch.setenv("FLAGOS_BACKEND_CONFIG", "/tmp/explicit.conf")
+    torch_fl._select_backend_config()
+    assert os.environ["FLAGOS_BACKEND_CONFIG"] == "/tmp/explicit.conf"

--- a/tests/unit/test_platform_support_detect.py
+++ b/tests/unit/test_platform_support_detect.py
@@ -1,0 +1,129 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit coverage for tests/integration/platform_support.py::detect_platform().
+
+detect_platform() is the shared platform-name resolver behind the profiler and
+AMP cross-backend contracts (tests/integration/profiler_support.py,
+tests/integration/amp_support.py). Its marker check
+(torch_fl/lib/flagos_platform) previously had no Ascend-writing counterpart in
+csrc/CMakeLists.txt, so it could only identify Ascend via the final
+FLAGOS_BACKEND_CONFIG substring match -- which itself depends on torch_fl's
+own /dev/davinci* runtime probe having succeeded. See issue #192: that probe
+is not guaranteed (e.g. /dev is not enumerable), and its fallback path is
+"cuda". These tests confirm the marker now lets detect_platform() identify
+Ascend without depending on that runtime probe at all.
+
+Run: pytest tests/unit/test_platform_support_detect.py -v
+"""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PLATFORM_SUPPORT_PATH = _REPO_ROOT / "tests" / "integration" / "platform_support.py"
+
+
+def _load_platform_support():
+    """Import platform_support.py without going through the tests/integration
+    pytest-plugin machinery (which requires the full integration conftest)."""
+    spec = importlib.util.spec_from_file_location(
+        "platform_support_under_test", _PLATFORM_SUPPORT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+platform_support = _load_platform_support()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("ACCELERATOR", raising=False)
+    monkeypatch.delenv("FLAGOS_BACKEND_CONFIG", raising=False)
+    monkeypatch.delenv("PPU_SDK", raising=False)
+    monkeypatch.delenv("PPU_HOME", raising=False)
+
+
+def test_accelerator_env_wins_outright():
+    os.environ["ACCELERATOR"] = "ascend"
+    assert platform_support.detect_platform() == "ascend"
+
+
+@pytest.fixture
+def isolated_torch_fl_import(monkeypatch):
+    """Temporarily hide the real torch_fl module so detect_platform()'s
+    ``import torch_fl`` resolves a throwaway stub instead.
+
+    The real torch_fl.__init__ has import-time side effects (it registers the
+    "flagos" device module with torch._register_device_module()), which
+    raises RuntimeError on a second real import and corrupts state for any
+    test running afterwards. Swapping sys.modules["torch_fl"] out and back in
+    avoids re-triggering that import entirely.
+    """
+    real_torch_fl = sys.modules.pop("torch_fl", None)
+    try:
+        yield
+    finally:
+        sys.modules.pop("torch_fl", None)
+        if real_torch_fl is not None:
+            sys.modules["torch_fl"] = real_torch_fl
+
+
+def test_marker_identifies_ascend_without_any_env_or_config(
+    isolated_torch_fl_import, tmp_path
+):
+    """The scenario the issue's reproduction targets: no ACCELERATOR, no
+    FLAGOS_BACKEND_CONFIG. Previously this fell through to the "cuda" default
+    unless torch_fl's own /dev/davinci* probe had already set
+    FLAGOS_BACKEND_CONFIG as a side effect of import. The marker makes this
+    deterministic instead of accidental."""
+    fake_torch_fl_dir = tmp_path / "torch_fl"
+    lib_dir = fake_torch_fl_dir / "lib"
+    lib_dir.mkdir(parents=True)
+    (lib_dir / "flagos_platform").write_text("ascend\n")
+    (fake_torch_fl_dir / "__init__.py").write_text("")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        assert platform_support.detect_platform() == "ascend"
+    finally:
+        sys.path.remove(str(tmp_path))
+
+
+def test_no_marker_and_no_config_falls_back_to_cuda(isolated_torch_fl_import, tmp_path):
+    """Documents the residual gap: a torch_fl install with no marker and no
+    FLAGOS_BACKEND_CONFIG set still can't be identified as anything but cuda.
+    This is expected for CUDA-compatible platforms; for Ascend it is now
+    avoided by the marker (see the sibling test above), not by this
+    function's own logic."""
+    fake_torch_fl_dir = tmp_path / "torch_fl"
+    fake_torch_fl_dir.mkdir()
+    (fake_torch_fl_dir / "__init__.py").write_text("")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        assert platform_support.detect_platform() == "cuda"
+    finally:
+        sys.path.remove(str(tmp_path))
+
+
+def test_ppu_sdk_env_detected_before_marker_check():
+    os.environ["PPU_SDK"] = "/opt/ppu"
+    assert platform_support.detect_platform() == "ppu"

--- a/torch_fl/__init__.py
+++ b/torch_fl/__init__.py
@@ -111,15 +111,19 @@ def _select_backend_config() -> None:
     metax_boxing = os.environ.get("FLAGOS_METAX_BOXING", "0") == "1"
 
     # A vendor build whose kernels are native (no CUDA boxing) records its
-    # platform in lib/flagos_platform. MUSA has an explicit opt-in hybrid
-    # config; all other native platforms retain their native-only config.
+    # platform in lib/flagos_platform. MUSA and Ascend each have an explicit
+    # opt-in hybrid config; all other native platforms retain their
+    # native-only config. This branch runs before the /dev/davinci* runtime
+    # check below, so it must reproduce that check's FlagGems opt-in itself --
+    # otherwise an Ascend build with the marker installed would silently drop
+    # FLAGOS_USE_FLAGGEMS=1 back to the native-only conf.
     marker = os.path.join(os.path.dirname(__file__), "lib", "flagos_platform")
     if os.path.exists(marker):
         with open(marker) as f:
             platform = f.read().strip().lower()
         platform_name = f"backends_{platform}"
-        if platform == "musa" and use_flaggems:
-            platform_name = "backends_musa_flagos_py"
+        if platform in ("musa", "ascend") and use_flaggems:
+            platform_name = f"backends_{platform}_flagos_py"
         platform_conf = os.path.join(
             os.path.dirname(__file__), "configs", f"{platform_name}.conf"
         )


### PR DESCRIPTION
<!--
⚠️ AI-GENERATED PR TEMPLATE ⚠️
This template is for PRs created by AI agents (Claude Code, GitHub Codex, Cursor, etc.).
ALL sections marked REQUIRED must be completed before submission.
PRs missing required sections will be automatically closed.
-->

## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Investigated and fixed sub-issue #192 (Ascend profiler platform-detection fallback to CUDA), including verifying the issue's claim on real Ascend 910 hardware and finding the practical impact narrower than reported.

## Summary
`csrc/CMakeLists.txt` only wrote the `lib/flagos_platform` marker for gcu/musa/bpu builds, not Ascend, even though Ascend is also a native (non-CUDA) backend. This PR adds Ascend to that marker-writing branch and extends `torch_fl/__init__.py`'s marker-consuming logic to preserve Ascend's FlagGems opt-in, which the marker branch did not previously handle. On real Ascend hardware, the change is verified not to alter current runtime behavior (no marker is present in the box's existing build), and unit tests pin the new marker-driven paths.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [x] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)

This is Ascend-specific: the CMake predicate change only adds a new `ACCELERATOR STREQUAL "ascend"` branch condition, and the Python-side change only adds a case for `platform == "ascend"` inside logic keyed off the marker's *content*, which is only ever `"ascend"` on an Ascend build. GCU/MUSA/BPU/CUDA/MetaX marker-selection paths are unchanged (verified: `test_all_vendors_have_consistent_profiles` and the full pre-existing `tests/unit/test_vendor_routing.py` suite still pass unmodified).

## Problem Analysis

### What was broken/missing?
`csrc/CMakeLists.txt` wrote and installed `lib/flagos_platform` only when `ACCELERATOR` was `gcu`, `musa`, or `bpu`. Ascend builds never wrote this marker. `tests/integration/platform_support.py::detect_platform()` checks, in order: `ACCELERATOR` env var, then the marker, then a `FLAGOS_BACKEND_CONFIG` substring match, and finally defaults to `"cuda"`. Without the marker, Ascend detection depended entirely on the third step.

### Why did it happen?
The marker was added for gcu/musa/bpu to solve a specific problem (routing away from the default `backends_cuda.conf`), and Ascend was not included at the time — likely because Ascend's own `_select_backend_config()` in `torch_fl/__init__.py` already has a separate runtime detection path (`/dev/davinci*` enumeration) that was assumed sufficient.

### Investigation process (root cause, corrected from the issue's framing):
1. Read `csrc/CMakeLists.txt:536-548` and confirmed the marker-writing predicate excludes `ascend`; confirmed on this machine's real installed build tree that no marker file exists (`torch_fl/lib/` has no `flagos_platform`).
2. Ran `tests/integration/platform_support.py::detect_platform()` on this real Ascend 910 box with `ACCELERATOR` and `FLAGOS_BACKEND_CONFIG` unset (the issue's exact reproduction). Result: `"ascend"`, **not** `"cuda"` as the issue's "Actual Behavior" section claims. Root cause: `detect_platform()` does `import torch_fl` as part of the marker check; that import runs `torch_fl.__init__._select_backend_config()`, which independently detects `/dev/davinci*` and sets `FLAGOS_BACKEND_CONFIG` to `backends_ascend.conf` as a side effect. `detect_platform()`'s later config-substring fallback then matches `"ascend"` in that path. **Correction to the issue: today's detection is correct, but by an import side effect, not by design** — the marker was the mechanism meant to make this deterministic, and Ascend never got it.
3. Reproduced the actual failure condition by patching `os.listdir` to raise `OSError` on `/dev` (simulating a host/container where `/dev` is not enumerable, e.g. a permission-restricted sandbox): `_select_backend_config()` then silently falls through to `backends_cuda.conf`, and `detect_platform()` misidentifies the platform as `"cuda"`. This is the same failure the issue describes, but gated on a concrete, narrower, and verifiable precondition (`/dev` not enumerable) rather than "any process that doesn't retain `ACCELERATOR`".
4. Checked whether writing the marker for Ascend would change `torch_fl/__init__.py`'s own config selection. The marker branch (previously lines 113-128) runs *before* the `/dev/davinci*` branch and only special-cased MUSA's FlagGems opt-in (`FLAGOS_USE_FLAGGEMS=1` -> `backends_musa_flagos_py.conf`). Reproduced the regression this would cause: placed a fake `ascend` marker file, set `FLAGOS_USE_FLAGGEMS=1`, and confirmed `_select_backend_config()` picked `backends_ascend.conf` (native-only) instead of `backends_ascend_flagos_py.conf` (the FlagGems opt-in) -- i.e. installing the marker without extending the special case would silently disable Ascend's FlagGems routing.

## Solution Design

### Implementation approach:
1. `csrc/CMakeLists.txt`: add `ACCELERATOR STREQUAL "ascend"` to the marker-writing predicate, so Ascend wheels install `lib/flagos_platform` containing `ascend\n`, matching gcu/musa/bpu.
2. `torch_fl/__init__.py::_select_backend_config()`: extend the marker branch's FlagGems opt-in check from `platform == "musa"` to `platform in ("musa", "ascend")`, and generalize the hybrid config name from the hardcoded `"backends_musa_flagos_py"` to `f"backends_{platform}_flagos_py"` (both configs already exist: `backends_musa_flagos_py.conf`, `backends_ascend_flagos_py.conf`).

### Key design decisions:
- Kept the `/dev/davinci*` runtime probe in place as a fallback rather than removing it, so a wheel built before this change (no marker) keeps working exactly as it does today.
- Did not change `detect_platform()`'s final fallback from `"cuda"` to a neutral value (the issue's "Proposed Solution" suggests considering this). That is a broader behavior change affecting every platform's fallback semantics, and is out of scope for a narrowly-targeted marker fix; flagging as a possible follow-up (see "Explicitly Not Included").

### Code changes by file:
- `csrc/CMakeLists.txt` (lines 537-548): added `ascend` to the marker-writing condition; expanded the comment to document why (davinci-probe fragility) and that the davinci probe remains a fallback for older wheels.
- `torch_fl/__init__.py` (lines 113-129): generalized the marker branch's FlagGems opt-in from MUSA-only to `("musa", "ascend")`, and generalized the hybrid config filename construction.
- `tests/unit/test_ascend_platform_marker.py` (new): unit tests for `_select_backend_config()` against a scratch install tree with a fake Ascend marker -- default native conf, FlagGems opt-in conf, graceful fallback if the opt-in conf is missing, and that an explicit `FLAGOS_BACKEND_CONFIG` still overrides the marker.
- `tests/unit/test_platform_support_detect.py` (new): unit tests for `detect_platform()` -- `ACCELERATOR` env wins outright, the marker resolves Ascend with no env/config set (the issue's exact scenario), the no-marker/no-config fallback to `"cuda"` (documents the residual, expected gap for CUDA-compatible platforms), and that `PPU_SDK` is still checked before the marker.

### Changes by commit:
1. `a42c176` - `fix: install lib/flagos_platform marker for Ascend builds`: the CMake + Python fix, plus the two new unit test files, in one commit (small, single logical change; splitting it further would leave an intermediate broken state where the marker exists but the FlagGems opt-in is silently dropped).

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (if applicable) -- no type checker configured in this repo
- [x] **All tests pass** (unit + integration)
- [x] **Manual testing completed** (include reproduction of original issue)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [x] **Documentation updated** (README, CLAUDE.md, docstrings as needed) -- N/A, see "Explicitly Not Included"
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ ruff check
All checks passed!

$ ruff format --check
2 files would be reformatted, 214 files already formatted
(the 2 flagged were the new test files; fixed with `ruff format`, now:)

$ ruff format --check
216 files already formatted
```

### Test Results
```bash
$ pytest tests/unit/ -v
...
================= 119 passed, 97 skipped, 45 warnings in 8.95s =================
```
(97 skipped are all pre-existing, platform-gated tests for other hardware -- e.g. MUSA/DCU/BPU-specific tests skipped on this Ascend box. 0 failures. The 8 new tests: 4 in `test_ascend_platform_marker.py`, 4 in `test_platform_support_detect.py`.)

```bash
$ pytest tests/integration/ops/test_softmax_dispatch.py tests/integration/ops/test_sum_dispatch.py tests/integration/ops/test_where_dispatch.py --tb=short -q
........ss.......s.....ss......sss.                                      [100%]
27 passed, 8 skipped in 66.81s (0:01:06)
```
(Representative dispatch/routing-sensitive integration tests, run on real Ascend 910 hardware, to confirm op routing behavior is unaffected since no marker is present in this box's actual installed build.)

```bash
$ PYTHONPATH=tests/integration pytest tests/integration/test_profiler_contract.py -v -m profiler --tb=short
...
tests/integration/test_profiler_contract.py::test_profiler_cpu_api_and_trace_export PASSED
tests/integration/test_profiler_contract.py::test_profiler_kernel_events SKIPPED
... (10 more SKIPPED, all correctly gated by the Ascend capability profile)
=================== 1 passed, 11 skipped, 1 warning in 0.64s ===================
```
(This is the issue's own reproduction command. Confirms the current real-hardware Ascend result is unaffected: `detect_platform()` already resolves to `"ascend"` here via the import side effect described above, and continues to after this change.)

### Manual Verification
```bash
# Command to reproduce original issue (from the issue body):
unset ACCELERATOR FLAGOS_BACKEND_CONFIG
python -c "from platform_support import detect_platform; print(detect_platform())"

# Output BEFORE fix (on this real Ascend 910 box):
ascend
# (NOT "cuda" -- correcting the issue's claimed "Actual Behavior". See Investigation
#  step 2 above for why: an import-time side effect in torch_fl currently masks the
#  missing marker on this specific hardware/build.)

# Reproducing the actual failure condition (marker absent, AND /dev not enumerable):
python -c "
import os
_orig = os.listdir
os.listdir = lambda p='.': (_ for _ in ()).throw(OSError(13, 'simulated')) if p == '/dev' else _orig(p)
from platform_support import detect_platform
print(detect_platform())
"
# Output: cuda
# (Confirms the issue's core concern IS real, just narrower than described: it
#  requires /dev enumeration to fail, not merely ACCELERATOR being unset.)

# Output AFTER fix, with the marker present (simulated -- see Verification Gaps,
# this worktree cannot do a full C++ rebuild+install):
echo "ascend" > torch_fl/lib/flagos_platform
python -c "
import os
_orig = os.listdir
os.listdir = lambda p='.': (_ for _ in ()).throw(OSError(13, 'simulated')) if p == '/dev' else _orig(p)
from platform_support import detect_platform
print(detect_platform())
"
# Output: ascend
# (The marker now makes detection survive the /dev-enumeration failure, instead
#  of depending on it.)
```

## Performance Impact
N/A -- this is a build/config-selection change, not a runtime hot path.

## Breaking Changes
None. This is additive: it only writes a new file for Ascend builds and adds a
new `platform in ("musa", "ascend")` case to existing logic. Wheels built before
this change (no marker) fall back to the pre-existing `/dev/davinci*` detection,
unchanged.

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code) -- mirrored the existing MUSA marker-branch pattern rather than inventing a new one
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (no reinventing)

### Edge Cases Considered
1. Marker present but the corresponding `_flagos_py.conf` is missing (e.g. an older/partial install) -- falls back to the native-only conf rather than raising (`test_ascend_marker_falls_back_to_native_conf_if_flaggems_conf_missing`).
2. An explicit `FLAGOS_BACKEND_CONFIG` set by the user/CI must still override the marker (`test_explicit_backend_config_overrides_the_marker`).
3. `PPU_SDK`/`PPU_HOME` detection in `detect_platform()` must still take priority over the marker check (`test_ppu_sdk_env_detected_before_marker_check`).
4. No marker and no `FLAGOS_BACKEND_CONFIG` at all (a CUDA-compatible platform, or an Ascend build predating this fix) still correctly falls back to `"cuda"` -- this residual gap is intentional and documented, not silently papered over (`test_no_marker_and_no_config_falls_back_to_cuda`).

### Potential Risks
1. If a future Ascend hybrid config is renamed away from the `backends_ascend_flagos_py.conf` convention, the `f"backends_{platform}_flagos_py"` generalization would silently miss it and fall back to the native-only conf (not raise). This mirrors the pre-existing MUSA behavior, so it is not a new risk introduced by this change, but worth flagging for reviewer awareness.
2. This change was validated using a real install tree's build artifacts (`torch_fl/lib/`, `torch_fl/_C*.so`, `torch_fl/_build_config.py`) copied in from a separate, previously-built checkout on this machine, since a full C++ rebuild was out of scope (see Verification Gaps). These artifacts are gitignored and were removed before committing; they are not part of this PR's diff.

### Rollback Plan
Revert this commit. The marker is purely additive (a new file in the install
tree); removing the CMake predicate change stops Ascend wheels from writing it,
and Ascend detection reverts to depending solely on the `/dev/davinci*` runtime
probe, exactly as before this PR.

## Related Work
- Fixes #192
- Related to #184 (the combined profiler report this is a sub-issue of)

## Explicitly Not Included
- Did not change `detect_platform()`'s final fallback from `"cuda"` to a neutral `"default"`/unknown value, as the issue's "Proposed Solution" suggests considering. That changes fallback semantics for every platform (CUDA included) and deserves its own discussion, not a side effect of an Ascend-only marker fix.
- Did not attempt a full C++ rebuild + wheel install to observe the marker land end-to-end in a freshly built Ascend package (see Verification Gaps below); verified the CMake predicate by inspection and the consuming Python logic against a simulated marker file plus the real, unmodified `_select_backend_config()` / `detect_platform()` functions on real Ascend hardware.
- Did not touch `docs/reference/operator-support.md`: this change does not add, enable, remove, disable, or reroute any operator through a vendor-native backend or FlagGems; it only changes how the platform identity is detected/recorded.

## Human Review Notes

### Areas needing special attention:
1. The correction to the issue's "Actual Behavior" claim (section "Investigation process", step 2): please confirm this reframing is acceptable, since it changes the PR's narrative from "Ascend is misidentified as CUDA today" to "Ascend detection currently works by accident, and can misidentify as CUDA under a narrower, verifiable condition (`/dev` not enumerable)."
2. The FlagGems-opt-in regression fix in `torch_fl/__init__.py` (generalizing `platform == "musa"` to `platform in ("musa", "ascend")`) is bundled into this PR because it is a real regression the marker addition would otherwise introduce silently. Please confirm bundling it here (rather than as a separate PR) is acceptable given it's a one-line consequence of the marker change.

### Questions for reviewer:
1. Should the `/dev/davinci*` fallback probe in `torch_fl/__init__.py` eventually be removed once all supported Ascend wheels ship the marker, or kept indefinitely for backward compatibility with older installs?
2. Is a full rebuild+install verification (see Verification Gaps) required before merge, or is the Python-level simulation + CMake inspection sufficient given the low risk of the CMake change (a boolean OR clause extension)?

## Additional Context

### Verification Gaps
- Could not perform a full C++ rebuild and wheel install in this worktree to observe `lib/flagos_platform` actually land in a freshly built Ascend package end-to-end. This worktree's `build/` directory is not populated (a full Ascend ACL build is expensive), and the task instructions explicitly prohibited touching the main checkout's `build/` directory. Mitigated by: (a) inspecting the CMake predicate change directly -- it is a minimal boolean-OR extension to an existing, working pattern used by gcu/musa/bpu; (b) testing the Python-side consumer logic (`_select_backend_config()`, `detect_platform()`) against a real install tree with a manually-placed marker file simulating what the CMake change would produce.
- This worktree lacked several gitignored build artifacts (`torch_fl/lib/*.so`, `torch_fl/_C*.so`, `torch_fl/_build_config.py`) needed to import `torch_fl` at all. These were copied in from a separately-built checkout on this machine for the duration of testing, and removed before committing; they are not part of this PR's diff (confirmed via `git status` and `git check-ignore`).

<!--
REJECTION CRITERIA - PRs will be closed if:
❌ Missing required sections
❌ No verification results (must paste actual output)
❌ No root cause analysis
❌ No manual testing proof
❌ Tests not passing
❌ Linting not passing
❌ Not written in English
❌ Contains debug/temporary code
❌ Doesn't follow existing code style
❌ No explanation of edge cases
❌ No human reviewer assigned
-->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
