### PR TITLE
fix: restore MetaX stream event semantics

### DIFF
--- a/tests/integration/test_compile.py
+++ b/tests/integration/test_compile.py
@@ -194,6 +194,71 @@ def test_metax_inductor_event_uses_real_stream(device):
     assert start.elapsed_time(end) >= 0
 
 
+metax_only = pytest.mark.skipif(
+    torch_fl._build_accelerator() != "metax",
+    reason="MetaX build required",
+)
+
+
+@metax_only
+def test_metax_stream_shim_supports_event_ordering(device):
+    """The stream shim must carry the event API, not just a raw handle.
+
+    Inductor's cudagraph manager runs
+    ``torch.cuda.Stream().wait_stream(torch.cuda.current_stream())``, and
+    ``wait_stream`` is ``self.wait_event(stream.record_event())`` -- so a shim
+    without ``record_event`` made torch.compile die with AttributeError before it
+    could run a single kernel (issue #157).
+    """
+    current = torch.cuda.current_stream()
+
+    # The launcher contract the shim exists for in the first place.
+    assert current.cuda_stream == 0
+    assert current.device == torch.device("cuda", torch_fl.flagos.current_device())
+
+    # The exact call from the traceback.
+    torch.cuda.Stream().wait_stream(current)
+
+    event = current.record_event()
+    assert isinstance(event, torch.cuda.Event)
+    event.synchronize()
+    assert event.query()
+
+    # An explicitly supplied event must be the one returned, as on a real Stream.
+    provided = torch.cuda.Event()
+    assert current.record_event(provided) is provided
+
+    current.wait_event(event)
+    assert isinstance(current.query(), bool)
+    current.synchronize()
+
+    output = torch.ones(1024, device=device) + 1
+    assert_on_flagos(output)
+
+
+@metax_only
+def test_metax_stream_context_selects_capture_stream(device):
+    """``get_raw_stream`` must follow the current stream, not always report 0.
+
+    Generated Inductor code launches every kernel on ``get_raw_stream(idx)``, and
+    ``torch.cuda.graph()`` makes its capture stream current before capturing. A
+    hardcoded 0 would send those launches to the default stream, silently leaving
+    them out of the captured graph rather than failing.
+    """
+    default_raw = torch._C._cuda_getCurrentRawStream(torch_fl.flagos.current_device())
+    assert default_raw == 0
+
+    side = torch.cuda.Stream()
+    with torch.cuda.stream(side):
+        assert torch.cuda.current_stream().cuda_stream == side.cuda_stream
+        assert torch._C._cuda_getCurrentRawStream(side.device_index) == side.cuda_stream
+        output = torch.ones(1024, device=device) + 1
+
+    # The context manager has to put the default stream back.
+    assert torch._C._cuda_getCurrentRawStream(torch_fl.flagos.current_device()) == 0
+    assert_on_flagos(output)
+
+
 def test_inductor_benchmark_accepts_triton_backend_name():
     """The Triton backend name must not reach torch.device() as a device type.
 

--- a/torch_fl/accelerator/metax/_metax_compat.py
+++ b/torch_fl/accelerator/metax/_metax_compat.py
@@ -230,18 +230,110 @@ def _device_index(device: Union[torch.device, int, str, None]) -> int:
     return int(device)
 
 
-class _MetaxStreamShim:
-    """Minimal stream object exposing ``.cuda_stream`` for triton-metax.
+def _real_stream(device_index=0):
+    """Resolve the true default stream as a real ``torch.cuda.Stream``.
 
-    Uses the null/default stream (0), consistent with the boxing path where the
-    caching allocator is given ``stream=nullptr``. FlagGems' Triton launcher
-    reads ``.cuda_stream`` (and torch._C._cuda_getCurrentRawStream) to pick the
-    launch stream; the maca cu-bridge treats handle 0 as the default stream.
+    ``torch.flagos.current_stream`` reads the stream tuple from the C++ runtime
+    (``_cuda_getCurrentStream``), which the shim below never overwrote, so it is
+    the same physical MetaX stream the boxing kernels submit to.
+    """
+    flagos = getattr(torch, "flagos", None)
+    if flagos is None:
+        return None
+    try:
+        return flagos.current_stream(device_index)
+    except Exception:
+        return None
+
+
+class _MetaxStreamShim:
+    """Stream stand-in for the CPU torch wheel, where torch.cuda.Stream is a
+    dummy base class that raises on construction.
+
+    FlagGems' Triton launcher reads ``.cuda_stream`` (and
+    ``torch._C._cuda_getCurrentRawStream``) to pick the launch stream; that is 0,
+    the null/default stream, until something selects another one, matching the
+    boxing path where the caching allocator is given ``stream=nullptr``.
+
+    The event/ordering half of the stream API is delegated to the real stream
+    (``_real_stream``) rather than stubbed out. Inductor's cudagraph manager runs
+    ``torch.cuda.Stream().wait_stream(torch.cuda.current_stream())``, and
+    ``torch.cuda.Stream.wait_stream`` is implemented as
+    ``self.wait_event(stream.record_event())`` -- so a stream object that cannot
+    record an event makes ``torch.compile`` fail outright, and one that records
+    on the wrong stream would order the capture against work that is not there.
     """
 
     def __init__(self, index=0):
