### PR TITLE
feat: add automated AMP development skill

### DIFF
--- a/.claude/skills/amp-development/SKILL.md
+++ b/.claude/skills/amp-development/SKILL.md
@@ -1,0 +1,464 @@
+---
+name: amp-development
+description: >
+  Automatically develop and land measured automatic mixed precision support for
+  torch_fl. Use this when an AMP operator, dtype, vendor runtime, autocast
+  route, GradScaler path, or training workload is missing or failing. The
+  workflow investigates the failure layer, chooses the existing CUDA/codegen or
+  vendor path, implements the smallest complete fix, regenerates artifacts,
+  runs CPU-reference and real-hardware tests, and reports unsupported scope
+  explicitly. Do not stop at registration or a single operator smoke test.
+---
+
+# Automatic AMP development (torch_fl)
+
+## Purpose
+
+This skill turns an AMP request into a repeatable development workflow. It is
+for **changing the repository**, not merely checking whether a known AMP path
+works. Use the validation contract in this skill after implementation; this workflow
+also applies when a validation-only request needs a code fix.
+
+The workflow is evidence-driven and fail-closed:
+
+```text
+request
+  -> identify torch/vendor/operator scope
+  -> reproduce and classify the failure
+  -> choose the existing backend/codegen path
+  -> implement the smallest complete change
+  -> regenerate and prove idempotency
+  -> add or extend contract tests
+  -> run CPU-reference and hardware validation
+  -> update measured support records
+  -> run pre-PR checks and report exact boundaries
+```
+
+A successful import, a registered dispatch key, a process-group constructor,
+or one matrix multiplication is not an AMP implementation. AMP work is complete
+only for the scope that has passed the corresponding gates below.
+
+## Inputs and defaults
+
+Accept a request containing any subset of:
+
+- target accelerator and hardware (`ACCELERATOR`, model, device index);
+- PyTorch minor line and vendor torch path;
+- target dtype (`float16`, `bfloat16`, or vendor-specific dtype);
+- failing operator or AMP component;
+- selected route (`cuda` boxing, vendor-native, FlagGems, or unknown);
+- required workload (eager, GradScaler, training, DDP/FSDP2);
+- whether the user wants a commit or PR.
+
+Make routine defaults without blocking:
+
+- device key: the torch_fl PrivateUse1 name, normally `flagos`;
+- validation interpreter: the interpreter that imports the vendor torch used to
+  build torch_fl;
+- reference: CPU FP32 with tolerances justified per dtype and operator;
+- target branch: the current stable PyTorch branch unless the user specifies
+  another supported branch;
+- implementation route: preserve the existing route unless measurement proves
+  that it is the failing layer.
+
+Ask a blocking question only when the target hardware, torch ABI, or requested
+scope cannot be determined safely. Never silently substitute a CPU or NVIDIA
+wheel for a vendor torch distribution.
+
+## Non-negotiable boundaries
+
+1. **No inferred support.** Do not infer AMP support from an API import, a route
+   table, a compiled symbol, or a passing context manager.
+2. **No hidden skips.** A skipped test is an evidence gap, not a pass. Record the
+   interpreter, skip reason, and hardware availability.
+3. **No dtype overclaims.** Do not claim BF16 from FP16, and do not claim a
+   vendor-specific dtype merely because torch accepts it.
+4. **No distributed overclaims.** Do not claim DDP, FSDP2, or multi-rank AMP from
+   single-device eager training.
+5. **No handwritten vendor operator kernels when codegen can express the path.**
+   Extend the relevant registry, category/template, generated source, and
+   routing configuration instead. If codegen cannot express the runtime
+   behavior, document the concrete limitation and obtain explicit human review.
+6. **No environment leakage.** Do not copy vendor drivers, SDKs, runtimes,
+   XMLIR, or Python environments into a wheel or repository artifact.
+7. **No destructive GitHub action without authorization.** Push ordinary
+   development branches only to the contributor fork; never expose tokens.
+8. **Keep claims scoped.** Every final report must distinguish autocast state,
+   operator policy, GradScaler, training, distributed AMP, dtype, backend route,
+   hardware, and performance.
+
+## Phase 0 — establish the development ledger
+
+Before editing, create an in-memory ledger (or a temporary evidence file outside
+the repository) with these fields:
+
+```text
+request:
+target_branch:
+target_accelerator:
+hardware_model:
+device_key:
+torch_version:
+torch_path:
+torch_fl_revision:
+route_and_config:
+requested_dtype:
+requested_scope:
+original_failure:
+files_examined:
+commands_run:
+changes_made:
+verification_results:
+unsupported_scope:
+```
+
+Print the resolved environment using the vendor interpreter:
+
+```bash
+python - <<'PY'
+import importlib.util
+import os
+import sys
+import torch
+
+# torch_fl must be imported before reading the device key: the PrivateUse1
+# rename to "flagos" happens at import time. Without it the key still reads
+# "privateuseone" and every autocast/device string in this workflow is wrong.
+import torch_fl
+from torch_fl._build_config import ACCELERATOR
+
+print("python", sys.version.split()[0])
+print("torch", torch.__version__)
+print("torch_file", torch.__file__)
+print("torch_fl_file", torch_fl.__file__)
+print("build_accelerator", ACCELERATOR)
+print("env_accelerator", os.environ.get("ACCELERATOR", "<unset>"))
+print("device_key", torch._C._get_privateuse1_backend_name())
+print("backend_config", os.environ.get("FLAGOS_BACKEND_CONFIG", "<unset>"))
+print("flag_gems", importlib.util.find_spec("flag_gems") is not None)
+print("flagcx", importlib.util.find_spec("flagcx") is not None)
+PY
+```
+
+Compare `build_accelerator` from `torch_fl/_build_config.py` against the
+requested `ACCELERATOR`. `_build_config.py` is generated at build time and is
+what the test gates read, so a mismatch means the installed extension was built
+for a different vendor and any AMP result from it is invalid.
+
+Also record the vendor runtime, SDK, visible devices, compiler, relevant
+`FLAGOS_*`, `GEMS_*`, `XPU_*`, `CUDA_*`, and `TORCH_*` variables, and the
+selected `FLAGOS_BACKEND_CONFIG`. If the environment cannot import the target
+vendor torch or discover the requested device, stop implementation claims and
+report an environment blocker.
+
+## Phase 1 — reproduce before designing
+
+Reproduce the smallest failing case in a fresh process. Capture stdout,
+stderr, exit status, and whether the process crashed. Classify the failure into
+exactly one primary layer before editing:
+
+| Symptom | Primary layer | First inspection |
+|---|---|---|
+| `Autocastflagos` dispatch error | registration | `csrc/aten/autocast.cc`, CMake definitions |
+| output dtype is wrong | policy/routing | ATen policy macros, config, selected backend |
+| `cudaErrorInvalidDeviceFunction` during cast | vendor cast/runtime | `_copy_from`, `_to_copy`, direct dtype cast |
+| non-finite check crash | GradScaler kernel | generated foreach kernel, backend helper |
+| scale changes but parameters update on overflow | scaler semantics | found-inf value, unscale, optimizer step |
+| finite eager step but wrong training result | numerical/training | CPU reference, gradients, optimizer state |
+| rank hang or unequal gradients | distributed AMP | process group, stream/order, scaler sync |
+| only FlagGems route fails | compiler route | config, generated wrapper, compiler logs |
+| one device index fails | device guard | current device, stream, pointer/view |
+
+Run layer-isolating probes, not a large combined script. For a cast failure,
+run direct FP32->target and target->FP32 conversions without autocast. For a
+GradScaler failure, invoke `_amp_foreach_non_finite_check_and_unscale_` with
+one finite tensor and one tensor containing `inf` or `nan` before testing a
+model. For a training failure, first test a scalar parameter and SGD.
+
+Do not change autocast policy to hide a vendor kernel failure. Do not route an
+operator to FlagGems merely because its native path failed; prove the selected
+route and compare both paths when relevant.
+
+## Phase 2 — inspect the repository path
+
+Read the complete relevant files before editing and trace the call chain:
+
+- `csrc/aten/autocast.cc`: generic `AutocastPrivateUse1` policy registration;
+- `csrc/aten/copy_ops.cc`: `_copy_from`, `_to_copy`, stream synchronization,
+  and portable conversion paths;
+- `csrc/aten/generated/cuda_kernels.cc`: generated CUDA-boxing wrappers;
+- `scripts/codegen_ops.py`: source of truth for generated wrappers and configs;
+- `csrc/CMakeLists.txt` and the top-level `CMakeLists.txt`: build definitions;
+- `torch_fl/__init__.py` and `torch_fl/configs/`: route selection;
+- `tests/integration/test_amp_contract.py`: shared AMP contract tests;
+- `tests/integration/amp_support.py`: per-platform AMP capability gates and
+  device-test requirements;
+- `docs/reference/operator-support.md`,
+  `docs/reference/compatibility.md`, and vendor installation docs: measured
+  support records.
+
+For a native non-CUDA-compatible backend, follow the native operator codegen
+rules in the repository. For a CUDA-compatible vendor, preserve CUDA boxing
+unless measurement rules it out. For a FlagGems route, validate that route
+separately rather than treating native/boxing evidence as FlagGems evidence.
+Consult the corresponding platform integration guidance when the target path
+requires it.
+
+Search for an existing implementation on another platform and reuse its helper,
+macro, guard, test fixture, or codegen category where semantics match. Record
+why a reused path is safe for the target vendor.
+
+## Phase 3 — choose the implementation strategy
+
+Use this decision table:
+
+| Measured condition | Strategy |
+|---|---|
+| Generic policy missing but backend kernels work | enable the existing generic `AutocastPrivateUse1` policy table for the target build |
+| CUDA-shaped vendor cast kernel works | keep generated CUDA boxing and add only policy/test wiring |
+| CUDA-shaped vendor cast kernel fails | route conversion through an existing portable path; synchronize before blocking copies |
+| Generated AMP kernel is ABI-compatible and works | keep generated dispatch and add contract coverage |
+| Generated AMP kernel crashes or has a vendor ABI limitation | add a focused backend helper and route to it from the generator |
+| FlagGems wrapper is the failing route | fix registry/schema/codegen/config; do not add a handwritten operator kernel |
+| Native vendor API is required | add a category/template/mapping entry through native-op codegen |
+| Requested dtype is unsupported | fail clearly or mark it not validated; do not silently fall back to a wrong dtype |
+
+Prefer the smallest change that fixes the measured layer. Keep vendor-specific
+preprocessor guards narrow (`USE_<VENDOR>`), use existing namespaces and stream
+helpers, and make error messages name the AMP operation and expected device.
+
+For a host-staged workaround, document all of the following in code and vendor
+docs:
+
+- the exact vendor runtime error or crash that necessitated it;
+- the synchronization point before a blocking copy;
+- whether strides, empty tensors, and dtype preservation are handled;
+- that it is correctness-first and may be slower;
+- the follow-up needed for a device-side implementation.
+
+## Phase 4 — implement with generated artifacts
+
+### Autocast registration
+
+Use upstream policy macros (`AT_FORALL_LOWER_PRECISION_FP`, `AT_FORALL_FP32`,
+`AT_FORALL_FP32_SET_OPT_DTYPE`, `AT_FORALL_PROMOTE`) and the existing dispatcher
+helpers. Do not enumerate individual operators by hand when the generic table
+already describes their policy. If safety restrictions such as banned BCE are
+changed for another vendor, call out the cross-vendor semantic impact.
+
+### GradScaler
+
+The minimum implementation contract is:
+
+```text
+_amp_foreach_non_finite_check_and_unscale_
+  -> detect inf/nan
+  -> unscale every finite gradient exactly once
+  -> write found_inf for both finite and overflow cases
+  -> let scaler.step skip overflow updates
+  -> let scaler.update grow/back off consistently
+```
+
+If a generated wrapper is changed, modify `scripts/codegen_ops.py` first and
+regenerate `csrc/aten/generated/cuda_kernels.cc`. Include all output variants
+that the schema exposes. Do not hand-edit generated artifacts. Check that tensor
+lists, `found_inf`, `inv_scale`, outputs, generators, and device views use the
+exact generated signatures.
+
+### Tests
+
+Extend `tests/integration/test_amp_contract.py` only when its contract applies
+to the new measured accelerator. Update `tests/integration/amp_support.py` with
+the platform's measured capability gates. Otherwise add a focused
+platform-marked test. Tests must:
+
+- use the current logical device key, not a hard-coded CUDA API;
+- compare values against CPU FP32 references;
+- assert dtype, shape, device, finiteness, and parameter state;
+- test finite and overflow paths separately;
+- leave autocast state and global settings restored;
+- skip only when the required hardware/runtime is absent, with a precise reason.
+
+Unit tests must not require vendor hardware. Use source/config fakes for policy
+and codegen logic. Hardware tests must use the vendor interpreter and explicit
+environment variables.
+
+## Phase 5 — regenerate and prove idempotency
+
+Run the generator in the exact build environment. On Kunlun, the vendor
+runtime may be initialized while torch imports, so preserve the runtime
+variables required by the vendor interpreter:
+
+```bash
+unset XPU_CUPTI_ENABLE_DEVICE
+export XPU_ENABLE_PROFILER_TRACING=1
+FLAGOS_CODEGEN_ALL=1 python scripts/codegen_ops.py
+```
+
+Review every generated file. Restore unrelated generated drift instead of
+bundling it. Check the generator exit status **before** comparing output, then
+run it again and require identical patches (or an empty intended-scope diff):
+
+```bash
+set -eu
+FLAGOS_CODEGEN_ALL=1 python scripts/codegen_ops.py
+# Save the complete tracked generated patch. Inspect any untracked generated
+# files separately before deciding whether they belong in the change.
+git diff --binary > /tmp/amp-codegen-first.patch
+FLAGOS_CODEGEN_ALL=1 python scripts/codegen_ops.py
+git diff --binary > /tmp/amp-codegen-second.patch
+cmp -s /tmp/amp-codegen-first.patch /tmp/amp-codegen-second.patch
+printf '%s\\n' "AMP codegen idempotent"
+```
+
+If the complete generator rewrites pre-existing unrelated artifacts, isolate
+the intended generated delta and record the pre-existing drift. Never claim
+idempotency by comparing only one hand-selected function while silently
+committing other generated changes. A failed generator run is a failed gate,
+even if two empty or unchanged patch files happen to compare equal.
+
+## Phase 6 — build and run the contract in layers
+
+Build through `setup.py`/`pip`, not by invoking `cmake` directly. `setup.py`
+supplies build variables that the top-level `CMakeLists.txt` requires and that
+are easy to omit by hand — notably `PYTHON_INCLUDE_DIR`, `PYTORCH_INSTALL_DIR`,
+and `CMAKE_INSTALL_PREFIX`. A bare `cmake -S . -B <dir> -DACCELERATOR=<vendor>`
+fails at configure time with `Cannot find Python directory`, and it also writes
+`torch_fl/_build_config.py`, which the test gates read.
+
+For Kunlun XPU, use the documented vendor invocation:
+
+```bash
+unset XPU_CUPTI_ENABLE_DEVICE
+export XPU_ENABLE_PROFILER_TRACING=1
+export LD_LIBRARY_PATH=/usr/local/xcudart/lib:/usr/local/xpu/lib:$LD_LIBRARY_PATH
+
+ACCELERATOR=kunlun \
+  XPU_ROOT=/usr/local/xpu \
+  XCUDART_ROOT=/usr/local/xcudart \
+  FLAGOS_BUILD_JOBS="$(nproc)" \
+  /path/to/vendor/python setup.py build_ext --inplace
+```
+
+Use `pip install --no-build-isolation -e .` for an installed editable build, and
+`build_ext --inplace` for an in-place source checkout. A plain `build_ext`
+without `--inplace` leaves the extension in a temporary directory and
+`import torch_fl._C` then fails. Consult the vendor installation document for
+the authoritative flags rather than reconstructing them.
+
+Install or select the newly built extension; never validate against a stale
+library without printing its path and build identity:
+
+```bash
+python -c "import torch_fl, torch_fl._C; print(torch_fl.__file__); print(torch_fl._C.__file__)"
+```
+
+Run checks in this order:
+
+1. **State:** enabled/disabled nesting, target dtype, exception cleanup, and
+   restoration after a failed operator.
+2. **Cast:** direct target casts and reverse casts, including float64 copy and
+   empty tensors where applicable.
+3. **Operator policy:** lower-precision (`mm`, `linear`, `conv2d`), FP32-
+   preserving (`log`, `layer_norm`, loss/reduction), explicit dtype, promotion,
+   and safety restrictions.
+4. **GradScaler primitive:** one finite and one non-finite gradient; assert
+   unscaled values and `found_inf`.
+5. **GradScaler semantics:** finite update/growth and overflow skip/backoff;
+   assert parameters before and after the optimizer step.
+6. **Single-device training:** deterministic model, fixed inputs, CPU FP32
+   reference, finite outputs/gradients/parameters, and optimizer state.
+7. **Distributed AMP, only if requested:** at least two ranks; use strict
+   FlagCX selection when applicable; assert synchronized overflow decisions and
+   optimizer steps. Otherwise report it not validated.
+
+Use the shared contract where the platform gate is justified:
+
+```bash
+ACCELERATOR=<vendor> <vendor-env> python -m pytest \
+  tests/integration/test_amp_contract.py -m amp -v
+```
+
+Also run focused config/codegen tests, `ruff check .`, `ruff format --check .`,
+`python -m compileall -q torch_fl tests`, and relevant unit tests. Capture actual
+output and exit status. If a broad unit suite fails for pre-existing vendor
+reasons, rerun at the base or a clean worktree and report both results; never
+hide the failure or call it an AMP pass.
+
+## Phase 7 — automated completion gate
+
+Before declaring the development task complete, evaluate this matrix. A box is
+checked only with direct evidence:
+
+| Gate | Required proof | Status label |
+|---|---|---|
+| Environment | intended vendor torch, extension, device, and runtime paths printed | environment resolved / blocked |
+| Registration | target autocast dispatch key executes a policy operator | autocast registration validated |
+| State | nesting and exception cleanup assertions pass | autocast state validated |
+| Policy | all requested policy classes pass CPU-reference comparison | autocast validated for `<dtype>/<operators>` |
+| GradScaler primitive | finite/non-finite and unscale assertions pass | non-finite handling validated |
+| GradScaler semantics | finite update/growth and overflow skip/backoff pass | GradScaler validated for `<scope>` |
+| Training | deterministic model update matches CPU reference | training validated for `<workload>` |
+| Distributed | two or more ranks and synchronized scaler decisions pass | distributed AMP validated |
+| Generation | second generator run produces no intended-scope diff | codegen idempotent |
+| Quality | lint, format, compile, relevant tests pass | quality checks passed |
+| Records | docs reflect measured hardware and unsupported scope | support records updated |
+
+A missing gate must be reported as `not validated`, `blocked`, or `not
+revalidated`, never as supported. The final response must include:
+
+- files changed and why;
+- root cause and the layer that was fixed;
+- exact test commands and output summaries;
+- hardware/interpreter/torch/runtime identity;
+- generated artifact and idempotency result;
+- known failures and whether they pre-date the change;
+- explicit dtype, route, distributed, and performance boundaries.
+
+## Phase 8 — commit and PR automation
+
+Only when the user requests submission:
+
+1. Read `.github/AI_AGENT_GUIDE.md`, `.github/CLAUDE_CODE_GUIDE.md`, and
+   `.github/PULL_REQUEST_TEMPLATE/ai_agent_pr.md`.
+2. Fetch the intended upstream branch before linting or rebasing.
+3. Isolate the AMP change from unrelated commits and generated drift.
+4. Use an English conventional commit with the required Claude co-author trailer.
+5. Validate the AI PR body with:
+
+   ```bash
+   python scripts/validate_ai_pr.py --pr-body <body-file>
+   ```
+
+6. Push only to the contributor fork and create the PR against the requested
+   upstream branch. Add `ai-generated` and request a human reviewer who is not
+   the PR author.
+7. Paste actual P800/XPU or other vendor test output into the PR. Do not paste
+   a skip as a pass. Mention pre-existing failures and all unvalidated scope.
+
+Do not force-push a shared branch, expose proxy credentials, or place tokens in
+an evidence file, commit, PR body, or log.
+
+## Failure recovery loop
+
+When a gate fails, return to the smallest layer that can explain it:
+
+```text
+failure
+  -> preserve complete log and exit status
+  -> reduce to a minimal reproducer
+  -> classify registration / policy / cast / runtime / scaler / training / comm
+  -> inspect the existing path and comparable backend
+  -> implement one focused change
+  -> regenerate if applicable
+  -> rerun the failed gate and all dependent gates
+```
+
+Never patch several unrelated layers at once. If the vendor runtime is unstable
+or unavailable, finish static/codegen work that does not depend on it, then
+report the runtime-dependent scope as not validated.
+
+## Related skills
+
+[[runtime-bringup]] · [[torch-version-port]] · [[cuda-compat-vendor]] ·
+[[native-op-backend]] · [[flaggems-integration]] · [[pre-pr-checks]]


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @lvyufeng
- **Session Summary**: Added and self-tested an automated AMP development workflow for torch_fl, using the Kunlun P800 XPU environment to validate each prescribed gate and correct workflow defects found during testing.

