### PR TITLE
docs: add the transformers coverage survey skill

### DIFF
--- a/.claude/skills/hf-coverage-survey/SKILL.md
+++ b/.claude/skills/hf-coverage-survey/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: hf-coverage-survey
+description: >
+  Measure torch_fl transformers coverage on an accelerator one model at a time,
+  and turn each new failure into an operator, feature, precision, or crash
+  finding with a named root cause. Use this to survey a platform's HuggingFace
+  model support, to check a model after enabling operators, or to re-measure
+  after a transformers version change. Covers: per-model probing without real
+  weights, the HF custom-device injection contract, CPU same-dtype precision
+  baselines, aten attribution through TorchDispatchMode, fingerprint dedup, and
+  the baseline-first issue policy. Do not use this to infer model support from a
+  routing table or from a passing operator suite.
+---
+
+# transformers coverage survey (torch_fl)
+
+## Scope and prerequisites
+
+This skill measures whether real transformers models run on the `flagos`
+device. It is a hardware measurement, not a routing audit: an operator that
+passes a standalone dispatch test can still fail inside a model through a shape,
+dtype, stride, or call-order the operator suite never produces.
+
+Complete these first:
+
+- [[runtime-bringup]] — the device and allocator contract must pass.
+- [[native-op-backend]] or [[cuda-compat-vendor]] — an operator path must exist.
+  A platform whose every compute op reaches `cpu_fallback` will "pass" this
+  survey while measuring nothing about the accelerator.
+
+The unit of work is **one model**. A full sweep is a loop over single-model
+runs, not a single long process. Prefer measuring the model you care about:
+a per-model run finishes in minutes and produces an actionable finding, while a
+full sweep across 300+ architectures mostly re-measures what the previous sweep
+already recorded.
+
+## Step 1 — pin the environment and record it
+
+Two versions decide how a result must be read: the `transformers` version and
+the torch_fl commit. A failure carries no meaning without both.
+
+Default to the latest `transformers`. Pin an older line only to reproduce a
+known-good state or to check a regression:
+
+```bash
+python tests/manual/hf_model_probe.py --model qwen3
+python tests/manual/hf_model_probe.py --model qwen3 --transformers-version 4.50.2
+```
+
+Install each requested `transformers` into its own cached virtual environment
+rather than the environment that holds torch_fl. `transformers` pulls its own
+torch constraint, and letting it resolve inside the torch_fl environment can
+replace the torch the extension was built against — which produces symbol
+errors or silent ABI corruption, not a coverage result.
+
+Record and keep with the run:
+
+```bash
+python - <<'PY'
+import torch, transformers, torch_fl
+print("torch", torch.__version__)
+print("transformers", transformers.__version__)
+print("device_count", torch.flagos.device_count())
+PY
+
+git rev-parse --short HEAD
+```
+
+For a vendor box, also record the chip model, driver, SDK revision, and any
+required environment. A model probe that ran against the wrong runtime is an
+environment failure, not a coverage data point.
+
+## Step 2 — inject `flagos` as the HF test device
+
+`transformers` supports a third-party device through two environment variables
+and a spec module. It validates only that the device name is constructible by
+`torch.device`, so `flagos` is accepted without patching HF:
+
+```bash
+export TRANSFORMERS_TEST_DEVICE=flagos
+export TRANSFORMERS_TEST_DEVICE_SPEC=tests/manual/hf_device_spec.py
+export RUN_THIRD_PARTY_DEVICE_TESTS=1
+```
+
+The spec module must define `DEVICE_NAME` plus the three backend hooks HF
+dispatches on; a missing hook raises at import unless HF has a default:
+
+```python
+DEVICE_NAME = "flagos"
+MANUAL_SEED_FN = torch.flagos.manual_seed
+EMPTY_CACHE_FN = torch.flagos.empty_cache
+DEVICE_COUNT_FN = torch.flagos.device_count
+```
+
+Note the gating split this produces, and do not try to defeat it:
+`require_torch_accelerator` passes for `flagos` (non-CPU, non-None), while
+`require_torch_gpu` skips because it compares against `cuda` literally. Cases
+skipped by `require_torch_gpu` are CUDA-specific and are not coverage gaps.
+
+The `transformers` wheel ships no `tests/` directory. The per-model probe in
+this skill therefore does not need an HF source checkout. A checkout is required
+only for the optional `--hf-tests` mode, and its `git describe` must match the
+installed `transformers` version — a version-mismatched checkout produces
+failures that belong to HF, not to torch_fl.
+
+## Step 3 — probe one model in layers
+
+Build the model from its `CONFIG_MAPPING` entry reduced to tiny dimensions and
+randomly initialized. Real pretrained weights are not needed to find missing
+operators, and requiring them makes the survey depend on downloads and device
+memory.
+
+Resolve the architecture key through `model_type_to_module_name()`. Keys and
+module directories disagree for a substantial minority of architectures
+(`blip-2` → `blip_2`, `audio-spectrogram-transformer` →
+`audio_spectrogram_transformer`); comparing the raw key against directory names
+misreports those models as absent.
+
+Run the layers in order and stop the model at the first failing layer. A model
+whose `.to(device)` fails produces meaningless forward and backward results:
+
+| Layer | What runs | What a failure means |
+|---|---|---|
+| L0 | build tiny model, `.to("flagos")` | allocator, copy, or dtype transfer |
+| L1 | forward, compare to CPU same dtype | missing operator or precision |
+| L2 | backward plus one optimizer step | missing backward operator |
+| L3 | short `generate()` | KV-cache, sampling, or control flow |
+
+If the requested model does not exist in the pinned `transformers`, record
+`NOT_IN_VERSION`. That is neither a pass nor a failure, and counting it either
+way corrupts the platform's rate.
+
+## Step 4 — isolate every model in a subprocess
+
+Run each model in its own subprocess with a timeout, even in single-model mode.
+Accelerator faults are not contained: one illegal memory access poisons the
+device context, after which every later operation fails with the same symptom.
+This has been measured in this repository — a single fault turned roughly one
+real failure into roughly eighty collateral ones.
+
+Treat a poisoned run as one finding for the whole model, never as a list of
+per-layer failures:
+
+```text
+illegal memory access | device-side assert | unspecified launch failure
+misaligned address | vmfault | acceleratorerror
+```
+
+Write results incrementally so an interrupted sweep resumes instead of
+restarting, and keep raw stdout/stderr per model for auditing.
+
+## Step 5 — classify the failure and name the root cause
+
+Every failure must land in exactly one class. The class selects the issue label
+and decides whether the finding is actionable:
+
+| Class | Signal | Label |
+|---|---|---|
+| `OP_UNSUPPORTED` | `NOT_SUPPORTED`, `backend not registered`, `could not run 'aten::…'` | `operator` |
+| `FEATURE_UNSUPPORTED` | non-operator runtime or feature gap | `enhancement` |
+| `PRECISION` | ran, but disagrees with the CPU baseline | `bug` |
+| `CRASH` | segfault, poison, or timeout | `bug` |
+
+For `OP_UNSUPPORTED` and `PRECISION`, re-run the failing layer under
+`TorchDispatchMode` and capture the aten calls, then put the specific operator
+in the finding. Without this attribution the report only says a model failed,
+which a maintainer cannot act on. `tests/manual/op_called_summary.py` is the
+existing pattern for this collection.
+
+## Step 6 — judge precision against CPU, same dtype
+
+The baseline is the same model, same seed, same dtype on CPU. A CUDA baseline is
+not usable here: most vendor boxes have no NVIDIA device, so it would make the
+survey unrunnable exactly where it is needed.
+
+Validate the CPU side first. If CPU itself errors, the case is `UNTESTED` — not
+a device failure. Then compare with dtype-scaled tolerances:
+
+| dtype | rtol | atol |
+|---|---|---|
+| float32 | 1e-5 | 1e-5 |
+| float16 | 1e-3 | 1e-3 |
+| bfloat16 | 1.6e-2 | 1e-2 |
+
+Keep `NaN`/`Inf` separate from magnitude disagreement and rank it higher. A NaN
+is always a defect; a tolerance miss may be legitimate accumulation-order
+variance. Reporting both as one class hides the real bug.
+
+## Step 7 — deduplicate before filing anything
+
+The same root cause reappears across models and platforms. Filing per model and
+per platform buries the signal under duplicates.
+
+Fingerprint the cause, not the occurrence:
+
+```text
+sha256(failure_class + operator_or_module + normalized_error_signature)[:12]
+```
+
+Normalization must strip addresses, shapes, durations, and temporary paths.
+Without it a differing pointer value creates a new issue for a known cause.
+
+Then, for each fingerprint:
+
+1. search existing open issues for the fingerprint;
+2. if found, add a comment carrying this platform's evidence;
+3. if not found, open one issue.
+
+State the chip and the model in the title, and the `transformers` version, so
+the title alone identifies the measurement:
+
+```text
+[AI][MUSA MTT S5000] qwen3: aten::index_copy_ not supported (transformers 5.16.1)
+[AI][Ascend 910] gemma3: fp16 logits mismatch vs CPU, max abs diff 3.2e-2 (transformers 5.16.1)
+```
+
+Use `.github/ISSUE_TEMPLATE/ai_agent_issue.md`, include a self-contained
+reproducer and the environment block, and write everything in English per
+`CLAUDE.md`.
+
+## Step 8 — baseline first, then only new failures
+
+A first sweep on a new platform can produce hundreds of failures at once.
+Filing those is not a report; it is a flood that hides every later regression.
+
+The first run on a platform records a baseline and files nothing. Later runs
+file only fingerprints absent from the baseline. Issue filing stays opt-in:
+
+```bash
+# first run on a platform: record the baseline, file nothing
+python tests/manual/hf_model_probe.py --model qwen3 --promote-baseline
+
+# later runs: file only newly appeared failures
+python tests/manual/hf_model_probe.py --model qwen3 \
+  --baseline docs/reference/hf-coverage-baseline-musa.json --file-issues
+```
+
+Default to report-only. Opening issues writes to a shared tracker and cannot be
+cleanly undone, so it must be requested explicitly rather than inferred.
+
+## Step 9 — record measured evidence
+
+Update `docs/reference/hf-coverage.md` with the chip, run date, `transformers`
+version, torch_fl commit, models attempted, and the per-class counts. Keep the
+raw JSON.
+
+Report only the models actually attempted. If a model was skipped, timed out, or
+was absent from the pinned version, say so in its own category. Do not carry a
+previous cohort's numbers forward as though they were re-measured, and do not
+copy one chip's rate onto another.
+
+Before opening a PR:
+
+- the `transformers` version and torch_fl commit are recorded with every result;
+- CPU baselines were validated before any device comparison;
+- poisoned runs are one finding per model, not per layer;
+- every `OP_UNSUPPORTED` and `PRECISION` finding names an operator;
+- `NOT_IN_VERSION`, `UNTESTED`, and CUDA-only skips are excluded from failures;
+- fingerprints were searched before filing, and duplicates became comments;
+- unavailable hardware is marked **not revalidated**;
+- `ruff check .` and `ruff format --check .` pass.
+
+Coverage may be claimed only for the models measured on that chip. A passing
+operator suite, a populated routing table, and another platform's rate are all
+not evidence.
+
+## Related
+
+[[runtime-bringup]] · [[native-op-backend]] · [[cuda-compat-vendor]] ·
+[[flaggems-integration]] · [[pre-pr-checks]]


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5
- **Human Reviewer**: @aoyulong
- **Session Summary**: Designed a workflow for measuring torch_fl transformers coverage per platform and captured it as a repository skill. The HuggingFace custom-device contract and architecture-name normalization claims were verified against the installed transformers before the skill was written.