-        self.cuda_stream = 0
         self.device_index = index
+        # Snapshot the stream that is current *now*, rather than reading it on
+        # every attribute access. A stream object has to keep denoting the same
+        # stream for as long as it is held: torch.cuda.StreamContext saves
+        # current_stream() on entry and restores it on exit, so a live view would
+        # restore whatever became current in between -- i.e. never restore at all.
+        self._real = _real_stream(index)
+
+    @property
+    def cuda_stream(self):
+        """Raw handle of the stream this object denotes.
+
+        0 (the null/default stream) when nothing else has been selected, which is
+        the boxing default and what the maca cu-bridge expects. It has to reflect
+        ``torch.cuda.set_stream`` rather than stay pinned at 0, because this is the
+        handle FlagGems' Triton launcher submits kernels on: inside a
+        ``torch.cuda.stream(...)`` block a constant 0 would launch onto the default
+        stream while the caller believes it selected another one -- unordered
+        against the surrounding work, which corrupts results silently.
+        """
+        return 0 if self._real is None else self._real.cuda_stream
+
+    @property
+    def device(self):
+        """The device this stream belongs to, spelled as torch.cuda spells it.
+
+        ``torch.cuda.StreamContext.__enter__`` compares ``current_stream().device``
+        against the target stream's, so a shim without this attribute breaks every
+        ``with torch.cuda.stream(...)`` block (that is what ``torch.cuda.graph()``
+        enters before capture).
+        """
+        return torch.device("cuda", self.device_index)
+
+    @property
+    def stream_id(self):
+        return 0 if self._real is None else self._real.stream_id
+
+    @property
+    def device_type(self):
+        # DeviceType::CUDA; only reachable when there is a real CUDA stream.
+        return 1 if self._real is None else self._real.device_type
+
+    def record_event(self, event=None):
+        if self._real is None:
+            raise RuntimeError(
+                "cannot record an event on the MetaX stream shim: "
+                "torch.flagos is not initialized"
+            )
+        if event is None:
+            # Not `real.record_event(None)`: that allocates the `Event` bound
+            # inside torch/cuda/streams.py, which is the dummy base class on the
+            # CPU torch wheel. `torch.cuda.Event` is the one _patch_inductor_event
+            # points at the working flagos wrapper.
+            event = torch.cuda.Event()
+        event.record(self._real)
+        return event
+
+    def wait_event(self, event):
+        if self._real is None:
+            return None
+        return self._real.wait_event(event)
+
+    def wait_stream(self, other):
+        if self._real is None:
+            return None
+        return self._real.wait_stream(other)
+
+    def query(self):
+        return True if self._real is None else self._real.query()
 
     def synchronize(self):
         _metax_synchronize()
@@ -433,8 +525,25 @@ def patch_torch_cuda_for_metax():
     torch.cuda._maybe_exchange_device = _exchange_device
 
     # triton reads torch._C._cuda_getCurrentRawStream(idx) -> raw handle.
+    #
+    # Ask the C++ runtime first and only fall back to the default stream when it
+    # cannot answer. Returning a hardcoded 0 is wrong as soon as a non-default
+    # stream is current: generated Inductor code launches every kernel on
+    # `get_raw_stream(idx)`, so under `torch.cuda.graph()` (which makes its capture
+    # stream current) the kernels would go to the default stream and be left out of
+    # the captured graph instead of failing visibly.
+    _orig_raw_stream = getattr(torch._C, "_cuda_getCurrentRawStream", None)
+
+    def _current_raw_stream(idx=0):
+        if _orig_raw_stream is not None:
+            try:
+                return _orig_raw_stream(idx)
+            except Exception:
+                pass
+        return 0  # null/default stream, which the maca cu-bridge accepts
+
     try:
-        torch._C._cuda_getCurrentRawStream = lambda idx=0: 0
+        torch._C._cuda_getCurrentRawStream = _current_raw_stream
     except Exception:
         pass
 


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Synced with upstream `main`, investigated issue #157 on a live 8x MetaX C550 box, confirmed the reported failure is still present on latest `main`, and fixed the MetaX stream shim rather than disabling CUDA graphs.

## Summary
`torch.compile` on the MetaX `flagos` device failed with `AttributeError: '_MetaxStreamShim' object has no attribute 'record_event'` before a single kernel ran. Inductor's cudagraph manager calls `self.stream.wait_stream(torch.cuda.current_stream())`, and `torch.cuda.Stream.wait_stream` is implemented as `self.wait_event(stream.record_event())` — but under boxing `torch.cuda.current_stream` is patched to a shim that only carried a raw stream handle. This PR gives the shim real event and ordering semantics, delegated to the actual underlying MetaX stream, and fixes two adjacent stream-selection defects that the same cudagraph path walks straight into.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [x] MetaX
- [ ] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)

Only the MetaX boxing compatibility layer (`torch_fl/accelerator/metax/_metax_compat.py`) is touched, so no other platform changes behavior. See "Explicitly Not Included" for the equivalent defect in the NVIDIA shim, which is deliberately left alone.

## Problem Analysis

### What was broken/missing?
`_MetaxStreamShim` implemented only `__init__`, `.cuda_stream`, `.device_index` and `synchronize()`. It was missing the entire event/ordering half of the stream contract (`record_event`, `wait_event`, `wait_stream`, `query`) and the `device` / `stream_id` / `device_type` attributes. Any caller that treated the result of `torch.cuda.current_stream()` as a stream — which Inductor's cudagraph manager does — hit an `AttributeError`.

Two further defects in the same patch function were found while verifying the fix:

1. `torch._C._cuda_getCurrentRawStream` was overwritten with `lambda idx=0: 0`.
2. `.cuda_stream` was hardcoded to `0` in `__init__`.

Both silently ignore stream selection. Generated Inductor code launches every kernel on `get_raw_stream(idx)`, and `torch.cuda.graph()` makes its capture stream current *before* capturing — so a constant `0` sends those launches to the default stream and leaves them out of the captured graph. That is a wrong-results failure mode, not a crash, which is why it had not surfaced as a bug report.

### Why did it happen?
The shim was introduced for one narrow job: the official `torch+cpu` wheel builds `torch.cuda.Stream` as a dummy base class that raises on construction, and FlagGems' Triton launcher needs *something* exposing `.cuda_stream`. It was intentionally minimal for that purpose, and its docstring said so. The compile path arrived later and expects the full contract.

The hardcoded `0` values date from the same assumption ("boxing always submits to the null stream"). That holds for eager boxing but not once cudagraph capture selects a side stream.

### Investigation process:
1. Read the issue, then confirmed it is still open and unfixed on `flagos/main` (`3a87ffc`) — `git log --all --grep='record_event|cudagraph'` found no prior fix.
2. Reproduced the minimal case on hardware: `torch.cuda.Stream().wait_stream(torch.cuda.current_stream())` → `AttributeError`.
3. Traced the chain from `cudagraph_trees.py:1946` through `torch/cuda/streams.py:75` (`self.wait_event(stream.record_event())`) and confirmed by reading the installed torch source that `wait_stream` genuinely requires `record_event` on its argument.
4. Checked whether the existing `patches["triton.cudagraphs"] = False` in `torch_fl/compile/inductor_backend.py:301` already covers this. It does not: it applies to `backend="flagos"`, while transformers' `CompileConfig` defaults to `backend="inductor"` and `mode="reduce-overhead"`.
5. Tested whether CUDA graphs work at all on MetaX before considering the issue's "disable cudagraphs" option — manual `capture_begin` / `capture_end` / `replay` produced correct results on a C550, so disabling would give up working functionality.
6. Verified `torch.flagos.current_stream()` / `_real_current_stream()` already resolve the true stream and that `record_event` / `wait_event` / `wait_stream` all work on it.
7. Checked that the native `torch._C._cuda_getCurrentRawStream` answers correctly on **both** the maca wheel and the official CPU wheel, which is what makes replacing the hardcoded `0` safe.
8. Confirmed the C++ boxing path reads the real current stream (`csrc/runtime/guard.h:119` `getCurrentCUDAStream`, `csrc/aten/copy_ops.cc:60`), so a stream-following shim is consistent with the kernels rather than a divergence from them.