## Summary

This PR adds `.claude/skills/amp-development/SKILL.md`, a fail-closed workflow for automatically developing AMP support rather than stopping at registration or a single operator smoke test. It covers environment identification, failure-layer classification, backend/codegen strategy selection, generated artifact idempotency, clean vendor builds, CPU-reference validation, GradScaler and training semantics, explicit unsupported scope, and PR automation. The skill was exercised against the current Kunlun P800 XPU checkout; its environment, codegen, build, AMP contract, routing, lint, format, and compile gates were tested, with pre-existing unit failures reported separately.

## Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [x] Platform-agnostic skill guidance (validated on Kunlun P800 XPU)

## Problem Analysis

### What was broken/missing?

The repository had `amp-integration`, which provides a validation contract, but no dedicated workflow for automatically taking a missing or failing AMP feature through investigation, implementation, code generation, testing, and support-record updates. Without such a workflow an agent could stop after importing `torch`, registering `AutocastPrivateUse1`, or passing one `mm`, while missing cast-runtime failures, GradScaler crashes, CPU-reference mismatches, generated-file drift, or unsupported dtype/distributed scope.

### Why did it happen?

AMP spans multiple independent layers: dispatcher registration, operator policy, vendor cast/runtime behavior, non-finite detection, optimizer-step semantics, training numerics, and distributed synchronization. Existing guidance was validation-oriented and did not encode a complete development loop or a completion matrix that made missing evidence fail closed.