## Summary
This adds `.claude/skills/hf-coverage-survey/SKILL.md`, a documentation-only skill describing how to measure which HuggingFace transformers models actually run on a torch_fl accelerator. The workflow probes one model at a time in layers, judges precision against a CPU same-dtype baseline, attributes operator failures to a specific aten operator, and constrains issue filing through root-cause fingerprints and a baseline-first policy. No executable harness is included in this change; the skill defines the contract that harness must satisfy.

## Change Type
- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [ ] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [x] Platform-agnostic (all platforms)

No platform behavior changes. The skill is applicable to any accelerator that has completed runtime bring-up and has an operator path.

## Problem Analysis
### What was broken/missing?
The repository had no documented method for measuring transformers model coverage on an accelerator. Operator-level evidence existed (`tests/manual/flaggems_overload_survey.py`, `docs/reference/operator-support.md`), but a passing operator suite does not establish that a model runs: inside a model an operator is reached with shapes, dtypes, strides, and call orders that the standalone suite never produces. Model-level failures were therefore found ad hoc, and one prior investigation had to cite HF unit-test nodes informally as evidence for a route change.

### Why did it happen?
Coverage measurement had been organized around operators because that is the unit the backends are built in. Nothing described how to go from "a model failed" to "this operator is missing", how to distinguish a genuine precision defect from tolerance noise, or how to keep an automated survey from flooding the issue tracker with one issue per model per platform for a single shared root cause.