## Solution Design

### Implementation approach:
Add a module-local `_real_stream(device_index)` helper that resolves the true stream via `torch.flagos.current_stream` (which reads `_cuda_getCurrentStream` from the C++ runtime — never shimmed). `_MetaxStreamShim` then delegates `record_event` / `wait_event` / `wait_stream` / `query` and exposes `device` / `stream_id` / `device_type` / `cuda_stream` from that stream.

`record_event(None)` allocates via `torch.cuda.Event` rather than letting the real stream allocate, because `torch.cuda.Stream.record_event` closes over the `Event` bound *inside* `torch/cuda/streams.py` — the dummy base class on the CPU wheel. `torch.cuda.Event` is the name `_patch_inductor_event()` already points at the working `flagos.Event`.

For the raw-stream getter, ask the native implementation first and keep `0` only as a fallback for builds that cannot answer.

### Key design decisions:
**Fix the shim instead of disabling cudagraphs.** The issue proposed disabling cudagraph capture on MetaX as the recommended option, on the assumption that MetaX may not support the stream/event primitives. I checked that assumption on hardware and it does not hold: manual CUDA graph capture and replay work on a C550, and `record_event` / `wait_event` on the real stream work. Disabling would trade away working functionality to hide a Python-layer gap, and would also leave `backend="inductor"` unaffected unless the global config were mutated.

**Snapshot the stream at construction, do not read it live.** This is the subtlety that my first attempt got wrong, and my own new test caught it. `torch.cuda.StreamContext` saves `current_stream()` on entry and restores it on exit. A shim whose `cuda_stream` was a live view of "whatever is current now" restores whatever became current in between — i.e. never restores at all, leaking the side stream out of the `with` block. A real `torch.cuda.Stream` denotes one fixed stream for its lifetime, so the shim must too.

**Delegate rather than reimplement.** The event plumbing already exists and is already verified (`torch.flagos.Event`, `_real_current_stream`). Adding a second ctypes-based event implementation over the cu-bridge, as the issue's option 1 suggested, would duplicate it.