### Investigation process:

1. Surveyed all existing `.claude/skills/` files, repository code-generation scripts, AMP tests, capability helpers, build instructions, and PR workflow guides.
2. Compared the new workflow against the current shared contract in `tests/integration/test_amp_contract.py` and `tests/integration/amp_support.py`.
3. Ran the initial Phase 0, Phase 5, and Phase 6 prescriptions on the P800 XPU environment.
4. Found and corrected three workflow defects: reading the PrivateUse1 device key before importing `torch_fl`, claiming codegen idempotency after failed generator runs, and using a raw CMake invocation that omitted required setup.py variables.
5. Re-ran structural, codegen, build, contract, routing, lint, format, compile, and unit-baseline checks.

## Solution Design

### Implementation approach:

Add one repository skill with a staged workflow:

```text
request -> environment ledger -> minimal reproduction -> failure layer
  -> existing route/codegen strategy -> implementation -> regeneration/idempotency
  -> clean build -> state/cast/policy/scaler/training tests
  -> measured support records -> pre-PR checks
```

The skill explicitly keeps CUDA boxing, native codegen, and FlagGems evidence separate and requires a direct hardware or CPU-reference gate for every claim.

### Key design decisions:

- **Fail closed:** a skip, unavailable device, unsupported dtype, missing generated output, or unvalidated distributed path is reported as `not validated`, `blocked`, or `not revalidated` rather than support.
- **Layered debugging:** failures are first classified as registration, policy, cast/runtime, GradScaler, training, distributed, compiler route, or device-guard issues before any code is changed.
- **Repository-native implementation:** the workflow reuses existing helpers and requires code-generator changes plus regenerated artifacts when the platform rules require them; it prohibits handwritten vendor kernels where codegen can express the behavior.
- **Vendor build correctness:** the skill now uses `setup.py`/`pip` for builds because the top-level CMake requires variables setup.py supplies, including `PYTHON_INCLUDE_DIR` and `PYTORCH_INSTALL_DIR`.
- **Correct environment identity:** `torch_fl` is imported before reading the PrivateUse1 name, and the generated build accelerator is compared with the requested accelerator.
- **Idempotency integrity:** generator exit status is checked before comparing outputs, and unrelated generated drift is explicitly isolated.
- **Evidence boundaries:** FP16 does not imply BF16, eager AMP does not imply distributed AMP, and a full unit suite with pre-existing vendor failures is not silently called a pass.

