### PR TITLE
fix: restore torch.compile on native MUSA and GCU accelerators

### DIFF
--- a/.github/configs/musa.yml
+++ b/.github/configs/musa.yml
@@ -96,6 +96,22 @@ integration_tests:
       python -m pytest tests/integration/test_math_bits_contract.py
       -v -m math_bits --tb=short
 
+  # Measured on the MTT S5000 on 2026-08-29: 11 passed, 1 skipped. The old
+  # withheld note incorrectly applied GCU's limitation to MUSA -- a CPU-only
+  # PyTorch/Kineto build supplying no PrivateUse1 resolver, so no device events
+  # reach the profiler. That does not hold here: the MUPTI tracer resolves
+  # device activity on this CPU 2.10 wheel, and the kernel, runtime, flow,
+  # linkage, metadata, demangling and capture-window cases all pass.
+  #
+  # Only gpu_memset skips, through the capability table in
+  # tests/integration/profiler_support.py rather than a deselect: MUPTI emits no
+  # memset records. gpu_memcpy is claimed for MUSA in that table because it is
+  # measured, so the memcpy case runs rather than skipping.
+  - name: Unified profiler contract
+    command: >-
+      python -m pytest tests/integration/test_profiler_contract.py
+      -v -m profiler --tb=short
+
   # Marker selection, not a file allowlist: the generic per-op dispatch files
   # carry @pytest.mark.anyplatform. The platform gate (conftest.py) skips the
   # cuda/metax/ascend/dcu/flaggems_python-marked cases on MUSA, so this selects
@@ -158,15 +174,26 @@ integration_tests:
 
   # ---------------------------------------------------------------------------
   # Deliberately not included yet, so the gap is recorded rather than implied:
-  #   - tests/integration/test_profiler_contract.py. MUSA shares the same
-  #     environment limitation recorded for GCU: a CPU-only PyTorch/Kineto build
-  #     supplies no PrivateUse1 resolver, so device events never reach the
-  #     profiler. Withheld until measured end to end with a vendor Kineto build.
   #   - tests/integration/test_compile.py. torch.compile needs the vendor
   #     flagtree (flagtree-0.5.0+mthreads3.1, Triton 3.1, backend "mthreads");
-  #     set_env_musa.sh deliberately does not link one. Add when the image bakes
-  #     the vendor triton stack.
+  #     set_env_musa.sh deliberately does not link one, and stock PyPI triton is
+  #     not a substitute -- it ships no mthreads backend and cannot compile a
+  #     MUSA kernel at all. The suite itself is green on the MTT S5000 with that
+  #     runtime on PYTHONPATH (2026-08-29: 25 passed, 19 skipped, 1 failed, the
+  #     failure being the torch.backends entry-point case, which asserts an
+  #     installed wheel and cannot hold in a build-tree run). Add this group when
+  #     the image bakes the vendor triton stack; it is an image gap, not a code
+  #     one.
   #   - tests/integration/ops/test_musa_flaggems.py (FLAGOS_USE_FLAGGEMS=1
-  #     hybrid route). Same vendor-triton prerequisite as compile.
+  #     hybrid route). Same vendor-triton prerequisite as compile: its two cases
+  #     skip without FlagGems installed, so adding the group to this image would
+  #     record a pass that measured nothing.
+  #   - tests/integration/test_profiler_parity.py. Unlike the contract group
+  #     above, parity diffs the flagos trace against a *torch-cuda baseline*, so
+  #     it is only meaningful on the CUDA-boxing platforms that run it (cuda,
+  #     dcu). Measured here on 2026-08-29 for completeness: 5 passed, 2 failed,
+  #     both on capabilities MUPTI does not report rather than on a torch_fl
+  #     defect -- no gpu_memset category, and no occupancy-derived kernel args
+  #     ('blocks per SM', 'warps per SM', 'est. achieved occupancy %').
   #   - Qwen3 inference/training smoke, pending a model mount on the runner.
   # ---------------------------------------------------------------------------

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -208,7 +208,13 @@ represented in tests or docs for this platform.
 
 ### Moore Threads MUSA
 