### Code changes by file:
- `torch_fl/accelerator/metax/_metax_compat.py` (lines 233-246, new `_real_stream`): resolves the true stream through `torch.flagos.current_stream`, returning `None` when `torch.flagos` is not yet registered.
- `torch_fl/accelerator/metax/_metax_compat.py` (lines 249-339, `_MetaxStreamShim`): snapshots the real stream in `__init__`; adds `cuda_stream` / `device` / `stream_id` / `device_type` properties and `record_event` / `wait_event` / `wait_stream` / `query`; docstring rewritten to state what the class is actually for (the CPU wheel's dummy `Stream`) rather than only the launcher handle.
- `torch_fl/accelerator/metax/_metax_compat.py` (lines 512-533): `_cuda_getCurrentRawStream` now defers to the native getter, falling back to `0`.
- `tests/integration/test_compile.py` (lines 197-262): two MetaX-gated regression tests, plus a shared `metax_only` marker.

### Changes by commit:
1. `8307686` - `fix: give the MetaX stream shim real event and ordering semantics`: single logical change — the shim contract and the two stream-selection defects it exposes are the same bug surface, and splitting them would leave an intermediate commit where `cuda_stream` and `get_raw_stream` disagree about which stream is current.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [ ] **Type checking passed** (if applicable) — no type checker configured in this repo
- [x] **All tests pass** (unit + integration) — modulo 4 pre-existing failures, shown below to be identical on a clean tree
- [x] **Manual testing completed** (include reproduction of original issue)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [x] **Documentation updated** (docstrings on every new member; no operator routing changed, so `docs/reference/operator-support.md` does not apply)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ ruff check
All checks passed!

$ ruff format --check
214 files already formatted
```

### Test Results
```bash
# Command:
MACA_PATH=/opt/maca FLAGOS_METAX_BOXING=1 pytest tests/integration/test_compile.py -q

# Output:
1 failed, 25 passed, 21 skipped, 14 warnings in 4.99s
FAILED tests/integration/test_compile.py::test_torch_backends_entry_point_is_registered

# The one failure is environmental and pre-existing: this checkout runs from
# PYTHONPATH rather than a pip install, so the torch.backends entry point is not
# in the installed metadata. Baseline on a clean tree (git stash) is identical.

# The two new tests specifically:
MACA_PATH=/opt/maca FLAGOS_METAX_BOXING=1 pytest tests/integration/test_compile.py -q \
  -k "metax_stream or metax_inductor_event"
3 passed, 44 deselected in 0.08s

# Unit suite:
MACA_PATH=/opt/maca FLAGOS_METAX_BOXING=1 pytest tests/unit/ -q
3 failed, 109 passed, 94 skipped, 30 warnings in 12.83s
FAILED tests/unit/test_compile_platform_profile.py::test_benchmarker_patch_translates_triton_device_name
FAILED tests/unit/test_compile_platform_profile.py::test_publish_on_device_module_is_a_noop_without_cpp_wrapper
FAILED tests/unit/test_profiler_privateuse1.py::test_cupti_library_locatable

# Same three fail on a clean tree (verified with git stash), so they are not
# caused by this change:
git stash && pytest tests/unit/ -q
3 failed, 109 passed, 94 skipped, 30 warnings in 12.80s   # identical set

# Stream/event regression suite for the surface this PR touches:
MACA_PATH=/opt/maca FLAGOS_METAX_BOXING=1 pytest tests/manual/metax/test_event_pin_metax.py -q
4 passed, 1 warning in 12.66s

# Eager op / allocator regression (shim must not disturb the eager path):
pytest tests/integration/test_ops.py tests/integration/test_allocator.py \
       tests/integration/test_factory_ops.py -q
2 failed, 113 passed in 1.12s
FAILED tests/integration/test_ops.py::TestMatrixOps::test_mm
FAILED tests/integration/test_ops.py::TestMatrixOps::test_mm_out
# Both pre-existing; identical on a clean tree (2 failed, 113 passed).
```

### Manual Verification
```bash
# Command to reproduce original issue -- the exact constructor from the traceback
# (torch/_inductor/cudagraph_trees.py:1946):
MACA_PATH=/opt/maca FLAGOS_METAX_BOXING=1 python -c "
import torch, torch_fl
import torch._inductor.cudagraph_trees as ct
ct.CUDAGraphTreeManager(torch_fl.flagos.current_device())
print('constructed OK')
"

# Output BEFORE fix:
R: FAIL AttributeError '_MetaxStreamShim' object has no attribute 'record_event'

# Output AFTER fix:
R: CUDAGraphTreeManager constructed OK CUDAGraphTreeManager
R: manager stream <torch.cuda.Stream device=cuda:0 cuda_stream=0x556df53c6020>
```

```bash
# The issue's minimal reproducer, after the fix:
R: type _MetaxStreamShim cuda_stream 0 device cuda:0
R: wait_stream OK
R: record_event Event query True
R: wait_event OK query False
R: in-context raw 94905232251536 expect 94905232251536   # stream selection now honored
R: out-of-context raw 0                                  # and correctly restored

# End-to-end compile, mode="reduce-overhead", fullgraph=True, backend="inductor":
R: device flagos:0 match True

# FlagGems routing unaffected (backends_metax_flaggems.conf active):
[flagos] loading backend config from .../configs/backends_metax_flaggems.conf
R: gelu ok True
R: shim stream 0        # launcher still gets the default-stream handle
```

Hardware: 8x MetaX C550, MACA 3.8.0.23, KMD 3.8.1, BIOS 1.29.1.0, triton 3.6.0+metax, torch 2.10.0.

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (no reinventing)

The comment style follows this file and `torch_fl/flagos/__init__.py`: explain the failure mode a reader would otherwise re-derive, not the mechanics. Event resolution reuses the existing `torch.flagos.current_stream` / `flagos.Event` path rather than adding a parallel cu-bridge implementation.

### Edge Cases Considered
1. **`torch.flagos` not yet registered.** `patch_torch_cuda_for_metax()` is called both before and after `torch.flagos` exists (see the `_patched` early-return). `_real_stream` returns `None` in that window; the accessors then report the default-stream values (`0`, `1`) and `wait_*` become no-ops, while `record_event` raises a named `RuntimeError` rather than an `AttributeError` on `None`.
2. **Explicitly supplied event.** `record_event(event)` must return *that* event, matching `torch.cuda.Stream`; asserted in the test.
3. **Stream restored after a `with torch.cuda.stream(...)` block.** Asserted explicitly — this is the case that caught the live-view bug in my first attempt.
4. **Non-zero device index.** `device` is built from `self.device_index`, and the raw-stream assertion in the test queries `side.device_index` rather than assuming 0.
5. **FlagGems launcher contract.** `cuda_stream == 0` on the default stream is asserted, since that is the whole reason the shim exists.
6. **Native getter missing or raising.** `_cuda_getCurrentRawStream` is captured with `getattr(..., None)` and wrapped in `try`, preserving the previous fallback.

### Potential Risks
1. `.cuda_stream` and `get_raw_stream` now follow the current stream instead of always reporting `0`. On the default stream both are still `0`, so the eager and FlagGems paths are byte-identical; behavior only differs inside an explicit stream context, where the old value was wrong. Verified eager + FlagGems + compile suites above.
2. Each `torch.cuda.current_stream()` call now constructs a real `torch.cuda.Stream` object, so it is slightly more expensive than returning a bare handle. It is not on a kernel-launch inner loop (generated code calls `get_raw_stream`, which is unchanged in cost), and the compile suite runtime did not move (4.66s baseline vs 4.99s).
3. `record_event` now raises `RuntimeError` where it previously raised `AttributeError` in the uninitialized-`torch.flagos` window. Both are failures; the new one names the cause.

### Rollback Plan
`git revert 8307686`. The change is confined to one compatibility module plus its tests, touches no generated artifacts, no C++, and no operator routing, so reverting restores the previous behavior exactly (including the original `AttributeError`).

## Related Work
- Fixes #157
- Related to #158 (`feat: validate MetaX FlagTree torch.compile integration`), which fixed the neighboring case where Inductor's autotuner constructed `torch.cuda.Event` against this same shim; that PR added `_patch_inductor_event()`, which this change reuses.

## Explicitly Not Included
- **The identical gap in the NVIDIA shim.** `torch_fl/accelerator/cuda/_cuda_compat.py` has the same minimal `_StreamShim` (line 268) and the same `_cuda_getCurrentRawStream = lambda idx=0: 0` (line 447), so it is presumably reachable the same way. I have no NVIDIA box in this session and will not change a stream path I cannot execute; that shim also hands out `flagos.Stream` for `torch.cuda.Stream`, so its behavior may differ. Worth a follow-up issue.
- **Anything about `triton.cudagraphs`.** `_resolve_config_patches` still forces cudagraphs off for `backend="flagos"`. I left that alone: it is a separate policy decision, and this fix makes the `backend="inductor"` path work rather than needing it suppressed.
- **The unrelated first-compile `mcPointerGetAttribute` failure.** While testing I hit an intermittent `ValueError: Pointer argument (at 1) cannot be accessed from Triton (cpu tensor?)` on the *first* compile of a small graph in a fresh process (succeeds on retry, and does not occur for a `Linear` model). It reproduces on a clean tree, is independent of the stream API, and is out of scope here — see "Questions for reviewer".
- **The 4 pre-existing test failures** listed above, all shown identical on a clean tree.

## Human Review Notes

### Areas needing special attention:
1. **The snapshot-vs-live decision in `__init__`** (`self._real = _real_stream(index)`). This is the load-bearing subtlety: a live view breaks `StreamContext` save/restore. Please sanity-check the reasoning, since it makes each shim instance denote a fixed stream, which is a semantic change from "always the default stream".
2. **Removing the hardcoded `0` from `_cuda_getCurrentRawStream`.** I verified the native getter behaves on both the maca and official CPU wheels, but this is the change with the widest blast radius (every generated kernel launch reads it), so it deserves a second opinion — particularly whether any supported MetaX wheel exists where the native getter misreports.
3. **`record_event`'s deliberate use of `torch.cuda.Event` over `real.record_event(None)`.** The reason is that `torch.cuda.Stream.record_event` closes over the module-level `Event` in `torch/cuda/streams.py`, which is the dummy class on the CPU wheel. If a future refactor "simplifies" this to `real.record_event(event)`, it will break on the CPU wheel but not on the maca wheel.

### Questions for reviewer:
1. Should I file a separate issue for the NVIDIA `_StreamShim` having the same defect, or would you prefer I extend this PR once someone can run it on an NVIDIA box?
2. The intermittent first-compile `mcPointerGetAttribute` failure noted above looks like a real (separate) bug in the boxing/allocator-vs-Triton interaction. Want me to open an issue with the reduction I have?

## Additional Context
The issue offered two options and recommended option 2 (disable cudagraph capture on MetaX) *if* stream/event primitives were unsupported. I checked that precondition on hardware rather than assuming it: manual CUDA graph capture and replay both work on a C550, and the real stream supports `record_event` / `wait_event`. So this PR implements option 1, which keeps the functionality.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