### Code changes by file:

- `.claude/skills/amp-development/SKILL.md` (464 lines): adds the automated AMP development workflow, phase gates, implementation strategy table, generated-artifact rules, hardware/CPU-reference test order, completion matrix, failure recovery loop, and PR checklist.

### Changes by commit:

1. `93852eb` - `feat: add automated AMP development skill`: adds the complete skill and its tested corrections.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [ ] **Type checking passed** (not configured for markdown skill files)
- [x] **All relevant tests pass** (AMP contract and routing checks; pre-existing unit failures characterized)
- [x] **Manual testing completed** (skill prescriptions executed on P800 XPU)
- [x] **No debug/temporary code** (skill file only; temporary logs outside repository)
- [x] **Documentation updated** (new skill documentation)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results

```bash
$ ruff check .
All checks passed!

$ ruff format --check .
226 files already formatted

$ python -m compileall -q torch_fl tests
# no output, exit 0

$ git diff --check
# no output, exit 0
```

### Test Results

Environment gate on Kunlun P800 XPU:

```text
python 3.10.20
torch 2.9.0+cu129
torch_file /flagos/lib/python3.10/site-packages/torch/__init__.py
torch_fl_file /public-flash/lvyufeng/Torch-FL/torch_fl/__init__.py
build_accelerator kunlun
env_accelerator kunlun
device_key flagos
backend_config /public-flash/lvyufeng/Torch-FL/torch_fl/configs/backends_cuda.conf
flag_gems True
flagcx True
```

