### PR TITLE
fix: handle empty MUSA tensors without CPU fallback

### DIFF
--- a/.github/configs/musa.yml
+++ b/.github/configs/musa.yml
@@ -118,15 +118,13 @@ integration_tests:
   # the anyplatform/main_ops subset that routes to the native mudnn backend.
   #
   # Ordered AFTER the contract groups (general/AMP/math-bits): this group has
-  # two known MUSA backend gaps (filed as issues; see issue_body.md):
-  #   1. narrow zero-length-slice backward -- mudnn pow rejects empty tensors
-  #      (test_narrow_backward_edge_cases[1-2-0]).
-  #   2. torch.mm on float64 -- mudnn GEMM has no double-precision path
+  # one known MUSA backend gap (filed as an issue; see issue_body.md):
+  #   1. torch.mm on float64 -- mudnn GEMM has no double-precision path
   #      (test_mm_still_runs[dtype3]).
-  # Both are deselected below so the pipeline can complete end to end while
-  # the dev fixes are queued. Remove each --deselect once the corresponding
-  # fix lands. run_integration_tests.py stops on the first non-zero group, so
-  # this ordering lets the contract groups above go green first.
+  # It is deselected below so the pipeline can complete end to end while the
+  # dev fix is queued. Remove the --deselect once the fix lands.
+  # run_integration_tests.py stops on the first non-zero group, so this
+  # ordering lets the contract groups above go green first.
   #
   # test_rng_dispatch.py is explicitly ignored here even though its tests carry
   # @pytest.mark.(anyplatform + main_ops) and would otherwise be collected:
@@ -145,7 +143,6 @@ integration_tests:
     command: >-
       python -m pytest tests/integration/ops/
       --ignore=tests/integration/ops/test_rng_dispatch.py
-      --deselect "tests/integration/ops/test_narrow_dispatch.py::TestNarrowAutograd::test_narrow_backward_edge_cases[1-2-0]"
       --deselect "tests/integration/ops/test_soft_lowp_gate_dispatch.py::TestSoftLowpGateLeavesFloatPathsAlone::test_mm_still_runs[dtype3]"
       -m "(anyplatform or main_ops) and not flaggems_python and not flaggems_cpp and not cuda and not ascend and not metax and not dcu and not gcu and not ppu"
       -v -s --tb=short

--- a/csrc/aten/backends/musa/generated/musa_kernels.cc
+++ b/csrc/aten/backends/musa/generated/musa_kernels.cc
@@ -18,6 +18,7 @@
 #include <ATen/ops/result_type.h>
 #include <c10/core/Scalar.h>
 #include <algorithm>
+#include <limits>
 #include <string>
 #include <vector>
 #include "../mudnn_common.h"