### Investigation process:
1. Surveyed the existing skills, `tests/manual/` harnesses, CI platform manifests, and issue templates to match established conventions.
2. Verified the HuggingFace custom-device contract in the installed `transformers`: `TRANSFORMERS_TEST_DEVICE` validates only that the name is constructible by `torch.device`, and `TRANSFORMERS_TEST_DEVICE_SPEC` requires `DEVICE_NAME`, `MANUAL_SEED_FN`, `EMPTY_CACHE_FN`, and `DEVICE_COUNT_FN`.
3. Confirmed on the MTT S5000 that `torch.device("flagos")` constructs, `torch.flagos.device_count()` returns 8, and `manual_seed`/`empty_cache` exist, so the spec can be satisfied without patching HuggingFace.
4. Confirmed the gating split: `require_torch_accelerator` passes for a non-CPU device while `require_torch_gpu` compares against `cuda` literally and correctly skips.
5. Established that the `transformers` wheel ships no `tests/` directory, so a per-model probe must not depend on one, and that architecture keys and module directories disagree for a substantial minority of models (`blip-2` -> `blip_2`), which requires `model_type_to_module_name()`.
6. Reviewed the recorded MUSA context-poisoning behavior, where one illegal memory access turned roughly one real failure into roughly eighty collateral ones, and adopted the existing subprocess-isolation approach.