Codegen gate using the skill's corrected `set -eu` procedure:

```text
run1 exit=0
run2 exit=0
diffs identical
AMP codegen idempotent
```

The full generator also rewrites pre-existing unrelated generated files in this checkout; those changes were inspected and restored rather than included.

Clean build gate:

```text
$ ACCELERATOR=kunlun XPU_ROOT=/usr/local/xpu XCUDART_ROOT=/usr/local/xcudart \
    FLAGOS_BUILD_JOBS="$(nproc)" /flagos/bin/python setup.py build_ext --inplace
# build exit=0
[100%] Built target torch_bindings
```

AMP contract on actual Kunlun P800 XPU hardware:

```text
$ ACCELERATOR=kunlun XPU_ENABLE_PROFILER_TRACING=1 FLAGOS_USE_FLAGGEMS=0 \
    /flagos/bin/python -m pytest tests/integration/test_amp.py -q
15 passed in 0.18s
```

The legacy `test_amp.py` suite is retained on this 2.9 checkout and is gated for DCU and Kunlun. The current main branch has since renamed the shared contract to `test_amp_contract.py`; the skill documents the current contract filename for future main-based work.

Routing regression check:

```text
$ /flagos/bin/python -m pytest tests/integration/ops/test_flaggems_conf_consistency.py -q
8 passed in 0.34s
```

