### PR TITLE
test: probe transformers models per architecture on accelerators

### DIFF
--- a/.claude/skills/hf-coverage-survey/SKILL.md
+++ b/.claude/skills/hf-coverage-survey/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: hf-coverage-survey
+description: >
+  Measure torch_fl transformers coverage on an accelerator one model at a time,
+  and turn each new failure into an operator, feature, precision, or crash
+  finding with a named root cause. Use this to survey a platform's HuggingFace
+  model support, to check a model after enabling operators, or to re-measure
+  after a transformers version change. Covers: per-model probing without real
+  weights, the HF custom-device injection contract, CPU same-dtype precision
+  baselines, aten attribution through TorchDispatchMode, fingerprint dedup, and
+  the baseline-first issue policy. Do not use this to infer model support from a
+  routing table or from a passing operator suite.
+---
+
+# transformers coverage survey (torch_fl)
+
+## Scope and prerequisites
+
+This skill measures whether real transformers models run on the `flagos`
+device. It is a hardware measurement, not a routing audit: an operator that
+passes a standalone dispatch test can still fail inside a model through a shape,
+dtype, stride, or call-order the operator suite never produces.
+
+Complete these first:
+
+- [[runtime-bringup]] — the device and allocator contract must pass.
+- [[native-op-backend]] or [[cuda-compat-vendor]] — an operator path must exist.
+  A platform whose every compute op reaches `cpu_fallback` will "pass" this
+  survey while measuring nothing about the accelerator.
+
+The unit of work is **one model**. A full sweep is a loop over single-model
+runs, not a single long process. Prefer measuring the model you care about:
+a per-model run finishes in minutes and produces an actionable finding, while a
+full sweep across 300+ architectures mostly re-measures what the previous sweep
+already recorded.
+
+## Step 1 — pin the environment and record it
+
+Two versions decide how a result must be read: the `transformers` version and
+the torch_fl commit. A failure carries no meaning without both.
+
+Default to the latest `transformers`. Pin an older line only to reproduce a
+known-good state or to check a regression:
+
+```bash
+python tests/manual/hf_model_probe.py --model qwen3
+python tests/manual/hf_model_probe.py --model qwen3 --transformers-version 4.50.2
+```
+
+Install each requested `transformers` into its own cached virtual environment
+rather than the environment that holds torch_fl. `transformers` pulls its own
+torch constraint, and letting it resolve inside the torch_fl environment can
+replace the torch the extension was built against — which produces symbol
+errors or silent ABI corruption, not a coverage result.
+
+Record and keep with the run:
+
+```bash
+python - <<'PY'
+import torch, transformers, torch_fl
+print("torch", torch.__version__)
+print("transformers", transformers.__version__)
+print("device_count", torch.flagos.device_count())
+PY
+
+git rev-parse --short HEAD
+```
+
+For a vendor box, also record the chip model, driver, SDK revision, and any
+required environment. A model probe that ran against the wrong runtime is an
+environment failure, not a coverage data point.
+
+## Step 2 — inject `flagos` as the HF test device
+
+`transformers` supports a third-party device through two environment variables
+and a spec module. It validates only that the device name is constructible by
+`torch.device`, so `flagos` is accepted without patching HF:
+
+```bash
+export TRANSFORMERS_TEST_DEVICE=flagos
+export TRANSFORMERS_TEST_DEVICE_SPEC=tests/manual/hf_device_spec.py
+export RUN_THIRD_PARTY_DEVICE_TESTS=1
+```
+
+The spec module must define `DEVICE_NAME` plus the three backend hooks HF
+dispatches on; a missing hook raises at import unless HF has a default:
+
+```python
+DEVICE_NAME = "flagos"
+MANUAL_SEED_FN = torch.flagos.manual_seed
+EMPTY_CACHE_FN = torch.flagos.empty_cache
+DEVICE_COUNT_FN = torch.flagos.device_count
+```
+
+Note the gating split this produces, and do not try to defeat it:
+`require_torch_accelerator` passes for `flagos` (non-CPU, non-None), while
+`require_torch_gpu` skips because it compares against `cuda` literally. Cases
+skipped by `require_torch_gpu` are CUDA-specific and are not coverage gaps.
+
+The `transformers` wheel ships no `tests/` directory. The per-model probe in
+this skill therefore does not need an HF source checkout. A checkout is required
+only for the optional `--hf-tests` mode, and its `git describe` must match the
+installed `transformers` version — a version-mismatched checkout produces
+failures that belong to HF, not to torch_fl.
+
+## Step 3 — probe one model in layers
+
+Build the model from its `CONFIG_MAPPING` entry reduced to tiny dimensions and
+randomly initialized. Real pretrained weights are not needed to find missing
+operators, and requiring them makes the survey depend on downloads and device
+memory.
+
+Resolve the architecture key through `model_type_to_module_name()`. Keys and
+module directories disagree for a substantial minority of architectures
+(`blip-2` → `blip_2`, `audio-spectrogram-transformer` →
+`audio_spectrogram_transformer`); comparing the raw key against directory names
+misreports those models as absent.
+
+Run the layers in order and stop the model at the first failing layer. A model
+whose `.to(device)` fails produces meaningless forward and backward results:
+
+| Layer | What runs | What a failure means |
+|---|---|---|
+| L0 | build tiny model, `.to("flagos")` | allocator, copy, or dtype transfer |
+| L1 | forward, compare to CPU same dtype | missing operator or precision |
+| L2 | backward plus one optimizer step | missing backward operator |
+| L3 | short `generate()` | KV-cache, sampling, or control flow |
+
+If the requested model does not exist in the pinned `transformers`, record
+`NOT_IN_VERSION`. That is neither a pass nor a failure, and counting it either
+way corrupts the platform's rate.
+
+## Step 4 — isolate every model in a subprocess
+
+Run each model in its own subprocess with a timeout, even in single-model mode.
+Accelerator faults are not contained: one illegal memory access poisons the
+device context, after which every later operation fails with the same symptom.
+This has been measured in this repository — a single fault turned roughly one
+real failure into roughly eighty collateral ones.
+
+Treat a poisoned run as one finding for the whole model, never as a list of
+per-layer failures:
+
+```text
+illegal memory access | device-side assert | unspecified launch failure
+misaligned address | vmfault | acceleratorerror
+```
+
+Write results incrementally so an interrupted sweep resumes instead of
+restarting, and keep raw stdout/stderr per model for auditing.
+
+## Step 5 — classify the failure and name the root cause
+
+Every failure must land in exactly one class. The class selects the issue label
+and decides whether the finding is actionable:
+
+| Class | Signal | Label |
+|---|---|---|
+| `OP_UNSUPPORTED` | `NOT_SUPPORTED`, `backend not registered`, `could not run 'aten::…'` | `operator` |
+| `FEATURE_UNSUPPORTED` | non-operator runtime or feature gap | `enhancement` |
+| `PRECISION` | ran, but disagrees with the CPU baseline | `bug` |
+| `CRASH` | segfault, poison, or timeout | `bug` |
+
+For `OP_UNSUPPORTED` and `PRECISION`, re-run the failing layer under
+`TorchDispatchMode` and capture the aten calls, then put the specific operator
+in the finding. Without this attribution the report only says a model failed,
+which a maintainer cannot act on. `tests/manual/op_called_summary.py` is the
+existing pattern for this collection.
+
+## Step 6 — judge precision against CPU, same dtype
+
+The baseline is the same model, same seed, same dtype on CPU. A CUDA baseline is
+not usable here: most vendor boxes have no NVIDIA device, so it would make the
+survey unrunnable exactly where it is needed.
+
+Validate the CPU side first. If CPU itself errors, the case is `UNTESTED` — not
+a device failure. Then compare with dtype-scaled tolerances:
+
+| dtype | rtol | atol |
+|---|---|---|
+| float32 | 1e-5 | 1e-5 |
+| float16 | 1e-3 | 1e-3 |
+| bfloat16 | 1.6e-2 | 1e-2 |
+
+Keep `NaN`/`Inf` separate from magnitude disagreement and rank it higher. A NaN
+is always a defect; a tolerance miss may be legitimate accumulation-order
+variance. Reporting both as one class hides the real bug.
+
+## Step 7 — deduplicate before filing anything
+
+The same root cause reappears across models and platforms. Filing per model and
+per platform buries the signal under duplicates.
+
+Fingerprint the cause, not the occurrence:
+
+```text
+sha256(failure_class + operator_or_module + normalized_error_signature)[:12]
+```
+
+Normalization must strip addresses, shapes, durations, and temporary paths.
+Without it a differing pointer value creates a new issue for a known cause.
+
+Then, for each fingerprint:
+
+1. search existing open issues for the fingerprint;
+2. if found, add a comment carrying this platform's evidence;
+3. if not found, open one issue.
+
+State the chip and the model in the title, and the `transformers` version, so
+the title alone identifies the measurement:
+
+```text
+[AI][MUSA MTT S5000] qwen3: aten::index_copy_ not supported (transformers 5.16.1)
+[AI][Ascend 910] gemma3: fp16 logits mismatch vs CPU, max abs diff 3.2e-2 (transformers 5.16.1)
+```
+
+Use `.github/ISSUE_TEMPLATE/ai_agent_issue.md`, include a self-contained
+reproducer and the environment block, and write everything in English per
+`CLAUDE.md`.
+
+## Step 8 — baseline first, then only new failures
+
+A first sweep on a new platform can produce hundreds of failures at once.
+Filing those is not a report; it is a flood that hides every later regression.
+
+The first run on a platform records a baseline and files nothing. Later runs
+file only fingerprints absent from the baseline. Issue filing stays opt-in:
+
+```bash
+# first run on a platform: record the baseline, file nothing
+python tests/manual/hf_model_probe.py --model qwen3 --promote-baseline
+
+# later runs: file only newly appeared failures
+python tests/manual/hf_model_probe.py --model qwen3 \
+  --baseline docs/reference/hf-coverage-baseline-musa.json --file-issues
+```
+
+Default to report-only. Opening issues writes to a shared tracker and cannot be
+cleanly undone, so it must be requested explicitly rather than inferred.
+
+## Step 9 — record measured evidence
+
+Update `docs/reference/hf-coverage.md` with the chip, run date, `transformers`
+version, torch_fl commit, models attempted, and the per-class counts. Keep the
+raw JSON.
+
+Report only the models actually attempted. If a model was skipped, timed out, or
+was absent from the pinned version, say so in its own category. Do not carry a
+previous cohort's numbers forward as though they were re-measured, and do not
+copy one chip's rate onto another.
+
+Before opening a PR:
+
+- the `transformers` version and torch_fl commit are recorded with every result;
+- CPU baselines were validated before any device comparison;
+- poisoned runs are one finding per model, not per layer;
+- every `OP_UNSUPPORTED` and `PRECISION` finding names an operator;
+- `NOT_IN_VERSION`, `UNTESTED`, and CUDA-only skips are excluded from failures;
+- fingerprints were searched before filing, and duplicates became comments;
+- unavailable hardware is marked **not revalidated**;
+- `ruff check .` and `ruff format --check .` pass.
+
+Coverage may be claimed only for the models measured on that chip. A passing
+operator suite, a populated routing table, and another platform's rate are all
+not evidence.
+
+## Related
+
+[[runtime-bringup]] · [[native-op-backend]] · [[cuda-compat-vendor]] ·
+[[flaggems-integration]] · [[pre-pr-checks]]

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -113,9 +113,41 @@ route-set hash, and harness version/hash with every published result. See
 [Operator Support](../reference/operator-support.md) for the current baseline
 and update procedure.
 