-No CI manifest exists for this platform. MUSA takes the native operator route through `mudnn`,
+A CI manifest exists for this platform ([`.github/configs/musa.yml`](../../.github/configs/musa.yml)),
+covering the isolated-environment preflight, MUSA dispatch, general factory ops, the unified AMP,
+math-bits and profiler contracts, the native mudnn operator subset, and the RNG suite. Three groups
+other platforms run are withheld with the reason recorded in that manifest: `torch.compile` and the
+FlagGems hybrid route both need the vendor Triton stack the CI image does not bake, and profiler
+parity is a torch-cuda baseline diff that only the CUDA-boxing platforms can meaningfully run.
+MUSA takes the native operator route through `mudnn`,
 with a documented CPU fallback for ops the vendor kernel table does not cover (see
 [`setup.py`](../../setup.py), lines 440-457, and
 `tests/integration/ops/test_musa_dispatch.py`, lines 15-24). No CUDA boxing kernels or FlagGems
@@ -221,11 +227,16 @@ GradScaler unscale operation currently follows the correctness-oriented CPU fall
 its mutated tensors and `found_inf` flag back to MUSA rather than using a native mudnn foreach
 kernel. Distributed support remains unvalidated on hardware. The optional MUPTI tracer has been
 measured on the available MTT S5000 host and emits real positive-duration kernel, runtime, and
-memcpy activities with device, stream, name, and Chrome-trace metadata. `torch.compile` is
+memcpy activities with device, stream, name, and Chrome-trace metadata. The unified profiler
+contract runs in CI for this platform and passed 11 of 12 cases on the MTT S5000 on 2026-08-29,
+including device kernel and runtime events, flow pairing, CPU-to-device linkage, kernel-name
+demangling and capture-window containment. Only `gpu_memset` is skipped, through the capability
+table rather than a deselect, because MUPTI emits no memset records. `torch.compile` is
 validated on this host against the vendor `flagtree-0.5.0+mthreads3.1` runtime and is not
-established by stock Triton: the 22-case `tests/integration/test_compile.py` suite passed on the
-MTT S5000, covering forward and backward execution, FP32/FP16 inputs, max-autotune,
-recompilation, FakeTensor tracing, and output/gradient placement on `flagos`. FlagTree reaches the
+established by stock Triton: `tests/integration/test_compile.py` passed on the MTT S5000 (25 passed
+on 2026-08-29), covering forward and backward execution, FP32/FP16 inputs, max-autotune,
+recompilation, FakeTensor tracing, and output/gradient placement on `flagos`. It is not yet a CI
+group, because the CI image bakes no vendor Triton stack. FlagTree reaches the
 device through `torch_fl.compile.flagtree_shim`, which rebinds the vendor MThreads driver's runtime
 lookups onto `torch_fl`; the separate `torch_musa` plugin is not installed and its `__init__` is
 never imported, since PrivateUse1 admits only one owner. The suite asserts that every rebound

--- a/tests/integration/profiler_support.py
+++ b/tests/integration/profiler_support.py
@@ -65,7 +65,7 @@ def capabilities_for_platform(platform: str) -> ProfilerCapabilities:
         device=device,
         kernel=device,
         runtime=runtime,
-        memcpy=device and platform in {"cuda", "metax", "ppu"},
+        memcpy=device and platform in {"cuda", "metax", "ppu", "musa"},
         memset=device and platform in {"cuda", "metax"},
         flow=device,
         linkage=device,

--- a/tests/unit/test_compile_platform_profile.py
+++ b/tests/unit/test_compile_platform_profile.py
@@ -53,7 +53,27 @@ def as_cuda(monkeypatch):
             lambda: pp._CUDA_PROFILE,
             raising=False,
         )
+    monkeypatch.setattr("torch_fl._build_config.ACCELERATOR", "cuda")
     return pp._CUDA_PROFILE
+
+
+@pytest.fixture
+def as_musa(monkeypatch):
+    """Force every profile consumer onto the MUSA profile.
+
+    Not CUDA-like, but not Ascend either: the third shape, and the one a single
+    `is_cuda_like` boolean cannot express. ACCELERATOR is patched alongside the
+    profile because the generated-code snippets branch on it directly, so a run
+    on any other platform's CI would otherwise take the wrong branch.
+    """
+    for module in ("platform_profile", "device_interface", "inductor_codegen"):
+        monkeypatch.setattr(
+            f"torch_fl.compile.{module}.platform_profile",
+            lambda: pp._MUSA_PROFILE,
+            raising=False,
+        )
+    monkeypatch.setattr("torch_fl._build_config.ACCELERATOR", "musa")
+    return pp._MUSA_PROFILE
 
 
 # --- profile selection ------------------------------------------------------
@@ -66,6 +86,8 @@ def as_cuda(monkeypatch):
         ("ascend", pp._ASCEND_PROFILE),
         ("metax", pp._METAX_PROFILE),
         ("dcu", pp._DCU_PROFILE),