Skill structure test:

```text
skill structure PASS: 14 sections, 9 phases
links PASS: all referenced skills resolved
paths PASS: all referenced repository paths exist
```

Unit suite:

```text
$ /flagos/bin/python -m pytest tests/unit/ -q
36 failed, 58 passed, 28 skipped, 2 warnings in 7.80s
```

These failures are pre-existing Kunlun gaps (BPU x86 stubs and PrivateUse1 profiler tests). The AMP skill requires a baseline rerun for exactly this reason. The new change is a markdown file and cannot affect those tests.

### Manual Verification

The workflow itself was tested through the following progression:

1. Initial Phase 0 probe reported `privateuseone`; investigation showed the skill read the key before `import torch_fl`. After correction it reported `device_key flagos` and matching `kunlun` build/environment accelerators.
2. Initial Phase 5 probe ran the generator twice with exit code 1 because `XPU_ENABLE_PROFILER_TRACING` was missing, yet incorrectly printed idempotency. After correction, the command used the required environment and `set -eu`; both runs exited 0 and produced identical patches.
3. Initial Phase 6 raw CMake probe failed exactly as the skill now documents:

```text
CMake Error at CMakeLists.txt:640 (message):
  Cannot find Python directory
```

   The workflow now uses setup.py, which supplies the required variables; the corrected clean build exited 0.