@@ -31,6 +32,10 @@ at::Tensor AbsKernelMusa(const at::Tensor& self) {
     return at::abs(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -46,6 +51,10 @@ at::Tensor SqrtKernelMusa(const at::Tensor& self) {
     return at::sqrt(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -61,6 +70,10 @@ at::Tensor RsqrtKernelMusa(const at::Tensor& self) {
     return at::rsqrt(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -76,6 +89,10 @@ at::Tensor ExpKernelMusa(const at::Tensor& self) {
     return at::exp(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -91,6 +108,10 @@ at::Tensor LogKernelMusa(const at::Tensor& self) {
     return at::log(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -106,6 +127,10 @@ at::Tensor Log2KernelMusa(const at::Tensor& self) {
     return at::log2(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -121,6 +146,10 @@ at::Tensor Log10KernelMusa(const at::Tensor& self) {
     return at::log10(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -136,6 +165,10 @@ at::Tensor Log1pKernelMusa(const at::Tensor& self) {
     return at::log1p(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -151,6 +184,10 @@ at::Tensor SinKernelMusa(const at::Tensor& self) {
     return at::sin(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -166,6 +203,10 @@ at::Tensor CosKernelMusa(const at::Tensor& self) {
     return at::cos(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -181,6 +222,10 @@ at::Tensor AcosKernelMusa(const at::Tensor& self) {
     return at::acos(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -196,6 +241,10 @@ at::Tensor AtanKernelMusa(const at::Tensor& self) {
     return at::atan(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -211,6 +260,10 @@ at::Tensor TanhKernelMusa(const at::Tensor& self) {
     return at::tanh(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -226,6 +279,10 @@ at::Tensor SigmoidKernelMusa(const at::Tensor& self) {
     return at::sigmoid(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -241,6 +298,10 @@ at::Tensor SiluKernelMusa(const at::Tensor& self) {
     return at::silu(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -256,6 +317,10 @@ at::Tensor ReluKernelMusa(const at::Tensor& self) {
     return at::relu(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -271,6 +336,10 @@ at::Tensor ReciprocalKernelMusa(const at::Tensor& self) {
     return at::reciprocal(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -286,6 +355,10 @@ at::Tensor ErfKernelMusa(const at::Tensor& self) {
     return at::erf(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -301,6 +374,10 @@ at::Tensor FloorKernelMusa(const at::Tensor& self) {
     return at::floor(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -316,6 +393,10 @@ at::Tensor CeilKernelMusa(const at::Tensor& self) {
     return at::ceil(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -331,6 +412,10 @@ at::Tensor SignKernelMusa(const at::Tensor& self) {
     return at::sign(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -346,6 +431,10 @@ at::Tensor NegKernelMusa(const at::Tensor& self) {
     return at::neg(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -366,6 +455,10 @@ at::Tensor TruncKernelMusa(const at::Tensor& self) {
     return at::trunc(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -386,6 +479,10 @@ at::Tensor Expm1KernelMusa(const at::Tensor& self) {
     return at::expm1(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary first;
@@ -420,6 +517,10 @@ at::Tensor MulTensorKernelMusa(const at::Tensor& self, const at::Tensor& other) 
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -446,6 +547,10 @@ at::Tensor DivTensorKernelMusa(const at::Tensor& self, const at::Tensor& other) 
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -472,6 +577,10 @@ at::Tensor MaximumKernelMusa(const at::Tensor& self, const at::Tensor& other) {
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -498,6 +607,10 @@ at::Tensor MinimumKernelMusa(const at::Tensor& self, const at::Tensor& other) {
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -524,6 +637,10 @@ at::Tensor RemainderTensorKernelMusa(const at::Tensor& self, const at::Tensor& o
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -550,6 +667,10 @@ at::Tensor FmodTensorKernelMusa(const at::Tensor& self, const at::Tensor& other)
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -576,6 +697,10 @@ at::Tensor PowTensorTensorKernelMusa(const at::Tensor& self, const at::Tensor& o
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -602,6 +727,10 @@ at::Tensor AddTensorKernelMusa(const at::Tensor& self, const at::Tensor& other, 
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -633,6 +762,10 @@ at::Tensor SubTensorKernelMusa(const at::Tensor& self, const at::Tensor& other, 
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -664,6 +797,10 @@ at::Tensor EqTensorKernelMusa(const at::Tensor& self, const at::Tensor& other) {
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -690,6 +827,10 @@ at::Tensor NeTensorKernelMusa(const at::Tensor& self, const at::Tensor& other) {
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -716,6 +857,10 @@ at::Tensor LtTensorKernelMusa(const at::Tensor& self, const at::Tensor& other) {
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -742,6 +887,10 @@ at::Tensor GtTensorKernelMusa(const at::Tensor& self, const at::Tensor& other) {
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -768,6 +917,10 @@ at::Tensor LeTensorKernelMusa(const at::Tensor& self, const at::Tensor& other) {
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -794,6 +947,10 @@ at::Tensor GeTensorKernelMusa(const at::Tensor& self, const at::Tensor& other) {
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -820,6 +977,10 @@ at::Tensor LogicalAndKernelMusa(const at::Tensor& self, const at::Tensor& other)
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -846,6 +1007,10 @@ at::Tensor LogicalOrKernelMusa(const at::Tensor& self, const at::Tensor& other) 
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -868,6 +1033,10 @@ at::Tensor MulScalarKernelMusa(const at::Tensor& self, const at::Scalar& other) 
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -892,6 +1061,10 @@ at::Tensor DivScalarKernelMusa(const at::Tensor& self, const at::Scalar& other) 
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -916,6 +1089,10 @@ at::Tensor PowTensorScalarKernelMusa(const at::Tensor& self, const at::Scalar& o
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -940,6 +1117,10 @@ at::Tensor RemainderScalarKernelMusa(const at::Tensor& self, const at::Scalar& o
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -964,6 +1145,10 @@ at::Tensor FmodScalarKernelMusa(const at::Tensor& self, const at::Scalar& other)
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -988,6 +1173,10 @@ at::Tensor AddScalarKernelMusa(const at::Tensor& self, const at::Scalar& other, 
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1012,6 +1201,10 @@ at::Tensor SubScalarKernelMusa(const at::Tensor& self, const at::Scalar& other, 
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1036,6 +1229,10 @@ at::Tensor EqScalarKernelMusa(const at::Tensor& self, const at::Scalar& other) {
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1060,6 +1257,10 @@ at::Tensor NeScalarKernelMusa(const at::Tensor& self, const at::Scalar& other) {
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1084,6 +1285,10 @@ at::Tensor LtScalarKernelMusa(const at::Tensor& self, const at::Scalar& other) {
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1108,6 +1313,10 @@ at::Tensor GtScalarKernelMusa(const at::Tensor& self, const at::Scalar& other) {
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1132,6 +1341,10 @@ at::Tensor LeScalarKernelMusa(const at::Tensor& self, const at::Scalar& other) {
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1156,6 +1369,10 @@ at::Tensor GeScalarKernelMusa(const at::Tensor& self, const at::Scalar& other) {
   auto result_dtype = at::result_type(self, other);
   auto self_c = self.scalar_type() == result_dtype ? self : self.to(result_dtype);
   auto out = at::empty(self.sizes(), self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1180,6 +1397,10 @@ at::Tensor MmKernelMusa(const at::Tensor& self, const at::Tensor& mat2) {
   std::vector<int64_t> out_shape = self.sizes().vec();
   out_shape.back() = mat2.size(-1);
   auto out = at::empty(out_shape, self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   auto self_c = self.contiguous();
   auto mat2_c = mat2.contiguous();
 
@@ -1204,6 +1425,10 @@ at::Tensor BmmKernelMusa(const at::Tensor& self, const at::Tensor& mat2) {
   std::vector<int64_t> out_shape = self.sizes().vec();
   out_shape.back() = mat2.size(-1);
   auto out = at::empty(out_shape, self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   auto self_c = self.contiguous();
   auto mat2_c = mat2.contiguous();
 
@@ -1325,6 +1550,10 @@ at::Tensor SumDimIntlistKernelMusa(
     self_c = self_c.contiguous();
   }
   auto out = at::empty(squeezed_shape, self.options().dtype(out_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return keepdim ? out.view(out_shape) : out;
   std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
@@ -1392,6 +1621,10 @@ at::Tensor MeanDimKernelMusa(
     self_c = self_c.contiguous();
   }
   auto out = at::empty(squeezed_shape, self.options().dtype(out_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return keepdim ? out.view(out_shape) : out;
   std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
@@ -1433,6 +1666,18 @@ at::Tensor SumKernelMusa(
     self_c = self_c.contiguous();
   }
   auto out = at::empty({}, self.options().dtype(out_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
+
+  // Reducing an empty input into a scalar: mudnn rejects the zero-element
+  // operand, but aten's answer is the reduction's identity (sum -> 0).
+  // Fill it on-device rather than launching or detouring through the host.
+  if (self_c.numel() == 0) {
+    out.fill_(0);
+    return out;
+  }
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1473,6 +1718,18 @@ at::Tensor MeanKernelMusa(
     self_c = self_c.contiguous();
   }
   auto out = at::empty({}, self.options().dtype(out_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
+
+  // Reducing an empty input into a scalar: mudnn rejects the zero-element
+  // operand, but aten's answer is the reduction's identity (mean -> nan).
+  // Fill it on-device rather than launching or detouring through the host.
+  if (self_c.numel() == 0) {
+    out.fill_(std::numeric_limits<double>::quiet_NaN());
+    return out;
+  }
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1493,6 +1750,10 @@ at::Tensor GeluKernelMusa(const at::Tensor& self, c10::string_view approximate) 
     return at::gelu(self.cpu(), approximate).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1512,6 +1773,10 @@ at::Tensor PrivSoftmaxKernelMusa(const at::Tensor& self, int64_t dim, bool half_
   }
   int64_t d = dim < 0 ? dim + self.dim() : dim;
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1530,6 +1795,10 @@ at::Tensor TanKernelMusa(const at::Tensor& self) {
     return at::tan(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1545,6 +1814,10 @@ at::Tensor RoundKernelMusa(const at::Tensor& self) {
     return at::round(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1560,6 +1833,10 @@ at::Tensor MishKernelMusa(const at::Tensor& self) {
     return at::mish(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1575,6 +1852,10 @@ at::Tensor HardswishKernelMusa(const at::Tensor& self) {
     return at::hardswish(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1590,6 +1871,10 @@ at::Tensor IsnanKernelMusa(const at::Tensor& self) {
     return at::isnan(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1605,6 +1890,10 @@ at::Tensor IsinfKernelMusa(const at::Tensor& self) {
     return at::isinf(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1620,6 +1909,10 @@ at::Tensor HardsigmoidKernelMusa(const at::Tensor& self) {
     return at::hardsigmoid(self.cpu()).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1637,6 +1930,10 @@ at::Tensor LeakyReluKernelMusa(const at::Tensor& self, const at::Scalar& negativ
     return at::leaky_relu(self.cpu(), negative_slope).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1659,6 +1956,10 @@ at::Tensor EluKernelMusa(
         .to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1678,6 +1979,10 @@ at::Tensor SoftplusKernelMusa(
     return at::softplus(self.cpu(), beta, threshold).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1698,6 +2003,10 @@ at::Tensor ClampKernelMusa(
     return at::clamp(self.cpu(), min, max).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1719,6 +2028,10 @@ at::Tensor ClampMinKernelMusa(const at::Tensor& self, const at::Scalar& min) {
     return at::clamp_min(self.cpu(), min).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1736,6 +2049,10 @@ at::Tensor ClampMaxKernelMusa(const at::Tensor& self, const at::Scalar& max) {
     return at::clamp_max(self.cpu(), max).to(self.device());
   }
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -1760,6 +2077,10 @@ at::Tensor LogicalXorKernelMusa(const at::Tensor& self, const at::Tensor& other)
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -1786,6 +2107,10 @@ at::Tensor FloorDivideKernelMusa(const at::Tensor& self, const at::Tensor& other
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -1814,6 +2139,10 @@ at::Tensor SigmoidBackwardKernelMusa(const at::Tensor& grad_output, const at::Te
   auto grad_b = grad_c.expand(out_shape);
   auto self_b = self_c.expand(out_shape);
   auto out = at::empty(out_shape, grad_output.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_grad(grad_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
@@ -1842,6 +2171,10 @@ at::Tensor TanhBackwardKernelMusa(const at::Tensor& grad_output, const at::Tenso
   auto grad_b = grad_c.expand(out_shape);
   auto self_b = self_c.expand(out_shape);
   auto out = at::empty(out_shape, grad_output.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_grad(grad_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
@@ -1870,6 +2203,10 @@ at::Tensor SiluBackwardKernelMusa(const at::Tensor& grad_output, const at::Tenso
   auto grad_b = grad_c.expand(out_shape);
   auto self_b = self_c.expand(out_shape);
   auto out = at::empty(out_shape, grad_output.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_grad(grad_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
@@ -1902,6 +2239,10 @@ at::Tensor GeluBackwardKernelMusa(
   auto grad_b = grad_c.expand(out_shape);
   auto self_b = self_c.expand(out_shape);
   auto out = at::empty(out_shape, grad_output.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_grad(grad_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
@@ -1936,6 +2277,10 @@ at::Tensor ThresholdBackwardKernelMusa(
   auto grad_b = grad_c.expand(out_shape);
   auto self_b = self_c.expand(out_shape);
   auto out = at::empty(out_shape, grad_output.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_grad(grad_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
@@ -1975,6 +2320,10 @@ at::Tensor LeakyReluBackwardKernelMusa(
   auto grad_b = grad_c.expand(out_shape);
   auto self_b = self_c.expand(out_shape);
   auto out = at::empty(out_shape, grad_output.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_grad(grad_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
@@ -2016,6 +2365,10 @@ at::Tensor AddcmulKernelMusa(
   auto t1_b = t1_c.expand(out_shape);
   auto t2_b = t2_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_t1(t1_b);
@@ -2058,6 +2411,10 @@ at::Tensor AddcdivKernelMusa(
   auto t1_b = t1_c.expand(out_shape);
   auto t2_b = t2_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_t1(t1_b);
@@ -2097,6 +2454,10 @@ at::Tensor WhereSelfKernelMusa(
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_cond(cond_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
@@ -2128,6 +2489,10 @@ at::Tensor AddmmKernelMusa(
   std::vector<int64_t> out_shape = mat1.sizes().vec();
   out_shape.back() = mat2.size(-1);
   auto out = at::empty(out_shape, mat1.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   auto mat1_c = mat1.contiguous();
   auto mat2_c = mat2.contiguous();
 
@@ -2194,6 +2559,10 @@ at::Tensor BaddbmmKernelMusa(
   std::vector<int64_t> out_shape = mat1.sizes().vec();
   out_shape.back() = mat2.size(-1);
   auto out = at::empty(out_shape, mat1.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
   auto mat1_c = mat1.contiguous();
   auto mat2_c = mat2.contiguous();
 
@@ -2251,6 +2620,10 @@ at::Tensor PrivLogSoftmaxKernelMusa(const at::Tensor& self, int64_t dim, bool ha
   }
   int64_t d = dim < 0 ? dim + self.dim() : dim;
   auto out = at::empty(self.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -2352,6 +2725,10 @@ at::Tensor AmaxKernelMusa(
     self_c = self_c.contiguous();
   }
   auto out = at::empty(squeezed_shape, self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return keepdim ? out.view(out_shape) : out;
   std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
@@ -2396,6 +2773,10 @@ at::Tensor AminKernelMusa(
     self_c = self_c.contiguous();
   }
   auto out = at::empty(squeezed_shape, self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return keepdim ? out.view(out_shape) : out;
   std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
@@ -2434,6 +2815,10 @@ at::Tensor ProdDimIntKernelMusa(
                                                    : self.scalar_type());
   auto self_c = self.scalar_type() == out_dtype ? self : self.to(out_dtype);
   auto out = at::empty(squeezed_shape, self.options().dtype(out_dtype));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return keepdim ? out.view(out_shape) : out;
   int mudnn_dim = static_cast<int>(d);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
@@ -2464,6 +2849,10 @@ at::Tensor AnyDimKernelMusa(const at::Tensor& self, int64_t dim, bool keepdim) {
 
   auto self_b = self.scalar_type() == at::kBool ? self : self.ne(0);
   auto out = at::empty(squeezed_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return keepdim ? out.view(out_shape) : out;
   int mudnn_dim = static_cast<int>(d);
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
@@ -2494,6 +2883,10 @@ at::Tensor AllDimKernelMusa(const at::Tensor& self, int64_t dim, bool keepdim) {
 
   auto self_b = self.scalar_type() == at::kBool ? self : self.ne(0);
   auto out = at::empty(squeezed_shape, self.options().dtype(at::kBool));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return keepdim ? out.view(out_shape) : out;
   int mudnn_dim = static_cast<int>(d);
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
@@ -2542,6 +2935,10 @@ at::Tensor VarCorrectionKernelMusa(
     self_c = self_c.contiguous();
   }
   auto out = at::empty(squeezed_shape, self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return keepdim ? out.view(out_shape) : out;
   std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
@@ -2593,6 +2990,10 @@ at::Tensor StdCorrectionKernelMusa(
     self_c = self_c.contiguous();
   }
   auto out = at::empty(squeezed_shape, self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return keepdim ? out.view(out_shape) : out;
   std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
@@ -2648,6 +3049,10 @@ at::Tensor LinalgVectorNormKernelMusa(
     self_c = self_c.contiguous();
   }
   auto out = at::empty(squeezed_shape, self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return keepdim ? out.view(out_shape) : out;
   std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
@@ -2828,6 +3233,10 @@ at::Tensor CatKernelMusa(const at::ITensorListRef& tensors, int64_t dim) {
   for (const auto& t : kept) total += t.size(d);
   out_shape[d] = total;
   auto out = at::empty(out_shape, kept[0].options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   std::vector<at::Tensor> ins_c;
   std::vector<std::unique_ptr<musa_ops::MudnnTensorWrapper>> wraps;
@@ -2886,6 +3295,10 @@ at::Tensor StackKernelMusa(at::TensorList tensors, int64_t dim) {
   for (const auto& t : kept) total += t.size(d);
   out_shape[d] = total;
   auto out = at::empty(out_shape, kept[0].options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   std::vector<at::Tensor> ins_c;
   std::vector<std::unique_ptr<musa_ops::MudnnTensorWrapper>> wraps;
@@ -2922,6 +3335,10 @@ at::Tensor GatherKernelMusa(
   auto self_c = self.contiguous();
   auto index_c = index.contiguous();
   auto out = at::empty(index.sizes(), self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_index(index_c);
@@ -2950,6 +3367,10 @@ at::Tensor IndexSelectKernelMusa(
   auto out_shape = self.sizes().vec();
   out_shape[d] = index.numel();
   auto out = at::empty(out_shape, self.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_index(index_c);
@@ -2989,6 +3410,10 @@ at::Tensor EmbeddingKernelMusa(
   std::vector<int64_t> flat_shape = weight.sizes().vec();
   flat_shape[0] = index_c.numel();
   auto out = at::empty(flat_shape, weight.options());
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out.view(out_shape);
 
   musa_ops::MudnnTensorWrapper t_weight(weight_c);
   musa_ops::MudnnTensorWrapper t_index(index_c);
@@ -3279,6 +3704,10 @@ at::Tensor CumsumKernelMusa(
   auto self_c = self.to(acc).contiguous();
   int64_t d = dim < 0 ? dim + self.dim() : dim;
   auto out = at::empty(self.sizes(), self.options().dtype(acc));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -3306,6 +3735,10 @@ at::Tensor CumprodKernelMusa(
   auto self_c = self.to(acc).contiguous();
   int64_t d = dim < 0 ? dim + self.dim() : dim;
   auto out = at::empty(self.sizes(), self.options().dtype(acc));
+  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty
+  // output holds no elements, so the allocation above is already the
+  // answer. Return it on-device without launching.
+  if (out.numel() == 0) return out;
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);

--- a/csrc/aten/backends/musa/generated/musa_register.inc
+++ b/csrc/aten/backends/musa/generated/musa_register.inc
@@ -8,6 +8,10 @@
 // without a kernel behind it fails the dispatcher's "backend not registered"
 // check, whereas an unregistered op simply reaches the cpu_fallback. So this
 // file is exactly the MUSA coverage set.
+//
+// The list also covers the handwritten mudnn convolution and native
+// muRAND/mudnn RNG kernels. Unsupported RNG schemas stay unregistered and
+// continue through cpu_fallback.
 
   m.impl("_log_softmax", WrapperPrivLogSoftmax);
   m.impl("_log_softmax_backward_data", WrapperPrivLogSoftmaxBackwardData);
@@ -92,14 +96,39 @@
   m.impl("mm.out", WrapperMmOut);
   m.impl("mul.Scalar", WrapperMulScalar);
   m.impl("mul.Tensor", WrapperMulTensor);
+  m.impl("native_dropout", WrapperNativeDropout);
+  m.impl("native_dropout_backward", WrapperNativeDropoutBackward);
   m.impl("native_layer_norm", WrapperNativeLayerNorm);
   m.impl("native_layer_norm_backward", WrapperNativeLayerNormBackward);
   m.impl("ne.Scalar", WrapperNeScalar);
   m.impl("ne.Tensor", WrapperNeTensor);
   m.impl("neg", WrapperNeg);
+  m.impl("normal_", WrapperNormalInplace);
   m.impl("pow.Tensor_Scalar", WrapperPowTensorScalar);
   m.impl("pow.Tensor_Tensor", WrapperPowTensorTensor);
   m.impl("prod.dim_int", WrapperProdDimInt);
+  m.impl("rand", WrapperRand);
+  m.impl("rand.generator", WrapperRandGenerator);
+  m.impl("rand.names_out", WrapperRandNamesOut);
+  m.impl("rand.out", WrapperRandOut);
+  m.impl("rand_like", WrapperRandLike);
+  m.impl("rand_like.generator", WrapperRandLikeGenerator);
+  m.impl("rand_like.out", WrapperRandLikeOut);
+  m.impl("randint", WrapperRandint);
+  m.impl("randint.generator", WrapperRandintGenerator);
+  m.impl("randint.low", WrapperRandintLow);
+  m.impl("randint.low_generator", WrapperRandintLowGenerator);
+  m.impl("randint.low_out", WrapperRandintLowOut);
+  m.impl("randint.out", WrapperRandintOut);
+  m.impl("randn", WrapperRandn);
+  m.impl("randn.generator", WrapperRandnGenerator);
+  m.impl("randn.names_out", WrapperRandnNamesOut);
+  m.impl("randn_like", WrapperRandnLike);
+  m.impl("randn_like.generator", WrapperRandnLikeGenerator);
+  m.impl("randn_like.out", WrapperRandnLikeOut);
+  m.impl("random_", WrapperRandomInplace);
+  m.impl("random_.from", WrapperRandomInplaceFrom);
+  m.impl("random_.to", WrapperRandomInplaceTo);
   m.impl("reciprocal", WrapperReciprocal);
   m.impl("relu", WrapperRelu);
   m.impl("remainder.Scalar", WrapperRemainderScalar);
@@ -131,35 +160,7 @@
   m.impl("threshold_backward", WrapperThresholdBackward);
   m.impl("topk", WrapperTopk);
   m.impl("trunc", WrapperTrunc);
+  m.impl("uniform_", WrapperUniformInplace);
   m.impl("var.correction", WrapperVarCorrection);
   m.impl("where.self", WrapperWhereSelf);
   m.impl("zero_", WrapperZeroInplace);
-
-  // Native muRAND/mudnn RNG kernels. Unsupported RNG schemas stay unregistered
-  // and continue through cpu_fallback.
-  m.impl("native_dropout", WrapperNativeDropout);
-  m.impl("native_dropout_backward", WrapperNativeDropoutBackward);
-  m.impl("normal_", WrapperNormalInplace);
-  m.impl("rand", WrapperRand);
-  m.impl("rand.generator", WrapperRandGenerator);
-  m.impl("rand.names_out", WrapperRandNamesOut);
-  m.impl("rand.out", WrapperRandOut);
-  m.impl("rand_like", WrapperRandLike);
-  m.impl("rand_like.generator", WrapperRandLikeGenerator);
-  m.impl("rand_like.out", WrapperRandLikeOut);
-  m.impl("randint", WrapperRandint);
-  m.impl("randint.generator", WrapperRandintGenerator);
-  m.impl("randint.low", WrapperRandintLow);
-  m.impl("randint.low_generator", WrapperRandintLowGenerator);
-  m.impl("randint.low_out", WrapperRandintLowOut);
-  m.impl("randint.out", WrapperRandintOut);
-  m.impl("randn", WrapperRandn);
-  m.impl("randn.generator", WrapperRandnGenerator);
-  m.impl("randn.names_out", WrapperRandnNamesOut);
-  m.impl("randn_like", WrapperRandnLike);
-  m.impl("randn_like.generator", WrapperRandnLikeGenerator);
-  m.impl("randn_like.out", WrapperRandnLikeOut);
-  m.impl("random_", WrapperRandomInplace);
-  m.impl("random_.from", WrapperRandomInplaceFrom);
-  m.impl("random_.to", WrapperRandomInplaceTo);
-  m.impl("uniform_", WrapperUniformInplace);

--- a/docs/reference/operator-support.md
+++ b/docs/reference/operator-support.md
@@ -345,6 +345,19 @@ This is targeted dtype evidence for CANN 9.0, not a claim that every ACLNN
 operator accepts every ACL dtype. Complex and quantized dtypes remain outside
 this cohort.
 
+### MUSA native empty-tensor handling (2026-08-30)
+
+The native mudnn kernels now handle zero-element tensors without a CPU fallback. mudnn v3300 rejects zero-element operands for its Unary, Binary, and Reduce modes, returning `NOT_SUPPORTED`; the generated kernels therefore return an already device-allocated empty output without launching. Whole-tensor `sum`, `mean`, and `prod` additionally fill their CPU-defined identities (`0`, `nan`, and `1`) on the device when the input is empty. This covers the zero-length `narrow` autograd path from issue #214, where `square().sum()` previously failed in the pow kernel and then in the reduction.
+
+Measured on the eight-device Moore Threads MTT S5000 host with CPU PyTorch 2.10.0 and mudnn v3300:
+
+- `tests/integration/ops/test_pow_dispatch.py -m anyplatform`: **22 passed, 4 deselected**; coverage includes both `pow.Tensor_Scalar` and `pow.Tensor_Tensor` empty outputs, empty broadcasting, the zero-length narrow backward path, and non-empty parity.
+- `tests/integration/ops/test_narrow_dispatch.py -m anyplatform`: **17 passed**, including `test_narrow_backward_edge_cases[1-2-0]`, which is no longer deselected in the MUSA CI manifest.
+- `tests/integration/ops/test_musa_dispatch.py -m musa`: **89 passed**.
+- The CI operator cohort (excluding the separately triaged RNG file and the known float64 `mm` gap) reached **480 passed, 14 skipped, and 3 xpassed**; three existing FlagGems configuration-consistency assertions failed because they inspect unrelated generic FlagGems routes, not MUSA native kernels.
+
+The empty-output path stays on `flagos:0` and preserves shape and dtype; no host round trip is used. The MUSA operator support cohort is otherwise unchanged.
+
 ### MUSA native RNG routes (2026-08-17)
 
 The MUSA route configuration includes native muRAND/mudnn implementations for the core RNG families (`rand`, `randn`, `rand_like`, `randn_like`, `randint`, `normal_`, `uniform_`, `random_`, and native dropout). They share the authoritative per-device PrivateUse1 generator with the optional FlagGems Philox bridge. `randperm` and unsupported distribution overloads remain on CPU fallback and are not counted as native support.
@@ -429,6 +442,7 @@ MetaX kernel mode or for additional MACA releases and devices.
 
 | Date | Hardware | Cohort | Change | Evidence |
 |---|---|---|---|---|
+| 2026-08-30 | MTT S5000 (8 devices) | Native MUSA empty-tensor handling | Added generated on-device handling for zero-element Unary/Binary/Reduce outputs and on-device identities for whole-tensor empty `sum`, `mean`, and `prod`; no CPU fallback is used. | `test_pow_dispatch.py`: 22 passed, 4 deselected; `test_narrow_dispatch.py`: 17 passed including the restored zero-length backward case; `test_musa_dispatch.py`: 89 passed. The full operator cohort reached 480 passed, 14 skipped, and 3 xpassed; three unrelated FlagGems consistency assertions remain environment/configuration failures. |
 | 2026-08-27 | Ascend 910 (CANN 9.0.0) | Native Ascend view routes | Added `_conj` and `_neg_view` as metadata-only view routes; without them every math-bit resolution raised `backend not registered`. Generic FlagGems cohort **not revalidated** because no FlagGems route changed. | `tests/integration/test_math_bits_contract.py`: 5 passed, 7 skipped. Negative-bit clone/copy/resolve are bit-exact; the Conjugate cases skip because CANN 9.0.0 has no complex compute (`_conj_physical` absent, `aclnnAdd`/`aclnnMul` reject Complex{Float,Double}). |
 | 2026-08-26 | MetaX mc550 (C550), MACA 3.8.0 | Shared soft-lowp matrix wrappers | Enabled the CUDA-boxing build gate for scalar FP8 and packed FP4 `mm`/`bmm`/`addmm`; ordinary dtypes retain MACA boxing and unsupported scaled-mm metadata remains fail-closed. The generic FlagGems survey was not rerun because it does not exercise these wrappers. | `tests/integration/ops/test_soft_lowp_gate_dispatch.py -m soft_lowp -v -s --tb=short`: 37 passed. Coverage includes five FP8 formats, packed FP4, matrix overloads, non-square packed layouts, in-place `addmm_`, and fail-closed scaled-mm. |
 | 2026-08-21 | MetaX C550 (MACA 3.8.0) | CUDA-boxing AMP routes | Enabled the shared AMP integration contract for MetaX and added it to the MetaX CI manifest; no operator route changed. Generic FlagGems routes were **not revalidated**. | `tests/integration/test_amp.py`: 25 passed, covering FP16/BF16 autocast policies and GradScaler finite/overflow training paths. |

--- a/scripts/codegen_mudnn.py
+++ b/scripts/codegen_mudnn.py
@@ -363,7 +363,7 @@ at::Tensor {kernel}(const at::Tensor& self) {{
     return at::{at_op}(self.cpu()).to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options());
-  musa_ops::MudnnTensorWrapper t_self(self);
+{empty_guard}  musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
   op.SetMode(musa_ops::mudnn::Unary::Mode::{mode});
@@ -384,7 +384,7 @@ at::Tensor {kernel}(const at::Tensor& self) {{
     return at::{at_op}(self.cpu()).to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options());
-  musa_ops::MudnnTensorWrapper t_self(self);
+{empty_guard}  musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
   op.SetMode(musa_ops::mudnn::Unary::Mode::{mode});
@@ -408,7 +408,7 @@ at::Tensor {kernel}(const at::Tensor& self) {{
     return at::{at_op}(self.cpu()).to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options());
-  musa_ops::MudnnTensorWrapper t_self(self);
+{empty_guard}  musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary first;
   first.SetMode(musa_ops::mudnn::Unary::Mode::{mode});
@@ -462,7 +462,7 @@ at::Tensor {kernel}(const at::Tensor& self, const at::Tensor& other) {{
     + _BINARY_PROLOGUE
     + """\
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -489,7 +489,7 @@ at::Tensor {kernel}(const at::Tensor& self, const at::Tensor& other, const at::S
     + _BINARY_PROLOGUE
     + """\
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -521,7 +521,7 @@ at::Tensor {kernel}(const at::Tensor& self, const at::Tensor& other) {{
     + _BINARY_PROLOGUE
     + """\
   auto out = at::empty(out_shape, self.options().dtype(at::kBool));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -570,7 +570,7 @@ at::Tensor {kernel}(const at::Tensor& self, const at::Scalar& other) {{
     + _SCALAR_PROLOGUE
     + """\
   auto out = at::empty(self.sizes(), self.options().dtype(result_dtype));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -600,7 +600,7 @@ at::Tensor {kernel}(const at::Tensor& self, const at::Scalar& other, const at::S
     + _SCALAR_PROLOGUE
     + """\
   auto out = at::empty(self.sizes(), self.options().dtype(result_dtype));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -632,7 +632,7 @@ at::Tensor {kernel}(const at::Tensor& self, const at::Scalar& other) {{
     + _SCALAR_PROLOGUE
     + """\
   auto out = at::empty(self.sizes(), self.options().dtype(at::kBool));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -662,7 +662,7 @@ at::Tensor {kernel}(const at::Tensor& self, const at::Tensor& mat2) {{
   std::vector<int64_t> out_shape = self.sizes().vec();
   out_shape.back() = mat2.size(-1);
   auto out = at::empty(out_shape, self.options());
-  auto self_c = self.contiguous();
+{empty_guard}  auto self_c = self.contiguous();
   auto mat2_c = mat2.contiguous();
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
@@ -766,7 +766,7 @@ at::Tensor {kernel}(
     self_c = self_c.contiguous();
   }}
   auto out = at::empty(squeezed_shape, self.options().dtype(out_dtype));
-  std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
+{empty_guard}  std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -809,6 +809,14 @@ at::Tensor {kernel}(
     self_c = self_c.contiguous();
   }}
   auto out = at::empty({{}}, self.options().dtype(out_dtype));
+{empty_guard}
+  // Reducing an empty input into a scalar: mudnn rejects the zero-element
+  // operand, but aten's answer is the reduction's identity ({identity_note}).
+  // Fill it on-device rather than launching or detouring through the host.
+  if (self_c.numel() == 0) {{
+    out.fill_({identity});
+    return out;
+  }}
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -832,7 +840,7 @@ at::Tensor {kernel}(const at::Tensor& self, c10::string_view approximate) {{
     return at::{at_op}(self.cpu(), approximate).to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options());
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
@@ -856,7 +864,7 @@ at::Tensor {kernel}(const at::Tensor& self, int64_t dim, bool half_to_float) {{
   }}
   int64_t d = dim < 0 ? dim + self.dim() : dim;
   auto out = at::empty(self.sizes(), self.options());
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Softmax op;
@@ -941,7 +949,7 @@ at::Tensor {kernel}(
     self_c = self_c.contiguous();
   }}
   auto out = at::empty(squeezed_shape, self.options());
-  std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
+{empty_guard}  std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -976,7 +984,7 @@ at::Tensor {kernel}(const at::Tensor& self, int64_t dim, bool keepdim) {{
 
   auto self_b = self.scalar_type() == at::kBool ? self : self.ne(0);
   auto out = at::empty(squeezed_shape, self.options().dtype(at::kBool));
-  int mudnn_dim = static_cast<int>(d);
+{empty_guard}  int mudnn_dim = static_cast<int>(d);
 
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1022,7 +1030,7 @@ at::Tensor {kernel}(
                                                    : self.scalar_type());
   auto self_c = self.scalar_type() == out_dtype ? self : self.to(out_dtype);
   auto out = at::empty(squeezed_shape, self.options().dtype(out_dtype));
-  int mudnn_dim = static_cast<int>(d);
+{empty_guard}  int mudnn_dim = static_cast<int>(d);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1076,7 +1084,7 @@ at::Tensor {kernel}(
     self_c = self_c.contiguous();
   }}
   auto out = at::empty(squeezed_shape, self.options());
-  std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
+{empty_guard}  std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1136,7 +1144,7 @@ at::Tensor {kernel}(
     self_c = self_c.contiguous();
   }}
   auto out = at::empty(squeezed_shape, self.options());
-  std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
+{empty_guard}  std::vector<int> mudnn_dims = musa_ops::ToMudnnDims(norm_dims, ndim);
 
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1322,7 +1330,7 @@ at::Tensor {kernel}(const at::Tensor& grad_output, const at::Tensor& self) {{
   auto grad_b = grad_c.expand(out_shape);
   auto self_b = self_c.expand(out_shape);
   auto out = at::empty(out_shape, grad_output.options().dtype(result_dtype));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_grad(grad_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1357,7 +1365,7 @@ at::Tensor {kernel}(
   auto grad_b = grad_c.expand(out_shape);
   auto self_b = self_c.expand(out_shape);
   auto out = at::empty(out_shape, grad_output.options().dtype(result_dtype));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_grad(grad_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1396,7 +1404,7 @@ at::Tensor {kernel}(
   auto grad_b = grad_c.expand(out_shape);
   auto self_b = self_c.expand(out_shape);
   auto out = at::empty(out_shape, grad_output.options().dtype(result_dtype));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_grad(grad_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1441,7 +1449,7 @@ at::Tensor {kernel}(
   auto grad_b = grad_c.expand(out_shape);
   auto self_b = self_c.expand(out_shape);
   auto out = at::empty(out_shape, grad_output.options().dtype(result_dtype));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_grad(grad_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1488,7 +1496,7 @@ at::Tensor {kernel}(
   auto t1_b = t1_c.expand(out_shape);
   auto t2_b = t2_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_t1(t1_b);
   musa_ops::MudnnTensorWrapper t_t2(t2_b);
@@ -1531,7 +1539,7 @@ at::Tensor {kernel}(
   auto self_b = self_c.expand(out_shape);
   auto other_b = other_c.expand(out_shape);
   auto out = at::empty(out_shape, self.options().dtype(result_dtype));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_cond(cond_b);
   musa_ops::MudnnTensorWrapper t_self(self_b);
   musa_ops::MudnnTensorWrapper t_other(other_b);
@@ -1578,7 +1586,7 @@ at::Tensor {kernel}(
   std::vector<int64_t> out_shape = mat1.sizes().vec();
   out_shape.back() = mat2.size(-1);
   auto out = at::empty(out_shape, mat1.options());
-  auto mat1_c = mat1.contiguous();
+{empty_guard}  auto mat1_c = mat1.contiguous();
   auto mat2_c = mat2.contiguous();
 
   musa_ops::MudnnTensorWrapper t_mat1(mat1_c);
@@ -1638,7 +1646,7 @@ at::Tensor {kernel}(const at::Tensor& self) {{
     return at::{at_op}(self.cpu()).to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options().dtype(at::kBool));
-  musa_ops::MudnnTensorWrapper t_self(self);
+{empty_guard}  musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
   op.SetMode(musa_ops::mudnn::Unary::Mode::{mode});
@@ -1659,7 +1667,7 @@ at::Tensor {kernel}(const at::Tensor& self) {{
     return at::{at_op}(self.cpu()).to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options());
-  musa_ops::MudnnTensorWrapper t_self(self);
+{empty_guard}  musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
   op.SetMode(musa_ops::mudnn::Unary::Mode::{mode});
@@ -1679,7 +1687,7 @@ at::Tensor {kernel}(const at::Tensor& self, const at::Scalar& {param}) {{
     return at::{at_op}(self.cpu(), {param}).to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options());
-  musa_ops::MudnnTensorWrapper t_self(self);
+{empty_guard}  musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
   op.SetMode(musa_ops::mudnn::Unary::Mode::{mode});
@@ -1700,7 +1708,7 @@ at::Tensor {kernel}(const at::Tensor& self, const at::Scalar& {param}) {{
     return at::{at_op}(self.cpu(), {param}).to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options());
-  musa_ops::MudnnTensorWrapper t_self(self);
+{empty_guard}  musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
   op.SetMode(musa_ops::mudnn::Unary::Mode::{mode});
@@ -1724,7 +1732,7 @@ at::Tensor {kernel}(
     return at::{at_op}(self.cpu(), min, max).to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options());
-  musa_ops::MudnnTensorWrapper t_self(self);
+{empty_guard}  musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
   op.SetMode(musa_ops::mudnn::Unary::Mode::{mode});
@@ -1753,7 +1761,7 @@ at::Tensor {kernel}(
     return at::{at_op}(self.cpu(), beta, threshold).to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options());
-  musa_ops::MudnnTensorWrapper t_self(self);
+{empty_guard}  musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
   op.SetMode(musa_ops::mudnn::Unary::Mode::{mode});
@@ -1782,7 +1790,7 @@ at::Tensor {kernel}(
         .to(self.device());
   }}
   auto out = at::empty(self.sizes(), self.options());
-  musa_ops::MudnnTensorWrapper t_self(self);
+{empty_guard}  musa_ops::MudnnTensorWrapper t_self(self);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Unary op;
   op.SetMode(musa_ops::mudnn::Unary::Mode::{mode});
@@ -1855,7 +1863,7 @@ at::Tensor {kernel}({list_type} tensors, int64_t dim) {{
   for (const auto& t : kept) total += t.size(d);
   out_shape[d] = total;
   auto out = at::empty(out_shape, kept[0].options());
-
+{empty_guard}
   std::vector<at::Tensor> ins_c;
   std::vector<std::unique_ptr<musa_ops::MudnnTensorWrapper>> wraps;
   std::vector<musa_ops::mudnn::Tensor> raw;
@@ -1897,7 +1905,7 @@ at::Tensor {kernel}(
   auto self_c = self.contiguous();
   auto index_c = index.contiguous();
   auto out = at::empty(index.sizes(), self.options());
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_index(index_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1931,7 +1939,7 @@ at::Tensor {kernel}(
   auto out_shape = self.sizes().vec();
   out_shape[d] = index.numel();
   auto out = at::empty(out_shape, self.options());
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_index(index_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -1976,7 +1984,7 @@ at::Tensor {kernel}(
   std::vector<int64_t> flat_shape = weight.sizes().vec();
   flat_shape[0] = index_c.numel();
   auto out = at::empty(flat_shape, weight.options());
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_weight(weight_c);
   musa_ops::MudnnTensorWrapper t_index(index_c);
   musa_ops::MudnnTensorWrapper t_out(out);
@@ -2234,7 +2242,7 @@ at::Tensor {kernel}(
   auto self_c = self.to(acc).contiguous();
   int64_t d = dim < 0 ? dim + self.dim() : dim;
   auto out = at::empty(self.sizes(), self.options().dtype(acc));
-
+{empty_guard}
   musa_ops::MudnnTensorWrapper t_self(self_c);
   musa_ops::MudnnTensorWrapper t_out(out);
   musa_ops::mudnn::Cum op;
@@ -2519,6 +2527,7 @@ FILE_HEADER = """\
 #include <ATen/ops/result_type.h>
 #include <c10/core/Scalar.h>
 #include <algorithm>
+#include <limits>
 #include <string>
 #include <vector>
 #include "../mudnn_common.h"
@@ -2542,6 +2551,10 @@ INC_HEADER = """\
 // without a kernel behind it fails the dispatcher's "backend not registered"
 // check, whereas an unregistered op simply reaches the cpu_fallback. So this
 // file is exactly the MUSA coverage set.
+//
+// The list also covers the handwritten mudnn convolution and native
+// muRAND/mudnn RNG kernels. Unsupported RNG schemas stay unregistered and
+// continue through cpu_fallback.
 
 """
 
@@ -2564,6 +2577,51 @@ def symbols(lib: Path):
         ["nm", "-DC", "--defined-only", str(lib)], capture_output=True, text=True
     )
     return set(re.findall(r"musa::dnn::(\w+)::", out.stdout))
+
+
+# mudnn rejects zero-element operands outright -- every mode probed on v3300
+# (Unary, Binary, Reduce, Fill, MatMul) answers NOT_SUPPORTED rather than
+# no-opping, and mudnn's UncontigHandle additionally faults. Empty tensors are
+# not an exotic input: a zero-length slice and its backward produce them, so the
+# kernels must handle them instead of erroring (issue #214). Where the *output*
+# is empty the answer carries no elements, so returning the allocation
+# unwritten is exactly aten's result and no launch is needed. This must stay on
+# device: a cpu() detour would silently move the result off the accelerator.
+#
+# A dim-wise reduce over an empty axis into a non-empty output is a separate
+# case, and mudnn already answers it correctly (measured on v3300: (4,0) reduced
+# over dim 1 gives sum 0, prod 1, mean nan, any false, all true, norm 0, all
+# matching CPU), so it is left alone. The whole-tensor reduce is the exception
+# handled by EMPTY_ALL_REDUCE_IDENTITY below: its output is a non-empty scalar,
+# so the guard here cannot fire, yet the empty input still trips mudnn.
+def empty_guard(ret_expr: str) -> str:
+    return (
+        "  // mudnn rejects zero-element operands (NOT_SUPPORTED); an empty\n"
+        "  // output holds no elements, so the allocation above is already the\n"
+        "  // answer. Return it on-device without launching.\n"
+        f"  if (out.numel() == 0) return {ret_expr};\n"
+    )
+
+
+# What each guarded template returns, so the guard's early return matches the
+# kernel's own final return (keepdim views included) instead of assuming `out`.
+EMPTY_GUARD_RETURN = {
+    "embedding": "out.view(out_shape)",
+    "reduce_bool": "keepdim ? out.view(out_shape) : out",
+    "reduce_correction": "keepdim ? out.view(out_shape) : out",
+    "reduce_dims_dtype": "keepdim ? out.view(out_shape) : out",
+    "reduce_dims_plain": "keepdim ? out.view(out_shape) : out",
+    "reduce_norm": "keepdim ? out.view(out_shape) : out",
+    "reduce_prod": "keepdim ? out.view(out_shape) : out",
+}
+
+# aten's whole-tensor reduction of an empty input, measured on CPU: sum 0,
+# mean nan (0/0), prod 1. Only these three ops use reduce_all_dtype.
+EMPTY_ALL_REDUCE_IDENTITY = {
+    "ADD": ("0", "sum -> 0"),
+    "MEAN": ("std::numeric_limits<double>::quiet_NaN()", "mean -> nan"),
+    "PROD": ("1", "prod -> 1"),
+}
 
 
 def wrapper_map():
@@ -2624,6 +2682,7 @@ def main():
             fn=fn,
             disp=disp,
             at_op=AT_OP_OVERRIDES.get(op, base),
+            empty_guard=empty_guard(EMPTY_GUARD_RETURN.get(cat, "out")),
             promote_integral="true" if base == "sum" else "false",
             dtype_pred=(
                 "MudnnSupportsArithmeticDtype"
@@ -2631,6 +2690,14 @@ def main():
                 else "MudnnSupportsDtype"
             ),
         )
+        if cat == "reduce_all_dtype":
+            if mode_name not in EMPTY_ALL_REDUCE_IDENTITY:
+                raise SystemExit(
+                    f"{op}: reduce_all_dtype mode {mode_name} has no empty-input "
+                    "identity; add it to EMPTY_ALL_REDUCE_IDENTITY"
+                )
+            ident, note = EMPTY_ALL_REDUCE_IDENTITY[mode_name]
+            fmt["identity"], fmt["identity_note"] = ident, note
         if cat == "unary_alpha_const":
             fmt["alpha"] = extra[0]
         elif cat == "unary_two_pass":

--- a/tests/integration/ops/test_pow_dispatch.py
+++ b/tests/integration/ops/test_pow_dispatch.py
@@ -113,6 +113,71 @@ class TestPowTensorScalarCorrectness:
         torch.testing.assert_close(out.cpu(), ref.cpu(), rtol=1e-6, atol=1e-6)
 
 
+class TestPowZeroElement:
+    """Zero-element pow must stay on the device (regression for issue #214).
+
+    mudnn rejects zero-element operands with NOT_SUPPORTED, so the MUSA kernels
+    short-circuit before launching. The result must still be a correctly shaped
+    device tensor -- not a host tensor and not an error -- because empty
+    intermediates arise naturally from zero-length slices and their backward.
+    """
+
+    @pytest.mark.parametrize("shape", [(0,), (0, 8), (4, 0), (3, 0, 5)])
+    @pytest.mark.anyplatform
+    def test_pow_scalar_empty(self, shape):
+        a = torch.randn(*shape, device=DEVICE)
+        out = torch.pow(a, 2.0)
+        assert out.device.type == "flagos"
+        assert out.shape == shape
+        assert out.numel() == 0
+        assert out.dtype == a.dtype
+
+    @pytest.mark.parametrize("shape", [(0,), (0, 8), (4, 0)])
+    @pytest.mark.anyplatform
+    def test_pow_tensor_empty(self, shape):
+        a = torch.randn(*shape, device=DEVICE)
+        b = torch.randn(*shape, device=DEVICE)
+        out = torch.pow(a, b)
+        assert out.device.type == "flagos"
+        assert out.shape == shape
+        assert out.numel() == 0
+
+    @pytest.mark.anyplatform
+    def test_pow_tensor_empty_broadcast(self):
+        """Broadcasting a non-empty operand against an empty one still empties."""
+        a = torch.randn(4, 0, device=DEVICE)
+        b = torch.randn(4, 1, device=DEVICE)
+        out = torch.pow(a, b)
+        assert out.device.type == "flagos"
+        assert out.shape == (4, 0)
+
+    @pytest.mark.anyplatform
+    def test_pow_empty_backward(self):
+        """The zero-length-slice gradient path from issue #214."""
+        base = torch.randn(4, 8)
+        x_fl = base.to(DEVICE).detach().requires_grad_(True)
+        x_ref = base.clone().detach().requires_grad_(True)
+
+        torch.narrow(x_fl, 1, 2, 0).square().sum().backward()
+        torch.narrow(x_ref, 1, 2, 0).square().sum().backward()
+
+        assert x_fl.grad.device.type == "flagos"
+        torch.testing.assert_close(x_fl.grad.cpu(), x_ref.grad)
+
+    @pytest.mark.anyplatform
+    def test_pow_nonempty_unaffected(self):
+        """The empty guard must not perturb the ordinary path."""
+        torch.manual_seed(6)
+        a = torch.randn(16, 16, device=DEVICE).abs() + 0.1
+        b = torch.randn(16, 16, device=DEVICE).abs() + 0.1
+        torch.testing.assert_close(
+            torch.pow(a, 2.0).cpu(), torch.pow(a.cpu(), 2.0), rtol=1e-4, atol=1e-4
+        )
+        torch.testing.assert_close(
+            torch.pow(a, b).cpu(), torch.pow(a.cpu(), b.cpu()), rtol=1e-4, atol=1e-4
+        )
+
+
 class TestPowTensorScalarDispatch:
     """Verify dispatch routing for pow.Tensor_Scalar op."""
 


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5
- **Human Reviewer**: @aoyulong
- **Session Summary**: Investigated and fixed issue #214 on the MUSA native mudnn backend. The fix was measured on an MTT S5000 and keeps all empty-tensor results on the MUSA device without a CPU fallback.

## Summary
MUSA mudnn v3300 rejects zero-element operands, causing the zero-length `narrow` backward regression in issue #214 to fail when autograd evaluates `square().sum()`. This change updates the MUSA code generator and regenerated artifacts to return empty outputs from device allocations before launching mudnn, and to fill whole-tensor `sum`, `mean`, and `prod` identities on-device for empty inputs. It restores the previously deselected MUSA regression case and records measured coverage.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [x] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)

MUSA (native mudnn) is the only affected platform.

## Problem Analysis
### What was broken/missing?
On MUSA, `torch.narrow(x, 1, 2, 0).square().sum().backward()` failed with `RuntimeError: pow failed: NOT_SUPPORTED` because the generated pow kernel launched mudnn with a zero-element tensor. After pow was addressed, the same unsupported empty operand surfaced in the following reduction, so the complete autograd path required device-side empty handling for both elementwise and reduction operations.

### Why did it happen?
The native MUSA backend calls mudnn directly. mudnn v3300 returns `NOT_SUPPORTED` for zero-element Unary, Binary, and Reduce operands instead of treating them as no-ops. The generated kernels allocated the correct output but unconditionally wrapped tensors and called `Run`. There was no generated early return for an empty output and no identity initialization for whole-tensor reductions whose output is a non-empty scalar.

### Investigation process:
1. Read issue #214, the narrow implementation, the AutogradPrivateUse1 registration, the MUSA CI manifest, and the mudnn code generator.
2. Reproduced the original failure on the MTT S5000: mudnn reported `NOT_SUPPORTED in Unary::Run, Reason: Unsupported empty tensor` for empty pow.
3. Probed mudnn empty behavior across Unary, Binary, Reduce, Fill, and MatMul; verified CPU identities for empty `sum`, `mean`, and `prod`.
4. Implemented the guard in `scripts/codegen_mudnn.py`, regenerated artifacts, rebuilt the extension, and reran the original regression and targeted MUSA suites.

## Solution Design
### Implementation approach:
The generator inserts an on-device early return after output allocation for generated templates whose result is empty. Whole-tensor `sum`, `mean`, and `prod` additionally detect an empty input and fill the CPU-defined identity into their already allocated MUSA scalar output. No path calls `.cpu()` for this condition, and no generated file is hand-edited.

### Key design decisions:
- Use the platform code generator as the source of truth, then commit regenerated C++ and registration artifacts.
- Return the already allocated output when `out.numel() == 0`; this preserves device, shape, dtype, and autograd metadata without launching mudnn.
- Handle scalar whole-tensor reductions separately because their output has one element even when the input is empty.
- Keep the existing float64 `mm` deselect and unrelated RNG triage unchanged.
- Retain the generated registration ordering and move the RNG registration explanation into the generated header so repeated generation is idempotent.

### Code changes by file:
- `scripts/codegen_mudnn.py`: Add reusable empty-output guard generation, whole-tensor reduction identities, and the generated-header registration note.
- `csrc/aten/backends/musa/generated/musa_kernels.cc`: Regenerated native MUSA kernels with on-device empty handling.
- `csrc/aten/backends/musa/generated/musa_register.inc`: Regenerated deterministic registration ordering.
- `tests/integration/ops/test_pow_dispatch.py`: Add scalar/tensor overload, broadcast, backward, empty shape/dtype/device, and non-empty parity coverage.
- `.github/configs/musa.yml`: Remove the narrow zero-length backward deselect while retaining the known float64 `mm` deselect.
- `docs/reference/operator-support.md`: Record the measured MTT S5000 results and the no-CPU-fallback behavior.

### Changes by commit:
1. `2bafc48` - `fix: handle empty MUSA tensors without CPU fallback`: Add the generated implementation, tests, CI restoration, and measured support documentation.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [ ] **Type checking passed** (not applicable)
- [ ] **All tests pass** (targeted MUSA suites pass; full operator cohort has unrelated pre-existing FlagGems consistency failures documented below)
- [x] **Manual testing completed** (original issue reproduced before rebuild and fixed after rebuild)
- [x] **No debug/temporary code** (no debug statements added)
- [x] **Documentation updated**
- [x] **Commit messages follow conventions**
- [x] **All text in English**

### Linting Results
```bash
$ python -m ruff check
All checks passed!

$ python -m ruff format --check
307 files already formatted
```

### Test Results
```bash
# MUSA pow regression and existing pow tests
$ python -m pytest tests/integration/ops/test_pow_dispatch.py -m anyplatform -v -s --tb=short
======================= 22 passed, 4 deselected in 4.33s =======================

# Original narrow regression
$ python -m pytest tests/integration/ops/test_narrow_dispatch.py -m anyplatform -v -s --tb=short
============================== 17 passed in 7.28s ==============================
# Includes test_narrow_backward_edge_cases[1-2-0] PASSED

# MUSA dispatch suite
$ python -m pytest tests/integration/ops/test_musa_dispatch.py -m musa -v -s --tb=short
============================= 89 passed in 42.39s ==============================

# CI operator cohort, excluding separately triaged RNG and known float64 mm gap
$ python -m pytest tests/integration/ops/ --ignore=tests/integration/ops/test_rng_dispatch.py --deselect "tests/integration/ops/test_soft_lowp_gate_dispatch.py::TestSoftLowpGateLeavesFloatPathsAlone::test_mm_still_runs[dtype3]" -m "(anyplatform or main_ops) and not flaggems_python and not flaggems_cpp and not cuda and not ascend and not metax and not dcu and not gcu and not ppu" -q --tb=line
3 failed, 480 passed, 14 skipped, 3 xpassed in 20.25s
```

The three full-cohort failures are existing `test_flaggems_conf_consistency.py` assertions about generic FlagGems `mm`/`bmm`/`addmm` routes; they do not exercise the native MUSA kernels changed here.

### Manual Verification
```bash
# Command to reproduce original issue before rebuilding the extension
$ python -c 'import torch_fl, torch; e=torch.randn(4,0,device="flagos:0"); torch.pow(e,2.0)'
muDNN(v3300) ... ERROR# NOT_SUPPORTED in Unary::Run, Reason: Unsupported empty tensor
RuntimeError: pow failed: NOT_SUPPORTED

# Output after rebuilding the generated MUSA extension
scalar: torch.Size([4, 0]) flagos:0 torch.float32
tensor: torch.Size([4, 0]) flagos:0
grad: torch.Size([4, 8]) flagos:0 0.0
nonempty ok: True
```

## Code Quality Verification
### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions
- [x] Followed project generator conventions
- [x] Comment density matches surrounding code
- [x] Used existing utilities and allocation paths

### Edge Cases Considered
1. Empty scalar and tensor exponent overloads.
2. Empty leading, trailing, and inner dimensions plus empty broadcasting.
3. Zero-length narrow backward with device gradient preservation.
4. Whole-tensor empty `sum`, `mean`, and `prod` identities.
5. Non-empty pow parity and unchanged dtype/device behavior.
6. Generator idempotency (two successive generations produce no diff).

### Potential Risks
1. The generated guard covers many mudnn templates; an incorrect return expression could alter keepdim or view semantics.
2. Empty whole-tensor reduction identity handling must remain aligned with ATen for dtype promotion and NaN semantics.

### Rollback Plan
Revert commit `2bafc48`. The MUSA CI deselect can be restored temporarily if the native extension shows a regression while the generator change is investigated.

## Related Work
- Fixes #214
- Related to the MUSA native mudnn code generator and zero-length narrow autograd coverage
- Depends on mudnn v3300 runtime behavior measured on MTT S5000

## Explicitly Not Included
- CPU fallback for empty MUSA tensors; the fix intentionally stays on-device.
- The known float64 `mm` mudnn gap.
- The separately triaged MUSA RNG seed-source/multi-device failures.
- Generic FlagGems configuration-consistency cleanup unrelated to this issue.

## Human Review Notes
### Areas needing special attention:
1. Verify the generator category coverage and generated return expressions, especially keepdim reduction views.
2. Review on-device scalar identity initialization for empty whole-tensor reductions.
3. Confirm the generated registration reorder is intentional and remains idempotent.

### Questions for reviewer:
1. Should future empty-input mudnn behavior be extended to additional handwritten templates as vendor support evolves?
2. Is the current generated registration ordering and header explanation preferable to retaining a trailing hand-maintained RNG block?

## Additional Context
The extension was rebuilt with CPU PyTorch 2.10.0, MUSA toolkit mudnn v3300, and the MTT S5000 device runtime. The empty path allocates with the original MUSA tensor options and returns without calling mudnn or moving data to the host.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