+        ("musa", pp._MUSA_PROFILE),
+        ("gcu", pp._GCU_PROFILE),
         ("cuda", pp._CUDA_PROFILE),
         ("ppu", pp._CUDA_PROFILE),
         ("", pp._CUDA_PROFILE),
@@ -337,10 +359,13 @@ def test_has_triton_priming_restores_the_device_table(as_ascend, monkeypatch):
 
     # A fresh cache over the same function, so the priming path is really taken
     # (it returns early when something is already memoized) without discarding
-    # the answer the rest of the process is using.
-    monkeypatch.setattr(
-        _triton, "has_triton", functools.cache(_triton.has_triton.__wrapped__)
-    )
+    # the answer the rest of the process is using. `__wrapped__` is only there
+    # while has_triton is still the functools.cache'd original: on a native
+    # accelerator host `import torch_fl` has already swapped in the plain
+    # has_native_triton override, and reaching through it raised AttributeError
+    # before the test could assert anything.
+    original = getattr(_triton.has_triton, "__wrapped__", _triton.has_triton)
+    monkeypatch.setattr(_triton, "has_triton", functools.cache(original))
     dyn_di.get_interface_for_device("cuda")
     before = dict(dyn_di.device_interfaces)
 
@@ -348,6 +373,32 @@ def test_has_triton_priming_restores_the_device_table(as_ascend, monkeypatch):
 
     assert dyn_di.device_interfaces == before
     assert _triton.has_triton.cache_info().currsize == 1
+
+
+@pytest.mark.anyplatform
+def test_has_triton_priming_tolerates_the_native_override(as_musa, monkeypatch):
+    """Priming must not assume has_triton is still the functools.cache'd original.
+
+    On a native accelerator the tail of register_flagos_device_interface()
+    replaces `_triton.has_triton` with a plain function. That function has no
+    `cache_info`, so reading it raises AttributeError -- and because the compile
+    backend re-registers before every compile_fx, this is what every
+    torch.compile after the first hits. It surfaced as
+    `BackendCompilerFailed: 'function' object has no attribute 'cache_info'`,
+    i.e. torch.compile broken outright on MUSA and GCU.
+    """
+    from torch.utils import _triton
+
+    from torch_fl.compile import device_interface as di
+
+    def has_native_triton() -> bool:
+        return True
+
+    monkeypatch.setattr(_triton, "has_triton", has_native_triton)
+
+    di._prime_has_triton()
+
+    assert _triton.has_triton is has_native_triton
 
 
 # --- codegen registration ---------------------------------------------------
@@ -400,6 +451,26 @@ def test_ascend_device_op_overrides_emit_no_cuda(as_ascend):
     for snippet in snippets:
         assert "cuda" not in snippet.lower(), snippet
     assert "current_acl_raw_stream" in snippets[-1]
+
+
+@pytest.mark.anyplatform
+def test_musa_device_op_overrides_emit_the_musa_raw_stream(as_musa):
+    """A non-CUDA build that is not Ascend must not get the ACL snippets.
+
+    MUSA and GCU are `is_cuda_like=False` like Ascend, but their raw-stream
+    getters are branches of FlagOSDeviceOpOverrides, so selecting on that boolean
+    emitted `current_acl_raw_stream` into generated MUSA code -- which dies at
+    call time on `libflagos.so: undefined symbol: GetCurrentStream`.
+    """
+    from torch_fl.compile import inductor_codegen as ic
+
+    overrides = ic._device_op_overrides()
+    assert isinstance(overrides, ic.FlagOSDeviceOpOverrides)
+    assert not isinstance(overrides, ic.FlagOSAscendDeviceOpOverrides)
+
+    snippet = overrides.import_get_raw_stream_as("get_raw_stream")
+    assert "current_acl_raw_stream" not in snippet
+    assert "get_musa_current_raw_stream as get_raw_stream" in snippet
 
 
 @pytest.mark.anyplatform

--- a/torch_fl/compile/device_interface.py
+++ b/torch_fl/compile/device_interface.py
@@ -568,7 +568,18 @@ def _prime_has_triton() -> None:
 
     from torch.utils import _triton
 
-    if _triton.has_triton.cache_info().currsize:
+    # On a native accelerator this function has already been replaced outright by
+    # the `has_native_triton` override installed at the end of
+    # register_flagos_device_interface(), which is a plain function and answers
+    # True unconditionally. There is no cache left to prime, and nothing to gain
+    # from priming one: `cache_info` is absent, so probing it raises. This is the
+    # second and every later call -- `import torch_fl` registers once, and the
+    # compile backend re-registers before each compile_fx.
+    cache_info = getattr(_triton.has_triton, "cache_info", None)
+    if cache_info is None:
+        return
+
+    if cache_info().currsize:
         return
 
     import torch._dynamo.device_interface as di