4. The rebuilt P800 extension passed the complete 15-test AMP suite, including FP16/BF16 policy cases, GradScaler finite/overflow behavior, and training-step coverage.

## Performance Impact

Not applicable. This PR adds documentation/workflow guidance only and does not change runtime code or performance.

## Code Quality Verification

### Style Consistency
- [x] Matched existing skill/documentation style
- [x] Followed repository naming and frontmatter conventions
- [x] Used the existing AMP, vendor, codegen, and pre-PR concepts rather than duplicating implementation guidance

### Edge Cases Considered

1. PrivateUse1 device key before and after `torch_fl` import.
2. Vendor build accelerator differing from the requested environment.
3. Generator failure followed by equal empty/unchanged patches.
4. Pre-existing unrelated generated-file drift.
5. Missing CMake Python variables and stale in-place extensions.
6. Unsupported FP32/FP64 autocast targets and unsupported vendor dtypes.
7. Finite and non-finite gradients, exactly-once unscale, skipped optimizer step, scale growth, and backoff.
8. Host-staged copies requiring stream synchronization.
9. Single-device success without distributed evidence.
10. Hardware test skips and broad unit-test failures that pre-date the change.
11. Native, CUDA-boxing, and FlagGems routes requiring separate evidence.
12. Human reviewer being the PR author and therefore not requestable through GitHub.