+### Per-model Transformers Coverage Probe
+
+`tests/manual/transformers_model_probe.py` measures one randomly initialized,
+tiny HuggingFace transformers architecture at a time on a real accelerator. It
+is deliberately separate from the model integration tests and from CI: a full
+architecture sweep is an external loop over isolated single-model runs, not one
+long process whose later results could be poisoned by an earlier device fault.
+
+The probe defaults to the latest installed `transformers` and accepts an older
+version explicitly. It does not install dependencies automatically; install the
+requested version in the active torch-fl environment without replacing its
+PyTorch:
+
+```bash
+python -m pip install --upgrade --no-deps transformers==5.16.1
+TORCH_DEVICE_BACKEND_AUTOLOAD=0 \
+python tests/manual/transformers_model_probe.py \
+  --model qwen3 --device flagos --out /tmp/qwen3.json
+```
+
+The probe runs transfer, forward, backward/optimizer, and short deterministic
+generation layers in order, comparing the device result with a CPU result using
+the same weights, seed, and dtype. A failure stops that model's later layers.
+The JSON preserves layer status, CPU-fallback/native ATen observations, error
+text, and the environment versions needed to interpret the result. A parameter
+cap protects composite configurations whose top-level tiny overrides do not
+shrink nested configs. Use `--list-models` to inspect the model types available
+in the installed version. Issue filing is intentionally not part of this probe;
+a future reporter consumes its JSON after fingerprint deduplication and a
+baseline comparison.
+
 ### Model Tests
 
 Model integration tests accept command-line options for model path and hyperparameters.
+
 
 **Inference test**:
 