--- a/torch_fl/compile/inductor_codegen.py
+++ b/torch_fl/compile/inductor_codegen.py
@@ -134,10 +134,19 @@ class FlagOSAscendDeviceOpOverrides(DeviceOpOverrides):
 
 
 def _device_op_overrides() -> DeviceOpOverrides:
-    """Pick the overrides matching this build's runtime."""
-    if platform_profile().is_cuda_like:
-        return FlagOSDeviceOpOverrides()
-    return FlagOSAscendDeviceOpOverrides()
+    """Pick the overrides matching this build's runtime.
+
+    Keyed on the vendor rather than on ``is_cuda_like``. MUSA and GCU are not
+    CUDA-like either, but their raw-stream imports are the ``musa``/``gcu``
+    branches of ``FlagOSDeviceOpOverrides.import_get_raw_stream_as`` -- selecting
+    the Ascend class for them emits ``current_acl_raw_stream`` into generated
+    code, which fails at call time on ``libflagos.so: undefined symbol:
+    GetCurrentStream``. Ascend is the only build whose device snippets come from
+    the ACL runtime.
+    """
+    if platform_profile().vendor == "ascend":
+        return FlagOSAscendDeviceOpOverrides()
+    return FlagOSDeviceOpOverrides()
 
 
 def register_flagos_codegen() -> None:


### PR DESCRIPTION
<!--
AI-generated PR: all required sections below are completed.
-->

## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @aoyulong
- **Session Summary**: Synchronized with the merged `flagos/main`, then ran the MUSA suites on an MTT S5000 to see what the new MUSA CI pipeline should guard. `torch.compile` turned out to be broken on `main` for every native accelerator by two independently-added patches colliding; fixed both, added hardware-free regression tests, and corrected the MUSA manifest's withheld notes against measured results.