## Solution Design
### Implementation approach:
The skill defines a per-model workflow: pin and record the `transformers` version and torch_fl commit, inject `flagos` through the documented HuggingFace device-spec hooks, build a tiny randomly initialized model from its config entry, and probe it in ordered layers (device transfer, forward, backward plus optimizer step, short generate), stopping at the first failing layer. Failures are classified as `OP_UNSUPPORTED`, `FEATURE_UNSUPPORTED`, `PRECISION`, or `CRASH`, and operator and precision failures are re-run under `TorchDispatchMode` so the finding names an operator.

### Key design decisions:
- One model per run is the primary unit; a full sweep is a loop, not a single long process. A per-model run finishes in minutes and yields an actionable finding.
- Tiny randomly initialized models rather than pretrained weights, so the survey needs no downloads or large device memory and stays reproducible offline.
- No HuggingFace source checkout for the per-model probe, since the wheel omits `tests/`. A checkout is required only for the optional HF-suite mode, where its version must match the installed `transformers`.
- CPU same-dtype baseline rather than CUDA, because most vendor boxes have no NVIDIA device and a CUDA baseline would make the survey unrunnable where it is most needed.
- CPU-side validation before any device comparison, so a case that fails on CPU is recorded as `UNTESTED` rather than as a device defect.
- `NaN`/`Inf` separated from magnitude disagreement, because a NaN is always a defect while a tolerance miss can be legitimate accumulation-order variance.
- Subprocess isolation per model with poison-pattern detection, so a device fault is one finding for the model instead of a long list of collateral failures.
- Root-cause fingerprints with normalization that strips addresses, shapes, durations, and temporary paths; a shared cause becomes one issue with added platform evidence.
- Baseline-first and opt-in filing, because a first sweep can produce hundreds of failures and writing to a shared tracker cannot be cleanly undone.

### Code changes by file:
- `.claude/skills/hf-coverage-survey/SKILL.md` (new, 270 lines): the workflow, the HuggingFace device-injection contract, the layer model, failure classes, precision tolerances, fingerprint dedup, the baseline-first issue policy, and the pre-PR checklist.