--- a/tests/manual/transformers_model_probe.py
+++ b/tests/manual/transformers_model_probe.py
@@ -1,0 +1,818 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Measure whether one HuggingFace transformers model runs on an accelerator.
+
+This is a manual hardware probe, not a pytest test. CI does not invoke files in
+``tests/manual``.
+
+The unit of measurement is a single model, probed in ordered layers: device
+transfer, forward, backward plus one optimizer step, and short generation. The
+model is built tiny and randomly initialized from its ``CONFIG_MAPPING`` entry,
+so no pretrained weights are downloaded and the probe runs offline. Each layer
+is compared against CPU at the same dtype, and the first failing layer stops the
+run because later layers cannot be interpreted once an earlier one is broken.
+
+A failing layer is attributed to a concrete ATen operator by replaying the model
+under ``TorchDispatchMode``, so a result names an operator rather than only a
+model. Operator coverage is reported per layer as native versus CPU fallback.
+
+Usage:
+  python tests/manual/transformers_model_probe.py --model qwen3
+  python tests/manual/transformers_model_probe.py --model qwen3 --dtype float16
+  python tests/manual/transformers_model_probe.py --model llama --out /tmp/p.json
+
+A full sweep is an external loop over single-model runs, not a mode of this
+script. Use ``--list-models`` to enumerate probeable architectures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+from importlib.metadata import PackageNotFoundError, version as package_version
+
+
+PYPI_TRANSFORMERS_JSON = "https://pypi.org/pypi/transformers/json"
+
+
+HARNESS_VERSION = 1
+
+# A fault on an accelerator is not contained: one illegal access poisons the
+# device context so every later operation fails with the same symptom. A layer
+# matching this is reported once, not multiplied into the layers behind it.
+POISON_RE = re.compile(
+    r"illegal memory access|device-side assert|unspecified launch failure|"
+    r"misaligned address|vmfault|acceleratorerror",
+    re.IGNORECASE,
+)
+
+LAYERS = ("transfer", "forward", "backward", "generate")
+
+# CPU same-dtype baselines. Reduction order legitimately differs between a CPU
+# kernel and an accelerator kernel, so fp16/bf16 need room that fp32 does not.
+TOLERANCES = {
+    "float32": {"rtol": 1e-5, "atol": 1e-5},
+    "float64": {"rtol": 1e-7, "atol": 1e-7},
+    "float16": {"rtol": 1e-3, "atol": 1e-3},
+    "bfloat16": {"rtol": 1.6e-2, "atol": 1e-2},
+}
+
+# Upper bound on a probe model. Some composite configs ignore top-level size
+# overrides and would otherwise instantiate a multi-billion parameter model:
+# a plain Gemma3Config with tiny hidden_size still built 2.7B parameters. The
+# cap turns that into an explicit CONFIG_TOO_LARGE result instead of an OOM.
+MAX_PROBE_PARAMS = 20_000_000
+
+
+def atomic_write(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=path.name, dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(value, f, indent=1, sort_keys=True)
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+MARK = "@@PROBE@@"
+
+
+def environment() -> dict:
+    """Collect the versions a result cannot be interpreted without."""
+    import torch
+    import transformers
+
+    commit = None
+    try:
+        commit = (
+            subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=Path(__file__).resolve().parent,
+            ).stdout.strip()
+            or None
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return {
+        "python": sys.version.split()[0],
+        "torch": torch.__version__,
+        "transformers": transformers.__version__,
+        "torch_fl_commit": commit,
+        "harness_version": HARNESS_VERSION,
+    }
+
+
+def installed_transformers() -> str | None:
+    try:
+        return package_version("transformers")
+    except PackageNotFoundError:
+        return None
+
+
+def latest_transformers(timeout: int = 30) -> str | None:
+    """Resolve the newest published release, or None when offline.
+
+    Only used to tell the user their installed version is behind. The probe
+    never installs or upgrades anything itself: replacing packages underneath a
+    built extension is how a run silently stops measuring the torch the
+    extension was compiled against.
+    """
+    try:
+        with urllib.request.urlopen(PYPI_TRANSFORMERS_JSON, timeout=timeout) as resp:
+            return json.load(resp)["info"]["version"]
+    except Exception:  # noqa: BLE001 - offline is normal on a vendor box
+        return None
+
+
+def check_transformers_version(requested: str, offline: bool) -> dict:
+    """Reconcile the requested version with what is importable.
+
+    Returns the resolution for the record. A mismatch is fatal: silently
+    measuring a different version than the one requested produces a result
+    that cannot be compared with anything.
+    """
+    have = installed_transformers()
+    if have is None:
+        raise SystemExit(
+            "transformers is not installed in this interpreter.\n"
+            "Install it without touching torch:\n"
+            "  python -m pip install --no-deps transformers==<version>"
+        )
+    record = {"requested": requested, "installed": have, "latest": None}
+    if requested == "latest":
+        if offline:
+            return record
+        latest = latest_transformers()
+        record["latest"] = latest
+        if latest is None:
+            print(
+                "note: could not reach PyPI; using installed "
+                f"transformers {have} and recording it as-is"
+            )
+            return record
+        try:
+            behind = Version(have) < Version(latest)
+        except InvalidVersion:
+            behind = False
+        if behind:
+            print(
+                f"note: installed transformers {have} is older than the latest "
+                f"release {latest}.\n"
+                "      Pass --transformers-version " + have + " to record this "
+                "deliberately, or upgrade with:\n"
+                "        python -m pip install --no-deps --upgrade transformers"
+            )
+        return record
+    if have != requested:
+        raise SystemExit(
+            f"requested transformers {requested} but {have} is installed.\n"
+            "A result measured against a different version is not comparable.\n"
+            f"  python -m pip install --no-deps transformers=={requested}"
+        )
+    return record
+
+
+def probeable_models() -> list[str]:
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
+    return sorted(CONFIG_MAPPING_NAMES)
+
+
+def run_model(model: str, args: argparse.Namespace, layers: list[str]) -> dict:
+    """Probe one model in a child process.
+
+    One process per model even in single-model mode: an accelerator fault can
+    abort the interpreter rather than raise, and a poisoned device context makes
+    every later result in the same process meaningless.
+    """
+    request = {
+        "model": model,
+        "device": args.device,
+        "dtype": args.dtype,
+        "layers": layers,
+        "tolerance": TOLERANCES[args.dtype],
+        "max_params": args.max_params,
+        "seed": args.seed,
+        "max_new_tokens": args.max_new_tokens,
+    }
+    child = Path(tempfile.gettempdir()) / f"transformers_probe_child_{os.getpid()}.py"
+    child.write_text(CHILD)
+    env = dict(os.environ)
+    # Keep a compiler/runtime cache per run so a poisoned or partial cache from
+    # one model cannot change the next model's result.
+    env["TRITON_CACHE_DIR"] = tempfile.mkdtemp(prefix=f"triton-probe-{os.getpid()}-")
+    started = time.time()
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(child), json.dumps(request)],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=tempfile.gettempdir(),
+            timeout=args.timeout,
+        )
+        stdout, stderr, rc = proc.stdout, proc.stderr, proc.returncode
+        timed_out = False
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        rc, timed_out = None, True
+    finally:
+        child.unlink(missing_ok=True)
+
+    events, pending = {}, list(layers)
+    for line in stdout.splitlines():
+        if not line.startswith(MARK):
+            continue
+        try:
+            rec = json.loads(line[len(MARK) :])
+        except json.JSONDecodeError:
+            continue
+        text = " ".join(str(rec.get(k, "")) for k in ("error", "detail", "traceback"))
+        if POISON_RE.search(text):
+            rec["context_poison"] = True
+        events[rec["layer"]] = rec
+        if rec["layer"] in pending:
+            pending.remove(rec["layer"])
+
+    combined = f"{stderr}\n{stdout}"
+    poisoned = bool(POISON_RE.search(combined))
+    # The child announces a deliberate stop after a failing layer. Only when it
+    # did not is a missing layer an actual crash or timeout.
+    stopped = events.pop("__stopped__", None) is not None
+    for index, name in enumerate(pending):
+        if stopped:
+            events[name] = {"layer": name, "status": "NOT_REACHED"}
+        elif index == 0:
+            # Attribute the fault once, to the first layer that never
+            # reported, rather than to everything queued behind it.
+            events[name] = {
+                "layer": name,
+                "status": "TIMEOUT" if timed_out else "CRASH",
+                "error": combined.strip()[-600:],
+                "returncode": rc,
+                "context_poison": poisoned,
+            }
+        else:
+            events[name] = {"layer": name, "status": "NOT_REACHED"}
+
+    return {
+        "model": model,
+        "device": args.device,
+        "dtype": args.dtype,
+        "duration_s": round(time.time() - started, 1),
+        "returncode": rc,
+        "timed_out": timed_out,
+        "context_poison": poisoned,
+        "layers": events,
+        "stderr_tail": stderr.strip()[-2000:] or None,
+    }
+
+
+def verdict(result: dict, layers: list[str]) -> str:
+    """Reduce one model's layers to a single verdict.
+
+    Ordered by how much they invalidate: an environment or config outcome is
+    not a coverage result at all, and must not be counted as either support or
+    a defect.
+    """
+    statuses = {
+        name: result["layers"].get(name, {}).get("status")
+        for name in ["config", *layers]
+    }
+    config = statuses.get("config")
+    if config in (
+        "UNKNOWN_MODEL",
+        "CONFIG_UNSUPPORTED",
+        "CONFIG_TOO_LARGE",
+        "UNSUPPORTED_TASK",
+        "ENVIRONMENT_ERROR",
+    ):
+        return config
+    ran = [statuses.get(name) for name in layers]
+    if any(s in ("CRASH", "TIMEOUT") for s in ran):
+        return "CRASH"
+    if any(s == "ERROR" for s in ran):
+        return "ERROR"
+    if any(s == "WRONG" for s in ran):
+        return "WRONG"
+    if all(s in ("PASS", "UNSUPPORTED", None) for s in ran):
+        return "PASS"
+    return "PARTIAL"
+
+
+CHILD = r'''
+import copy
+import json
+import sys
+import traceback
+
+import torch
+import torch_fl  # noqa: F401
+from transformers.configuration_utils import PretrainedConfig
+from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+request = json.loads(sys.argv[1])
+MODEL = request["model"]
+DEV = request["device"]
+DTYPE = getattr(torch, request["dtype"])
+LAYERS = request["layers"]
+TOL = request["tolerance"]
+MAX_PARAMS = request["max_params"]
+SEED = request["seed"]
+MAX_NEW_TOKENS = request["max_new_tokens"]
+
+# Only lines starting with this marker are events. Vendor runtimes write
+# unstructured diagnostics to stdout, and parsing those as results would
+# invent statuses that no layer reported.
+MARK = "@@PROBE@@"
+
+
+def emit(layer, status, **extra):
+    print(MARK + json.dumps({"layer": layer, "status": status, **extra}), flush=True)
+
+
+def stop():
+    """Mark a deliberate early exit.
+
+    Without this the parent cannot tell "the child chose to stop after a
+    failing layer" from "a faulting kernel killed the process", and would
+    report the unreached layers as crashes they had no part in.
+    """
+    emit("__stopped__", "STOPPED")
+    sys.exit(0)
+
+
+def fail(layer, status, exc=None, **extra):
+    if exc is not None:
+        extra["error"] = f"{type(exc).__name__}: {exc}"
+        extra["traceback"] = traceback.format_exc()[-4000:]
+    emit(layer, status, **extra)
+    stop()
+
+
+# --- tiny config construction -------------------------------------------------
+
+# Shrink targets. Attention heads must still divide hidden_size, so heads are
+# handled after sizes and hidden_size is snapped up to a multiple of the heads.
+SIZE_FIELDS = (
+    "hidden_size", "intermediate_size", "ffn_dim", "d_model", "d_ff",
+    "encoder_ffn_dim", "decoder_ffn_dim", "projection_dim", "text_config_dim",
+)
+DEPTH_FIELDS = (
+    "num_hidden_layers", "num_layers", "n_layer", "num_encoder_layers",
+    "num_decoder_layers", "encoder_layers", "decoder_layers",
+    "num_local_experts", "num_experts", "num_experts_per_tok",
+)
+HEAD_FIELDS = ("num_attention_heads", "num_heads", "n_head", "encoder_attention_heads",
+               "decoder_attention_heads")
+KV_HEAD_FIELDS = ("num_key_value_heads", "num_kv_heads")
+VOCAB_FIELDS = ("vocab_size",)
+POS_FIELDS = ("max_position_embeddings", "n_positions", "max_seq_len",
+              "max_sequence_length", "model_max_length")
+
+TINY_HIDDEN = 32
+TINY_HEADS = 2
+TINY_LAYERS = 2
+TINY_VOCAB = 256
+TINY_POS = 64
+
+
+def shrink(cfg, depth=0):
+    """Recursively shrink a config in place.
+
+    Composite configs (multimodal, encoder-decoder) hold nested
+    PretrainedConfig objects that ignore top-level overrides entirely, so the
+    nested objects must be shrunk directly.
+    """
+    if depth > 4:
+        return
+    for field in DEPTH_FIELDS:
+        if isinstance(getattr(cfg, field, None), int):
+            setattr(cfg, field, min(getattr(cfg, field), TINY_LAYERS))
+    for field in HEAD_FIELDS:
+        if isinstance(getattr(cfg, field, None), int):
+            setattr(cfg, field, TINY_HEADS)
+    for field in KV_HEAD_FIELDS:
+        if isinstance(getattr(cfg, field, None), int):
+            setattr(cfg, field, TINY_HEADS)
+    for field in SIZE_FIELDS:
+        if isinstance(getattr(cfg, field, None), int):
+            setattr(cfg, field, TINY_HIDDEN)
+    for field in VOCAB_FIELDS:
+        if isinstance(getattr(cfg, field, None), int):
+            setattr(cfg, field, TINY_VOCAB)
+    for field in POS_FIELDS:
+        if isinstance(getattr(cfg, field, None), int):
+            setattr(cfg, field, TINY_POS)
+    # head_dim is often derived; keep it consistent when explicitly present.
+    if isinstance(getattr(cfg, "head_dim", None), int):
+        cfg.head_dim = TINY_HIDDEN // TINY_HEADS
+    for value in list(vars(cfg).values()):
+        if isinstance(value, PretrainedConfig):
+            shrink(value, depth + 1)
+
+
+def build_config():
+    if MODEL not in CONFIG_MAPPING:
+        fail("config", "UNKNOWN_MODEL",
+             detail=f"{MODEL} is not in CONFIG_MAPPING for this transformers version")
+    try:
+        cfg = CONFIG_MAPPING[MODEL]()
+        shrink(cfg)
+    except Exception as exc:  # noqa: BLE001 - any config error is a real result
+        fail("config", "CONFIG_UNSUPPORTED", exc)
+    for field, value in (("bos_token_id", 0), ("eos_token_id", 1), ("pad_token_id", 2)):
+        if getattr(cfg, field, None) is not None:
+            setattr(cfg, field, value)
+    # Deterministic generation: sampling tokens would make token-level
+    # comparison meaningless rather than measuring the device.
+    if hasattr(cfg, "use_cache"):
+        cfg.use_cache = True
+    return cfg
+
+
+def build_model(cfg):
+    from transformers import AutoModelForCausalLM
+    torch.manual_seed(SEED)
+    try:
+        model = AutoModelForCausalLM.from_config(cfg)
+    except Exception as exc:  # noqa: BLE001
+        fail("config", "UNSUPPORTED_TASK", exc,
+             detail="no causal-LM mapping, or the config cannot instantiate one")
+    params = sum(p.numel() for p in model.parameters())
+    if params > MAX_PARAMS:
+        fail("config", "CONFIG_TOO_LARGE", params=params, max_params=MAX_PARAMS,
+             detail="config ignored the tiny overrides; refusing to allocate")
+    return model.to(DTYPE).eval(), params
+
+
+# --- comparison ---------------------------------------------------------------
+
+def compare(ref, got, path="out"):
+    """Compare nested CPU and device outputs, returning a mismatch or None."""
+    if isinstance(ref, torch.Tensor):
+        if not isinstance(got, torch.Tensor):
+            return {"path": path, "reason": "type", "detail": type(got).__name__}
+        if tuple(ref.shape) != tuple(got.shape):
+            return {"path": path, "reason": "shape",
+                    "detail": f"cpu={tuple(ref.shape)} dev={tuple(got.shape)}"}
+        dev = got.detach().to("cpu", torch.float32)
+        cpu = ref.detach().to(torch.float32)
+        # A NaN or Inf that CPU did not produce is always a defect; a tolerance
+        # miss can be legitimate accumulation-order variance. Keep them apart.
+        if torch.isfinite(cpu).all() and not torch.isfinite(dev).all():
+            return {"path": path, "reason": "nan_inf",
+                    "detail": "device produced non-finite values, CPU did not"}
+        if not torch.allclose(cpu, dev, rtol=TOL["rtol"], atol=TOL["atol"],
+                              equal_nan=True):
+            diff = (cpu - dev).abs()
+            denom = cpu.abs().clamp_min(1e-12)
+            return {"path": path, "reason": "tolerance",
+                    "max_abs": float(diff.max()),
+                    "max_rel": float((diff / denom).max()),
+                    "rtol": TOL["rtol"], "atol": TOL["atol"]}
+        return None
+    if isinstance(ref, (list, tuple)):
+        if len(ref) != len(got):
+            return {"path": path, "reason": "length",
+                    "detail": f"cpu={len(ref)} dev={len(got)}"}
+        for i, (a, b) in enumerate(zip(ref, got)):
+            found = compare(a, b, f"{path}[{i}]")
+            if found:
+                return found
+        return None
+    if hasattr(ref, "keys"):
+        for key in ref.keys():
+            if ref[key] is None:
+                continue
+            found = compare(ref[key], got[key], f"{path}.{key}")
+            if found:
+                return found
+        return None
+    return None
+
+
+# --- operator attribution -----------------------------------------------------
+
+from torch.utils._python_dispatch import TorchDispatchMode  # noqa: E402
+
+
+class OpTracer(TorchDispatchMode):
+    """Record ATen ops and whether each has a PrivateUse1 kernel.
+
+    An op without a device kernel reaches the CPU fallback, which is the
+    difference between "the model ran" and "the accelerator ran the model".
+    """
+
+    def __init__(self):
+        self.native = set()
+        self.fallback = set()
+        self._cache = {}
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        name = str(func)
+        has_kernel = self._cache.get(name)
+        if has_kernel is None:
+            try:
+                has_kernel = torch._C._dispatch_has_kernel_for_dispatch_key(
+                    func.name(), "PrivateUse1")
+            except Exception:  # noqa: BLE001 - attribution must never fail a layer
+                has_kernel = True
+            self._cache[name] = has_kernel
+        (self.native if has_kernel else self.fallback).add(name)
+        return func(*args, **(kwargs or {}))
+
+    def report(self):
+        return {"native": sorted(self.native), "fallback": sorted(self.fallback)}
+
+
+def make_inputs(cfg):
+    vocab = max(int(getattr(cfg, "vocab_size", 256)), 8)
+    ids = torch.tensor([[0, 3, 4, 5]], dtype=torch.long)
+    ids = ids.remainder(vocab)
+    return {"input_ids": ids, "attention_mask": torch.ones_like(ids)}
+
+
+def tensors_on(value, device):
+    if isinstance(value, torch.Tensor):
+        return value.to(device)
+    if isinstance(value, (list, tuple)):
+        return type(value)(tensors_on(x, device) for x in value)
+    if hasattr(value, "keys"):
+        return {k: tensors_on(v, device) for k, v in value.items()}
+    return value
+
+
+def first_tensor(value):
+    if isinstance(value, torch.Tensor):
+        return value
+    if isinstance(value, (list, tuple)):
+        for x in value:
+            found = first_tensor(x)
+            if found is not None:
+                return found
+    if hasattr(value, "values"):
+        for x in value.values():
+            found = first_tensor(x)
+            if found is not None:
+                return found
+    return None
+
+
+def output_device_ok(value, device):
+    tensor = first_tensor(value)
+    return tensor is not None and tensor.device.type == device.split(":", 1)[0]
+
+
+def run_layer(layer, cpu_model, dev_model, cpu_inputs, dev_inputs):
+    tracer = OpTracer()
+    if layer == "transfer":
+        ok = all(p.device.type == DEV.split(":", 1)[0]
+                 for p in dev_model.parameters())
+        emit(layer, "PASS" if ok else "WRONG", ops=tracer.report())
+        return
+    try:
+        if layer == "forward":
+            with torch.no_grad():
+                with tracer:
+                    got = dev_model(**dev_inputs)
+                ref = cpu_model(**cpu_inputs)
+            mismatch = compare(ref, got)
+            if not output_device_ok(got, DEV):
+                mismatch = mismatch or {"path": "out", "reason": "device"}
+        elif layer == "backward":
+            if not any(p.requires_grad for p in dev_model.parameters()):
+                emit(layer, "UNSUPPORTED", detail="no trainable parameter",
+                     ops=tracer.report())
+                return
+            cpu_model.zero_grad(set_to_none=True)
+            dev_model.zero_grad(set_to_none=True)
+            with tracer:
+                got = dev_model(**dev_inputs)
+                first_tensor(got).float().mean().backward()
+            ref = cpu_model(**cpu_inputs)
+            first_tensor(ref).float().mean().backward()
+            mismatch = None
+            for (name, a), (_, b) in zip(cpu_model.named_parameters(),
+                                         dev_model.named_parameters()):
+                if a.grad is None and b.grad is None:
+                    continue
+                if (a.grad is None) != (b.grad is None):
+                    mismatch = {"path": f"grad.{name}", "reason": "grad_presence",
+                                "detail": f"cpu={a.grad is not None} "
+                                          f"dev={b.grad is not None}"}
+                    break
+                mismatch = compare(a.grad, b.grad, f"grad.{name}")
+                if mismatch:
+                    break
+            if mismatch is None:
+                # One optimizer step exercises the update path, which uses
+                # operators the forward and backward passes never reach.
+                with tracer:
+                    dev_model.probe_optimizer.step()
+                cpu_model.probe_optimizer.step()
+                for (name, a), (_, b) in zip(cpu_model.named_parameters(),
+                                             dev_model.named_parameters()):
+                    mismatch = compare(a, b, f"stepped.{name}")
+                    if mismatch:
+                        break
+        elif layer == "generate":
+            if not hasattr(dev_model, "generate"):
+                emit(layer, "UNSUPPORTED", detail="model has no generate method",
+                     ops=tracer.report())
+                return
+            with torch.no_grad():
+                with tracer:
+                    got = dev_model.generate(**dev_inputs, max_new_tokens=MAX_NEW_TOKENS,
+                                             do_sample=False)
+                with torch.no_grad():
+                    ref = cpu_model.generate(**cpu_inputs, max_new_tokens=MAX_NEW_TOKENS,
+                                             do_sample=False)
+            mismatch = compare(ref, got)
+            if not output_device_ok(got, DEV):
+                mismatch = mismatch or {"path": "generated", "reason": "device"}
+        else:
+            emit(layer, "UNKNOWN_LAYER")
+            return
+        emit(layer, "PASS" if mismatch is None else "WRONG",
+             comparison=mismatch, ops=tracer.report())
+        if mismatch is not None:
+            stop()
+    except Exception as exc:  # noqa: BLE001 - child reports all runtime failures
+        fail(layer, "ERROR", exc, ops=tracer.report())
+
+
+# Load and run after definitions so config errors are reported in the protocol.
+try:
+    cfg = build_config()
+    model, params = build_model(cfg)
+    # Module.to() mutates in place and returns self, so the CPU baseline must
+    # be a distinct object. Sharing one would compare the device against
+    # itself and report every layer as passing.
+    cpu_model = model
+    dev_model = copy.deepcopy(model).to(DEV)
+    cpu_model.probe_optimizer = torch.optim.SGD(cpu_model.parameters(), lr=1e-3)
+    dev_model.probe_optimizer = torch.optim.SGD(dev_model.parameters(), lr=1e-3)
+    cpu_inputs = make_inputs(cfg)
+    dev_inputs = tensors_on(cpu_inputs, DEV)
+    emit("config", "PASS", params=params)
+except SystemExit:
+    raise
+except Exception as exc:  # noqa: BLE001
+    fail("config", "ENVIRONMENT_ERROR", exc,
+         detail="model built on CPU but could not be placed on the device")
+
+for layer in LAYERS:
+    run_layer(layer, cpu_model, dev_model, cpu_inputs, dev_inputs)
+'''
+
+
+def summarize(result: dict, layers: list[str]) -> str:
+    lines = [
+        f"model      {result['model']}",
+        f"device     {result['device']}  dtype {result['dtype']}",
+        f"verdict    {result['verdict']}",
+        f"duration   {result['duration_s']}s",
+    ]
+    config = result["layers"].get("config", {})
+    if config.get("params"):
+        lines.append(f"params     {config['params']:,}")
+    if result.get("context_poison"):
+        lines.append("WARNING    device context was poisoned; later layers are void")
+    lines.append("")
+    for name in layers:
+        event = result["layers"].get(name)
+        if not event:
+            continue
+        row = f"  {name:<9} {event['status']}"
+        ops = event.get("ops") or {}
+        if ops.get("fallback"):
+            row += f"  [cpu-fallback: {len(ops['fallback'])}]"
+        if event.get("comparison"):
+            cmp = event["comparison"]
+            row += f"  {cmp.get('reason')} at {cmp.get('path')}"
+            if cmp.get("max_abs") is not None:
+                row += f" (max_abs {cmp['max_abs']:.3g})"
+        if event.get("error"):
+            row += f"  {event['error'].splitlines()[0][:120]}"
+        lines.append(row)
+    fallback = sorted(
+        {
+            op
+            for event in result["layers"].values()
+            for op in (event.get("ops") or {}).get("fallback", [])
+        }
+    )
+    if fallback:
+        lines += ["", "CPU-fallback operators (not running on the accelerator):"]
+        lines += [f"  {op}" for op in fallback]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Probe one HuggingFace transformers model on an accelerator.",
+    )
+    parser.add_argument("--model", help="model type, e.g. qwen3")
+    parser.add_argument("--device", default="flagos")
+    parser.add_argument("--dtype", default="float32", choices=sorted(TOLERANCES))
+    parser.add_argument(
+        "--layers",
+        default=",".join(LAYERS),
+        help=f"comma-separated subset of {','.join(LAYERS)}",
+    )
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--max-params", type=int, default=MAX_PROBE_PARAMS)
+    parser.add_argument("--max-new-tokens", type=int, default=4)
+    parser.add_argument("--seed", type=int, default=1729)
+    parser.add_argument("--out", type=Path, help="write the JSON result here")
+    parser.add_argument(
+        "--transformers-version",
+        default="latest",
+        help="'latest' (default) records the installed version and notes when it is "
+        "behind PyPI; an explicit version must match what is installed",
+    )
+    parser.add_argument(
+        "--offline", action="store_true", help="skip the PyPI latest-release check"
+    )
+    parser.add_argument(
+        "--list-models", action="store_true", help="list probeable model types and exit"
+    )
+    args = parser.parse_args()
+
+    if args.list_models:
+        for name in probeable_models():
+            print(name)
+        return 0
+    if not args.model:
+        parser.error("--model is required (or use --list-models)")
+
+    resolution = check_transformers_version(args.transformers_version, args.offline)
+
+    layers = [name.strip() for name in args.layers.split(",") if name.strip()]
+    unknown = [name for name in layers if name not in LAYERS]
+    if unknown:
+        parser.error(f"unknown layers: {', '.join(unknown)}")
+    # Keep the documented order regardless of how they were listed: a later
+    # layer's result cannot be read if an earlier one has not run.
+    layers = [name for name in LAYERS if name in layers]
+
+    env = environment()
+    env["transformers_requested"] = resolution["requested"]
+    env["transformers_latest"] = resolution["latest"]
+    result = run_model(args.model, args, layers)
+    result["verdict"] = verdict(result, layers)
+    result["environment"] = env
+    result["fingerprint"] = hashlib.sha256(
+        f"{result['verdict']}|{args.model}|{args.device}".encode()
+    ).hexdigest()[:12]
+
+    print(
+        f"transformers {env['transformers']}  torch {env['torch']}"
+        f"  torch_fl {env['torch_fl_commit']}"
+    )
+    print()
+    print(summarize(result, layers))
+
+    if args.out:
+        atomic_write(args.out, result)
+        print(f"\nJSON written to {args.out}")
+    return 0 if result["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_transformers_model_probe.py
+++ b/tests/unit/test_transformers_model_probe.py
@@ -1,0 +1,211 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit coverage for the transformers model probe's reporting logic.
+
+Pure logic over recorded layer events: no accelerator, no transformers, no
+subprocess. What is covered here is the reasoning that decides what a hardware
+run *means* — which failures count as coverage results, which are environment
+noise, and which layers a fault may be blamed on. Those judgements are the part
+that silently corrupts a support claim when wrong, and the part a hardware run
+cannot check for itself.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tests" / "manual" / "transformers_model_probe.py"
+
+_spec = importlib.util.spec_from_file_location("transformers_model_probe", SCRIPT)
+probe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(probe)
+
+ALL_LAYERS = list(probe.LAYERS)
+
+
+def _result(**layers):
+    return {"layers": {name: {"layer": name, **rec} for name, rec in layers.items()}}
+
+
+# --- verdicts -----------------------------------------------------------------
+
+
+def test_all_layers_passing_is_a_pass():
+    result = _result(
+        config={"status": "PASS"},
+        **{name: {"status": "PASS"} for name in ALL_LAYERS},
+    )
+    assert probe.verdict(result, ALL_LAYERS) == "PASS"
+
+
+def test_unsupported_layer_does_not_defeat_a_pass():
+    """A model without a differentiable output or generate() is not a failure.
+
+    Counting a genuinely inapplicable layer as a defect would understate
+    support for every architecture that simply has no such path.
+    """
+    result = _result(
+        config={"status": "PASS"},
+        transfer={"status": "PASS"},
+        forward={"status": "PASS"},
+        backward={"status": "UNSUPPORTED"},
+        generate={"status": "UNSUPPORTED"},
+    )
+    assert probe.verdict(result, ALL_LAYERS) == "PASS"
+
+
+def test_wrong_result_outranks_passing_layers():
+    result = _result(
+        config={"status": "PASS"},
+        transfer={"status": "PASS"},
+        forward={"status": "WRONG"},
+        backward={"status": "NOT_REACHED"},
+        generate={"status": "NOT_REACHED"},
+    )
+    assert probe.verdict(result, ALL_LAYERS) == "WRONG"
+
+
+def test_crash_outranks_error():
+    result = _result(
+        config={"status": "PASS"},
+        transfer={"status": "PASS"},
+        forward={"status": "ERROR"},
+        backward={"status": "CRASH"},
+        generate={"status": "NOT_REACHED"},
+    )
+    assert probe.verdict(result, ALL_LAYERS) == "CRASH"
+
+
+def test_environment_error_is_not_a_coverage_failure():
+    """An unusable environment must not be recorded as a device defect."""
+    result = _result(config={"status": "ENVIRONMENT_ERROR"})
+    assert probe.verdict(result, ALL_LAYERS) == "ENVIRONMENT_ERROR"
+
+
+def test_config_too_large_is_reported_verbatim():
+    """The parameter cap is a safety boundary, not a measurement."""
+    result = _result(config={"status": "CONFIG_TOO_LARGE", "params": 2_723_312_896})
+    assert probe.verdict(result, ALL_LAYERS) == "CONFIG_TOO_LARGE"
+
+
+def test_unknown_model_is_distinct_from_a_failure():
+    result = _result(config={"status": "UNKNOWN_MODEL"})
+    assert probe.verdict(result, ALL_LAYERS) == "UNKNOWN_MODEL"
+
+
+def test_verdict_only_considers_selected_layers():
+    """A layer that was not requested cannot decide the verdict."""
+    result = _result(
+        config={"status": "PASS"},
+        transfer={"status": "PASS"},
+        forward={"status": "PASS"},
+    )
+    assert probe.verdict(result, ["transfer", "forward"]) == "PASS"
+
+
+# --- tolerances ---------------------------------------------------------------
+
+
+def test_every_supported_dtype_has_a_tolerance():
+    for dtype, tol in probe.TOLERANCES.items():
+        assert tol["rtol"] > 0 and tol["atol"] > 0, dtype
+
+
+def test_reduced_precision_is_looser_than_fp32():
+    """Reduction order differs between CPU and accelerator kernels."""
+    assert probe.TOLERANCES["float16"]["atol"] > probe.TOLERANCES["float32"]["atol"]
+    assert probe.TOLERANCES["bfloat16"]["rtol"] > probe.TOLERANCES["float16"]["rtol"]
+
+
+# --- poison detection --------------------------------------------------------
+
+
+def test_poison_patterns_are_recognized():
+    for text in (
+        "RuntimeError: MUSA error: illegal memory access was encountered",
+        "device-side assert triggered",
+        "unspecified launch failure",
+        "misaligned address",
+    ):
+        assert probe.POISON_RE.search(text), text
+
+
+def test_ordinary_operator_gap_is_not_poison():
+    """An unsupported operator leaves the context usable; it must not be
+    treated as a fault that voids the layers behind it."""
+    assert not probe.POISON_RE.search("RuntimeError: zero_ failed: NOT_SUPPORTED")
+
+
+# --- atomic write ------------------------------------------------------------
+
+
+def test_explicit_version_mismatch_is_fatal(monkeypatch):
+    """Measuring a version other than the requested one is not comparable."""
+    monkeypatch.setattr(probe, "installed_transformers", lambda: "5.16.1")
+    with pytest.raises(SystemExit) as excinfo:
+        probe.check_transformers_version("4.50.2", offline=True)
+    assert "4.50.2" in str(excinfo.value)
+
+
+def test_matching_explicit_version_is_recorded(monkeypatch):
+    monkeypatch.setattr(probe, "installed_transformers", lambda: "4.50.2")
+    record = probe.check_transformers_version("4.50.2", offline=True)
+    assert record["installed"] == "4.50.2"
+
+
+def test_missing_transformers_explains_the_no_deps_install(monkeypatch):
+    monkeypatch.setattr(probe, "installed_transformers", lambda: None)
+    with pytest.raises(SystemExit) as excinfo:
+        probe.check_transformers_version("latest", offline=True)
+    assert "--no-deps" in str(excinfo.value)
+
+
+def test_latest_offline_does_not_query_pypi(monkeypatch):
+    """A vendor box is often offline; that must not block a run."""
+    monkeypatch.setattr(probe, "installed_transformers", lambda: "5.16.1")
+
+    def fail():  # pragma: no cover - must not be called
+        raise AssertionError("PyPI queried in offline mode")
+
+    monkeypatch.setattr(probe, "latest_transformers", fail)
+    record = probe.check_transformers_version("latest", offline=True)
+    assert record["latest"] is None
+
+
+def test_latest_records_the_resolved_release(monkeypatch):
+    monkeypatch.setattr(probe, "installed_transformers", lambda: "5.16.1")
+    monkeypatch.setattr(probe, "latest_transformers", lambda: "5.17.0")
+    record = probe.check_transformers_version("latest", offline=False)
+    assert record == {
+        "requested": "latest",
+        "installed": "5.16.1",
+        "latest": "5.17.0",
+    }
+
+
+def test_unreachable_pypi_falls_back_to_the_installed_version(monkeypatch):
+    monkeypatch.setattr(probe, "installed_transformers", lambda: "5.16.1")
+    monkeypatch.setattr(probe, "latest_transformers", lambda: None)
+    record = probe.check_transformers_version("latest", offline=False)
+    assert record["installed"] == "5.16.1" and record["latest"] is None
+
+
+def test_atomic_write_leaves_no_temporary_files(tmp_path):
+    target = tmp_path / "nested" / "result.json"
+    probe.atomic_write(target, {"verdict": "PASS"})
+    assert target.exists()
+    assert sorted(p.name for p in target.parent.iterdir()) == ["result.json"]


### PR DESCRIPTION
## Summary

Operator surveys measure operators. A model fails on paths no single operator test reaches, so this adds `tests/manual/transformers_model_probe.py`: it builds one tiny randomly initialized architecture from `CONFIG_MAPPING` and runs transfer, forward, backward with an optimizer step, and deterministic generation, comparing each layer against CPU with the same weights, seed, and dtype. No weights are downloaded, so it runs offline.

Failing layers are attributed to concrete ATen operators through `TorchDispatchMode`, which also records which operators ran natively and which reached the CPU fallback — the difference between "the model ran" and "the accelerator ran the model".

One model per invocation, one child process per model. An accelerator fault aborts the interpreter rather than raising, and a poisoned device context makes every later result in the same process meaningless, so a full architecture sweep is an external loop over isolated runs rather than one long process.

## The defect it found

On MTT S5000 with transformers 5.16.1 and torch 2.10.0, qwen3 passes transfer and forward but backward fails:

```
RuntimeError: zero_ failed: NOT_SUPPORTED
```

Root cause, reduced to one line:

```python
torch.empty(0, device="flagos").zero_()   # NOT_SUPPORTED
```

The transformers v5 KV cache does `torch.cat([empty_cache, value_states], dim=-2)`, and that `cat` backward calls `zero_` on the zero-element operand. **Every causal-LM backward pass fails on MUSA while forward passes cleanly.** #228 added `numel() == 0` guards to the unary, binary, and reduction kernels but not the in-place fill path, so this is the gap it left open. `fill_` is affected the same way.

An operator-level survey cannot see this: standalone `zero_` on a non-empty tensor and `Embedding` backward both pass. Only the empty operand inside a real model triggers it. The failure also reproduces without this probe's dispatch tracer, so it is not a harness artifact. The fix is a separate PR; this one is the measurement that finds it and the regression check that will confirm it.

## Design notes

Configs are shrunk recursively. A composite config ignores top-level size overrides: a plain `Gemma3Config` with a tiny `hidden_size` still built 2.7B parameters, because the nested text and vision configs kept their real sizes. Shrinking nested configs brings it to 74K, and a parameter cap turns anything that still escapes into `CONFIG_TOO_LARGE` rather than an OOM on a shared box.

Statuses are kept distinguishable on purpose. An unusable environment, a config that cannot instantiate, and a device defect are three different things, and collapsing them would either invent support or invent defects. The child announces a deliberate stop after a failing layer so unreached layers are `NOT_REACHED` rather than crashes they had no part in, and a fault that kills the process is attributed to the first layer that never reported instead of to everything queued behind it. Non-finite output the CPU did not produce is separated from a tolerance miss, since the latter can be legitimate accumulation-order variance.

Version handling never installs anything: replacing packages underneath a built extension is how a run silently stops measuring the torch the extension was compiled against. `--transformers-version latest` records the installed version and notes when it is behind PyPI; an explicit version must match what is installed or the run is refused.

Issue filing is deliberately not part of this probe. A future reporter consumes the JSON after fingerprint deduplication and a baseline comparison.

## Test

Measured on MTT S5000 (mudnn v3300), transformers 5.16.1, torch 2.10.0:

| model | transfer | forward | backward | generate |
|---|---|---|---|---|
| qwen3 | PASS | PASS | **ERROR** `zero_ NOT_SUPPORTED` | NOT_REACHED |
| llama | PASS | PASS | not run | not run |
| bert | PASS | PASS | not run | not run |
| gemma3 | PASS | PASS | not run | not run |

qwen3 also passes bfloat16 forward. The CPU control passes all four layers in 4.5s, which is what establishes the MUSA backward result as a device defect rather than a model or harness problem.

Guards verified on hardware: unknown model reports `UNKNOWN_MODEL`, the parameter cap reports `CONFIG_TOO_LARGE`, an unknown layer name is rejected by the CLI, a mismatched explicit `--transformers-version` is fatal, and `--offline` skips the PyPI check.

`tests/unit/test_transformers_model_probe.py` covers the version-independent reporting logic with no accelerator, no transformers, and no subprocess: verdict precedence, `UNSUPPORTED` not defeating a pass, environment and config outcomes staying out of coverage results, tolerance ordering across dtypes, poison classification, and the version gate. 19 tests pass. `ruff check` and `ruff format --check` are clean across 316 files.

## Notes for reviewers

The 12 CPU-fallback operators the probe reports on all four models (`_safe_softmax`, `arange`, `ones`, and others) are a separate performance question from the defect above, not addressed here.

Generated with `claude-opus-5[1m]`.