## Summary
Restores `torch.compile` on the native (non-CUDA-runtime) accelerators, MUSA and GCU, where it is currently broken on `main`: two patches added independently for Ascend (#189) and GCU (#187) collide, so the second and every later compile in a process raises `BackendCompilerFailed`, and the generated code imports an Ascend-only stream getter that does not resolve on MUSA. Both fixes are small and vendor-scoped; neither touches the CUDA-like platforms.

Also adds the unified profiler contract as a guarded group in the MUSA CI manifest. It was withheld on the stated grounds that MUSA shares GCU's CPU-only-Kineto limitation, which does not hold on this host: MUPTI resolves real device activity and 11 of 12 cases pass. The remaining withheld entries are rewritten so each records the actual reason, and `compatibility.md` no longer claims MUSA has no CI manifest.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [x] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [x] MUSA (vendor-specific)
- [x] GCU (vendor-specific, same code path)
- [ ] Platform-agnostic (all platforms)

## Problem Analysis
### What was broken/missing?

Three separate things, found in this order.

1. **`torch.compile` fails on the second and every later compile.** `_prime_has_triton()` reads `torch.utils._triton.has_triton.cache_info()`. On a native accelerator that attribute is gone, so any real `torch.compile` dies:

   ```
   torch._dynamo.exc.BackendCompilerFailed: backend='flagos' raised:
   AttributeError: 'function' object has no attribute 'cache_info'
   ```

2. **Generated MUSA code imports an Ascend stream getter.** With the above fixed, compilation proceeds and then fails at kernel launch:

   ```
   /tmp/torchinductor_root/3l/c3l...py:122: in call
       stream0 = get_raw_stream(0)
   torch_fl/accelerator/ascend/acl_stream.py:324: in current_acl_raw_stream
   E   AttributeError: /publi-flash/lvyufeng/PyTorch-Plugin-FL/torch_fl/lib/libflagos.so: undefined symbol: GetCurrentStream
   ```

3. **The MUSA CI manifest withheld the profiler contract for a reason that does not apply**, and `docs/reference/compatibility.md` still said "No CI manifest exists for this platform" after #213 added one.

### Why did it happen?

Bugs 1 and 2 are both collisions between two patches that were correct in isolation and never ran on each other's hardware.

`git log -S` places them precisely:

- `has_native_triton` — the override that replaces `_triton.has_triton` with a plain function at the end of `register_flagos_device_interface()` — came from `a97a138` (GCU, #187).
- `_prime_has_triton` — which assumes `has_triton` is still `functools.cache`d — came from `e197bfe` (Ascend, #189).

Ascend does not take the override (`is_native_accelerator()` is `{"musa", "gcu"}`), so the Ascend PR never saw the plain function; the GCU PR predates the priming helper. The failure needs *both* patches plus a native accelerator, which is exactly the untested intersection. It reproduces on the first re-registration, and since `inductor_backend.py:450` re-registers before every `compile_fx`, that is every compile after import:

```
after torch_fl import: has_triton = <function register_flagos_device_interface.<locals>.has_native_triton>
  has cache_info? False
second register: AttributeError: 'function' object has no attribute 'cache_info'
```

Bug 2 has the same shape. Before #189 every build used `FlagOSDeviceOpOverrides` (confirmed at `e197bfe^`: `register_device_op_overrides(DEVICE_TYPE, FlagOSDeviceOpOverrides())`). #189 generalized the choice to `if platform_profile().is_cuda_like`, reading that boolean as "is this Ascend". It is not: MUSA and GCU are also `is_cuda_like=False`, but their raw-stream getters are the `musa`/`gcu` branches *inside* `FlagOSDeviceOpOverrides.import_get_raw_stream_as`. So they silently inherited Ascend's ACL snippet.

Bug 3 is ordinary staleness: #213 landed the MUSA pipeline, and the withheld note was copied from the GCU manifest, where the CPU-only-Kineto reasoning is genuine.

### Investigation process:

1. Ran `tests/integration/test_compile.py` on the MTT S5000 with the vendor FlagTree runtime on `PYTHONPATH`. Result: 12 failed, 14 passed. Grouped the failures by exception type — a single distinct cause, `'function' object has no attribute 'cache_info'`.
2. Read `torch_fl/compile/device_interface.py:695-747` and found the `has_native_triton` override installed at the tail of the same function that calls `_prime_has_triton()` at line 709.
3. Used `git log -S'_prime_has_triton'` and `git log -S'has_native_triton'` to date the two patches to different PRs (#189, #187), confirming a collision rather than a design.
4. Reproduced outside pytest in ~10 lines (import `torch_fl`, inspect `_triton.has_triton`, call `register_flagos_device_interface()` again) to confirm the trigger is re-registration, not any test fixture.
5. Grepped for callers of `register_flagos_device_interface` to establish the blast radius: `torch_fl/__init__.py:1620` (once at import) and `inductor_backend.py:450` (before every `compile_fx`).
6. Fixed bug 1, re-ran, and got a different single cause — the `GetCurrentStream` undefined symbol — which pointed at `_device_op_overrides()`.
7. Read `platform_profile.py` in full and confirmed `is_cuda_like` is `False` for three vendors, not one, then checked `e197bfe^` to see what MUSA used before the generalization.
8. Re-ran the compile suite (25 passed), then the profiler contract (11 passed, 1 skipped), then the full MUSA manifest through `run_integration_tests.py`.
9. Bisected the remaining failures against a clean tree with `git stash` to separate pre-existing breakage from anything I introduced.

## Solution Design
### Implementation approach:

Bug 1: probe for `cache_info` instead of assuming it. If it is absent, `has_triton` is already the native override — there is no cache to prime and no reason to want one, so return early.

Bug 2: key `_device_op_overrides()` on `platform_profile().vendor == "ascend"` rather than on `is_cuda_like`. Ascend is the only build whose device snippets come from the ACL runtime; every other build, CUDA-like or not, wants `FlagOSDeviceOpOverrides` and its existing per-vendor branches.

Bug 3: add the profiler group to the manifest, claim `gpu_memcpy` for MUSA in the capability table since it is measured, and rewrite the withheld comments to state the reason for each.

### Key design decisions:

**Probe the attribute rather than reorder the registration.** An alternative fix is to call `_prime_has_triton()` after installing the override, or to make the override a `functools.cache`d function so `cache_info` exists. Both are more fragile: the first makes two unrelated blocks order-dependent with nothing to enforce it, and the second fakes a cache API purely to satisfy a caller that has no use for the cache. Absence of `cache_info` is precisely the condition "priming is moot", so testing for it says what is meant.

**Key on `vendor`, not on a new boolean.** I considered adding an `is_ascend`-style field to `PlatformProfile`, but `vendor` already exists for exactly this purpose — its docstring says it is "used to pick the vendor runtime when `is_cuda_like` is False and the two non-CUDA paths diverge". This bug *is* that divergence, so the existing field is the intended tool. Adding a second boolean would also leave `is_cuda_like` looking like it still answers this question.

**Fix the two stale unit tests rather than skip them.** They failed on this host before any of my changes, for the same underlying reason as the shipped bug (assuming the CUDA-like shape). Skipping them would hide the same class of defect the rest of this PR is about.

**Claim `gpu_memcpy` in the capability table, not via a deselect.** The table is the existing mechanism for per-platform profiler capability, and MUSA genuinely emits memcpy records, so the case should *run*. `gpu_memset` stays skipped there because MUPTI reports no memset records at all.

### Code changes by file:
- `torch_fl/compile/device_interface.py` (lines 569-582): `_prime_has_triton()` probes for `cache_info` via `getattr` and returns early when it is absent, i.e. when the native `has_triton` override is installed. Comment records why the attribute can be missing and that this is the common path.
- `torch_fl/compile/inductor_codegen.py` (lines 136-149): `_device_op_overrides()` selects `FlagOSAscendDeviceOpOverrides` only for `vendor == "ascend"`; everything else gets `FlagOSDeviceOpOverrides`. Docstring records the concrete failure the old `is_cuda_like` check produced.
- `tests/unit/test_compile_platform_profile.py` (lines 47-92, 349-400, 480-500): adds the `as_musa` fixture, `musa`/`gcu` rows to the profile-selection parametrization, `test_has_triton_priming_tolerates_the_native_override`, and `test_musa_device_op_overrides_emit_the_musa_raw_stream`; repairs the `__wrapped__` reach-through and pins `ACCELERATOR` in the `as_cuda` fixture.
- `.github/configs/musa.yml` (lines 99-115, 174-199): adds the `Unified profiler contract` group with its measured result; rewrites the withheld block so compile, FlagGems, and profiler parity each record a reason.
- `tests/integration/profiler_support.py` (line 68): adds `musa` to the `memcpy` capability set.
- `docs/reference/compatibility.md` (lines 211-216, 228-234, 236-239): replaces the "no CI manifest" claim with what the manifest covers and what it withholds; adds the profiler contract result; marks `torch.compile` as hardware-measured but not yet CI-guarded.

### Changes by commit:
1. `358bee7` - `fix: restore torch.compile on native MUSA and GCU accelerators`: the two production fixes, kept together because the second is only reachable once the first is fixed — separating them would leave a commit where compile still fails.
2. `5f0376a` - `test: cover the native-accelerator compile paths on any host`: regression coverage for both, plus the two stale-test repairs.
3. `9ac2283` - `ci: guard the MUSA profiler contract and correct the withheld notes`: CI manifest, capability table, and documentation.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (if applicable) — no separate type checker configured in this repo
- [x] **All tests pass** (unit + integration) — with three pre-existing `main` failures documented below
- [x] **Manual testing completed** (include reproduction of original issue)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [x] **Documentation updated** (README, CLAUDE.md, docstrings as needed)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ ruff check
# Output:
All checks passed!

$ ruff format --check
# Output:
305 files already formatted
```

CI manifest validation:

```bash
$ python .github/scripts/run_integration_tests.py --validate-only
# Output:
Validated 8 configured integration test(s)
```

### Test Results

Hardware-free unit suite (the regression coverage), on this MUSA host:

```bash
# Command:
python -m pytest tests/unit/test_compile_platform_profile.py -q --tb=short -p no:randomly

# Output (including test count):
36 passed, 45 warnings in 3.32s
```

Before this PR, on the same host, the same file:

```
FAILED tests/unit/test_compile_platform_profile.py::test_has_triton_priming_restores_the_device_table
FAILED tests/unit/test_compile_platform_profile.py::test_cuda_device_op_overrides_use_flagos_device_state
2 failed, 32 passed, 43 warnings in 3.12s
```

`torch.compile` on the MTT S5000 with `flagtree-0.5.0+mthreads3.1`:

```bash
# Command:
python -m pytest tests/integration/test_compile.py -v --tb=short -p no:randomly

# Output:
tests/integration/test_compile.py::test_flagtree_compiles_correct_results PASSED
tests/integration/test_compile.py::test_musa_flagtree_binds_to_torch_fl_runtime PASSED
tests/integration/test_compile.py::test_musa_flagtree_compiles_forward_backward PASSED
...
1 failed, 25 passed, 19 skipped in 10.49s
```

The one remaining failure is `test_torch_backends_entry_point_is_registered`, which asserts an installed wheel's entry point (`found {'flagcx': 'flagcx:init'}`) and cannot hold in a build-tree run. It is unrelated to this change and fails identically before it.

New CI group, run as CI will run it:

```bash
# Command:
python -m pytest tests/integration/test_profiler_contract.py -v -m profiler --tb=short

# Output:
11 passed, 1 skipped, 1 warning in 6.92s
```

Full MUSA manifest through the CI runner, per-group:

```bash
# Command:
INTEGRATION_TESTS="$(...musa.yml...)" python .github/scripts/run_integration_tests.py

# Output (per group):
Check isolated MUSA environment              89 passed in 42.13s
Run MUSA dispatch tests                      46 passed in 8.55s
Run general tests                            27 passed, 3 warnings in 8.81s
Unified AMP contract                         12 passed in 1.34s
Unified math-bits contract                   11 passed, 1 skipped in 6.92s
Unified profiler contract                    (new group, above)
Run operator tests (native mudnn, main ops)  3 failed, 469 passed, 14 skipped, 498 deselected, 3 xpassed
```

The operator group's 3 failures are all in `test_flaggems_conf_consistency.py` (`mm`/`bmm`/`addmm` present in `flaggems_python_kernels.cc` but unrouted in `register.inc`). Confirmed pre-existing by stashing this branch's changes and re-running on a clean tree — identical 3 failures. Out of scope here; this PR touches no operator registration.

### Manual Verification
```bash
# Command to reproduce original issue:
python -c "
import torch, torch_fl
from torch.utils import _triton
print('has cache_info?', hasattr(_triton.has_triton, 'cache_info'))
from torch_fl.compile.device_interface import register_flagos_device_interface
register_flagos_device_interface()
print('second register: OK')
"

# Output BEFORE fix:
after torch_fl import: has_triton = <function register_flagos_device_interface.<locals>.has_native_triton>
  has cache_info? False
second register: AttributeError: 'function' object has no attribute 'cache_info'

# Output AFTER fix:
  has cache_info? False
second register: OK
```

End to end, the user-visible symptom — `torch.compile` on MUSA:

```
# BEFORE fix (bug 1):
torch._dynamo.exc.BackendCompilerFailed: backend='flagos' raised:
AttributeError: 'function' object has no attribute 'cache_info'
=> 12 failed, 14 passed

# BEFORE fix (bug 2, after bug 1 fixed):
E   AttributeError: torch_fl/lib/libflagos.so: undefined symbol: GetCurrentStream
=> 11 failed, 15 passed

# AFTER both fixes:
=> 25 passed, 19 skipped, 1 failed (unrelated wheel entry-point assertion)
```

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (no reinventing)

Both fixes stay inside the existing selector functions and reuse `PlatformProfile.vendor`, which already exists for per-vendor divergence. The new unit fixture mirrors the existing `as_ascend`/`as_cuda` shape. The manifest comments follow the file's established convention of recording *why* a group is present or withheld.

### Edge Cases Considered
1. **Ascend must keep the ACL snippets.** The `vendor == "ascend"` check is exactly equivalent to the old `not is_cuda_like` branch for Ascend; `test_ascend_device_op_overrides_emit_no_cuda` and `test_ascend_device_op_overrides_reject_cpp_wrapper` still pass unchanged.
2. **CUDA-like platforms must be untouched.** They were already on the `is_cuda_like` true branch and remain on the same class; `test_cuda_device_op_overrides_use_flagos_device_state` covers this.
3. **GCU gets the same fix as MUSA.** It shares both code paths (`is_native_accelerator()` is `{"musa", "gcu"}`, and `import_get_raw_stream_as` has a `gcu` branch), so it is fixed by the same two changes. I have no GCU hardware, so this is reasoned from the code, not measured — flagged for review below.
4. **First vs. later registration.** Priming still works normally on the first call before the override is installed, and on non-native platforms where it is never installed; the early return only triggers once priming is meaningless.
5. **Unit tests must hold on hosts that are not MUSA.** The `as_musa` fixture patches `ACCELERATOR` as well as the profile, because the snippet branch reads `ACCELERATOR` directly — otherwise the new test would take the wrong branch on a CUDA runner.
6. **A profiler capability that is claimed but absent would turn a skip into a hard failure.** `gpu_memcpy` was measured passing on this host before claiming it; `gpu_memset` was left unclaimed because MUPTI reports no such records.

### Potential Risks
1. **GCU is fixed but unverified on hardware.** The reasoning is that GCU takes the identical two code paths as MUSA, and the change moves it back to the pre-#189 behaviour. If GCU's generated code somehow depended on the ACL snippet, this would surface there — but that snippet imports an Ascend-only symbol, so it cannot have been working.
2. **The new profiler CI group depends on the runner's MUPTI.** If the CI image's MUSA toolkit lacks the profiler SDK or forbids a subscriber, the group's device cases would fail where they pass on this S5000. The tracer is optional at runtime, so this is an image-capability question; if it bites, the group can be withheld again with a recorded reason.
3. **`vendor` is `""` for the CUDA and MetaX profiles.** That is fine for this check (neither is Ascend), but it does mean `vendor` is not a complete key for every future dispatch. Noted rather than fixed, since populating it is out of scope.

### Rollback Plan

Each commit reverts independently and cleanly. `git revert 9ac2283` drops the CI group and documentation, restoring the previous withheld notes, with no code effect. `git revert 5f0376a` drops the tests. `git revert 358bee7` restores the previous selector logic, which returns `torch.compile` on MUSA and GCU to its current broken-on-`main` state but affects no other platform. No build artifacts, generated files, or persisted state are involved.

## Related Work
- Fixes the native-accelerator regression introduced by the interaction of #187 and #189
- Related to #213 (added the MUSA CI pipeline this PR extends)
- Related to #159 (MUSA FlagTree `torch.compile` integration, whose suite this restores)
- Depends on nothing

## Explicitly Not Included
- **The 3 `test_flaggems_conf_consistency.py` failures.** Pre-existing on `main` and verified as such by stashing; they are `mm`/`bmm`/`addmm` routing drift between `flaggems_python_kernels.cc` and `register.inc`, unrelated to compile or profiling. Fixing operator registration here would mix two unrelated concerns in one review.
- **`test_profiler_privateuse1.py::test_guard_stream_is_real_not_synthetic`.** Also pre-existing on this host (a CPU-wheel single-stream artifact), likewise confirmed by stashing.
- **Adding `test_compile.py` to the MUSA CI manifest.** It needs the vendor FlagTree runtime the image does not bake. The manifest now records this as an image gap with the measured on-hardware result, rather than implying the code is unproven.
- **Adding the FlagGems hybrid group.** Its two cases skip without FlagGems installed, so guarding it on this image would record a pass that measured nothing.
- **Adding `test_profiler_parity.py`.** It diffs against a torch-cuda baseline and is only meaningful on CUDA-boxing platforms; measured here for completeness (5 passed, 2 failed) and both failures are MUPTI capability gaps, not defects.
- **Populating `vendor` for the CUDA/MetaX profiles.** Not needed by this fix.
- **The stale `pr_musa_*.md` scratch files in the working tree.** Untracked and left alone.

## Human Review Notes
### Areas needing special attention:
1. **The `vendor == "ascend"` inversion in `_device_op_overrides()`.** This is the judgement call worth checking: I read `is_cuda_like` as having been used to mean "is Ascend", which held when it was written and stopped holding once MUSA and GCU arrived. If the intent was instead that *any* non-CUDA-like platform should get the Ascend snippets, then the real bug is elsewhere and this fix is wrong — but the ACL symbol is Ascend-only, so I do not think that reading survives.
2. **GCU, which I could not test.** Please confirm on GCU hardware if available. I expect a strict improvement (it restores pre-#189 behaviour), but it is unverified.
3. **Whether the CI image's MUPTI supports the new profiler group.** My measurement is from this S5000 host, not the CI runner. If they differ, this group is where it shows.

### Questions for reviewer:
1. Should the two production fixes be split into separate commits for cleaner bisection? I kept them together because bug 2 is unreachable until bug 1 is fixed, so the intermediate commit would still fail — but I can split if the convention prefers one fix per commit.
2. Is there a preferred way to guard against this whole class of bug — a native-accelerator smoke path in the hardware-free unit suite, so the next vendor patch cannot silently break MUSA/GCU again? The new `as_musa` fixture is a start, but a shared "third shape" fixture set might be worth generalizing.

## Additional Context

The two bugs are the same failure mode twice: a patch generalized a per-platform decision using a boolean that happened to be equivalent to "is Ascend" at the time it was written. `is_cuda_like` distinguishes CUDA-shaped platforms from non-CUDA ones, and there are now three of the latter with materially different runtimes. `platform_profile.py`'s own docstring anticipates this — it notes that `vendor` exists "to pick the vendor runtime when `is_cuda_like` is False and the two non-CUDA paths diverge" — which is why the fix uses the field already provided rather than adding another flag.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