### Changes by commit:
1. `17f0085` - `docs: add the transformers coverage survey skill`: adds the skill.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [ ] **Type checking passed** (not applicable, documentation only)
- [x] **All tests pass** (no code changed; full suite unaffected)
- [x] **Manual testing completed** (the skill's factual claims were verified against the installed transformers and on MUSA hardware)
- [x] **No debug/temporary code**
- [x] **Documentation updated** (this change is the documentation)
- [x] **Commit messages follow conventions**
- [x] **All text in English**

### Linting Results
```bash
$ python -m ruff check .
All checks passed!

$ python -m ruff format --check .
314 files already formatted
```

### Test Results
```bash
# This change adds no executable code, so no test behavior changes.
# The skill's frontmatter, structure, and cross-links were validated:
frontmatter parsed: True
keys: ['description', 'name']
name: hf-coverage-survey
links: ['cuda-compat-vendor', 'flaggems-integration', 'native-op-backend', 'pre-pr-checks', 'runtime-bringup']
unresolved: []
lines: 270

# Referenced repository paths resolve:
OK  tests/manual/op_called_summary.py
OK  .github/ISSUE_TEMPLATE/ai_agent_issue.md
```

### Manual Verification
```bash
# The HuggingFace device-spec contract the skill relies on:
$ python -c "..."   # against the installed transformers
MANUAL_SEED_FN referenced: True
EMPTY_CACHE_FN referenced: True
DEVICE_COUNT_FN referenced: True
DEVICE_NAME referenced: True
require_torch_accelerator non-cpu gate: True
require_torch_gpu literal cuda gate: True
blip-2 -> blip_2
audio-spectrogram-transformer -> audio_spectrogram_transformer

# The flagos side of the contract, on the MTT S5000:
torch.device('flagos') -> flagos
device_count: 8
has manual_seed: True
has empty_cache: True
is_available: True
```

## Code Quality Verification
### Style Consistency
- [x] Matched the existing skill structure (frontmatter, scope and prerequisites, numbered steps, checklist, `Related` cross-links)
- [x] Followed naming conventions (kebab-case skill directory and `name`)
- [x] Length comparable to the existing skills (270 lines against 180-259)
- [x] Referenced existing repository utilities rather than proposing new ones

### Edge Cases Considered
1. A model absent from the pinned `transformers` version is `NOT_IN_VERSION`, neither pass nor failure.
2. A case that fails on CPU is `UNTESTED`, not a device failure.
3. Cases skipped by `require_torch_gpu` are CUDA-specific and are not coverage gaps.
4. Architecture keys that do not match module directory names require `model_type_to_module_name()`.
5. A device fault poisons the context, so a poisoned run is one finding per model.
6. A platform whose every compute op reaches `cpu_fallback` would pass the survey while measuring nothing, which is why the operator path is a prerequisite.
7. A root cause shared across models and platforms must not produce one issue per occurrence.

### Potential Risks
1. The skill documents a contract before the harness exists, so the harness must be reviewed against it rather than the reverse.
2. The HuggingFace device-spec hook names and gating behavior are version-specific; a future `transformers` change could require updating Step 2.

### Rollback Plan
Revert commit `17f0085`. The change is documentation only and affects no build, runtime, or test behavior.

## Related Work
- Related to `tests/manual/flaggems_overload_survey.py`, whose subprocess isolation, poison detection, resume, and CPU-first validation this workflow follows
- Related to `tests/manual/op_called_summary.py`, the existing `TorchDispatchMode` operator-attribution pattern
- Related to `docs/reference/operator-support.md`, which records operator-level measured evidence

## Explicitly Not Included
- The executable harness (`hf_model_probe.py`, the device spec module, the issue reporter). This PR is the agreed contract; the implementation follows separately.
- Any measured coverage numbers. No platform has been surveyed under this workflow yet, so `docs/reference/hf-coverage.md` is intentionally absent rather than seeded with unmeasured data.
- CI integration. The workflow is a manual hardware measurement, matching the `tests/manual/` convention that CI does not collect.
- Any change to operator routing, kernels, or platform behavior.

## Human Review Notes
### Areas needing special attention:
1. The failure classification table and the precision tolerances, since these decide what becomes an issue and what is treated as noise.
2. The baseline-first and opt-in filing policy, which is the main guard against flooding the tracker.
3. The fingerprint definition and its normalization rules, which determine whether a shared root cause aggregates correctly.

### Questions for reviewer:
1. Should a full sweep run models sequentially with resume, or shard across the available devices on multi-device hosts?
2. Is `docs/reference/hf-coverage.md` the right home for the measured report, alongside `operator-support.md`?

## Additional Context
The `transformers` wheel omits `tests/`, so the per-model probe deliberately avoids depending on an HF source checkout; that dependency applies only to the optional HF-suite mode. The latest published `transformers` at the time of writing is 5.16.1, and the skill defaults to the latest while allowing an older line to be pinned for regression work.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