### Potential Risks

1. The skill is guidance rather than an executable orchestration script, so future changes to repository test names or build interfaces can make its commands stale.
2. The workflow intentionally allows vendor-specific host staging as a correctness fallback; agents must not misrepresent its performance.
3. The current 2.9 branch and main branch have different AMP test filenames; the skill documents the current main contract and calls out the legacy 2.9 suite.

### Rollback Plan

Revert commit `93852eb` or remove `.claude/skills/amp-development/SKILL.md`. No runtime code, package metadata, or public API is changed.

## Related Work
- Related to #210 (Kunlun P800 XPU AMP support)
- Related to #230 (transformers coverage survey skill and current main skill set)
- Related to the existing `amp-integration`, `pre-pr-checks`, `cuda-compat-vendor`, `native-op-backend`, and `flaggems-integration` skills

## Explicitly Not Included

- Runtime AMP implementation changes.
- New operator kernels or routing changes.
- Distributed AMP implementation or validation.
- AMP performance benchmarking.
- A new executable orchestration framework; this repository uses markdown skills.
- Changes to the current shared AMP contract or platform capability tables.

## Human Review Notes

### Areas needing special attention:

1. Whether the distinction between development workflow and validation-only `amp-integration` guidance is clear.
2. Whether the generated-artifact/idempotency instructions are sufficiently strict for all platform generators.
3. Whether the setup.py-over-raw-CMake build guidance should be generalized to every vendor skill.
4. Whether documenting the legacy 2.9 test filename alongside the current main filename is useful or confusing.

### Questions for reviewer:

1. Should this skill eventually be registered in a repository-level skill index or CI documentation?
2. Should future AMP development work add a dedicated machine-readable evidence artifact in addition to the markdown ledger?

## Additional Context

The skill was tested on the actual Kunlun P800 XPU environment, not a CPU substitute:

```text
XPU-RT 5.37.1
torch 2.9.0+cu129
ACCELERATOR=kunlun
device flagos:0
device_count 8
```

The final scope labels from the hardware validation are:

```text
AMP autocast validated for Kunlun P800 XPU FP16/BF16 policy scope
AMP GradScaler validated for Kunlun P800 XPU finite/overflow/growth/backoff scope
AMP single-device training validated for Kunlun P800 XPU tested workload
AMP distributed training not validated
AMP performance not validated
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
