### PR TITLE
feat: add automated AMP development skill

### DIFF
--- a/.claude/skills/amp-development/SKILL.md
+++ b/.claude/skills/amp-development/SKILL.md
@@ -1,0 +1,459 @@
+---
+name: amp-development
+description: >
+  Automatically develop and land measured automatic mixed precision support for
+  torch_fl. Use this when an AMP operator, dtype, vendor runtime, autocast
+  route, GradScaler path, or training workload is missing or failing. The
+  workflow investigates the failure layer, chooses the existing CUDA/codegen or
+  vendor path, implements the smallest complete fix, regenerates artifacts,
+  runs CPU-reference and real-hardware tests, and reports unsupported scope
+  explicitly. Do not stop at registration or a single operator smoke test.
+---
+
+# Automatic AMP development (torch_fl)
+
+## Purpose
+
+This skill turns an AMP request into a repeatable development workflow. It is
+for **changing the repository**, not merely checking whether a known AMP path
+works. Use [[amp-integration]] for a validation-only request; this skill uses
+that contract after implementation.
+
+The workflow is evidence-driven and fail-closed:
+
+```text
+request
+  -> identify torch/vendor/operator scope
+  -> reproduce and classify the failure
+  -> choose the existing backend/codegen path
+  -> implement the smallest complete change
+  -> regenerate and prove idempotency
+  -> add or extend contract tests
+  -> run CPU-reference and hardware validation
+  -> update measured support records
+  -> run pre-PR checks and report exact boundaries
+```
+
+A successful import, a registered dispatch key, a process-group constructor,
+or one matrix multiplication is not an AMP implementation. AMP work is complete
+only for the scope that has passed the corresponding gates below.
+
+## Inputs and defaults
+
+Accept a request containing any subset of:
+
+- target accelerator and hardware (`ACCELERATOR`, model, device index);
+- PyTorch minor line and vendor torch path;
+- target dtype (`float16`, `bfloat16`, or vendor-specific dtype);
+- failing operator or AMP component;
+- selected route (`cuda` boxing, vendor-native, FlagGems, or unknown);
+- required workload (eager, GradScaler, training, DDP/FSDP2);
+- whether the user wants a commit or PR.
+
+Make routine defaults without blocking:
+
+- device key: the torch_fl PrivateUse1 name, normally `flagos`;
+- validation interpreter: the interpreter that imports the vendor torch used to
+  build torch_fl;
+- reference: CPU FP32 with tolerances justified per dtype and operator;
+- target branch: the current stable PyTorch branch unless the user specifies
+  another supported branch;
+- implementation route: preserve the existing route unless measurement proves
+  that it is the failing layer.
+
+Ask a blocking question only when the target hardware, torch ABI, or requested
+scope cannot be determined safely. Never silently substitute a CPU or NVIDIA
+wheel for a vendor torch distribution.
+
+## Non-negotiable boundaries
+
+1. **No inferred support.** Do not infer AMP support from an API import, a route
+   table, a compiled symbol, or a passing context manager.
+2. **No hidden skips.** A skipped test is an evidence gap, not a pass. Record the
+   interpreter, skip reason, and hardware availability.
+3. **No dtype overclaims.** Do not claim BF16 from FP16, and do not claim a
+   vendor-specific dtype merely because torch accepts it.
+4. **No distributed overclaims.** Do not claim DDP, FSDP2, or multi-rank AMP from
+   single-device eager training.
+5. **No handwritten vendor operator kernels when codegen can express the path.**
+   Extend the relevant registry, category/template, generated source, and
+   routing configuration instead. If codegen cannot express the runtime
+   behavior, document the concrete limitation and obtain explicit human review.
+6. **No environment leakage.** Do not copy vendor drivers, SDKs, runtimes,
+   XMLIR, or Python environments into a wheel or repository artifact.
+7. **No destructive GitHub action without authorization.** Push ordinary
+   development branches only to the contributor fork; never expose tokens.
+8. **Keep claims scoped.** Every final report must distinguish autocast state,
+   operator policy, GradScaler, training, distributed AMP, dtype, backend route,
+   hardware, and performance.
+
+## Phase 0 — establish the development ledger
+
+Before editing, create an in-memory ledger (or a temporary evidence file outside
+the repository) with these fields:
+
+```text
+request:
+target_branch:
+target_accelerator:
+hardware_model:
+device_key:
+torch_version:
+torch_path:
+torch_fl_revision:
+route_and_config:
+requested_dtype:
+requested_scope:
+original_failure:
+files_examined:
+commands_run:
+changes_made:
+verification_results:
+unsupported_scope:
+```
+
+Print the resolved environment using the vendor interpreter:
+
+```bash
+python - <<'PY'
+import importlib.util
+import os
+import sys
+import torch
+
+# torch_fl must be imported before reading the device key: the PrivateUse1
+# rename to "flagos" happens at import time. Without it the key still reads
+# "privateuseone" and every autocast/device string in this workflow is wrong.
+import torch_fl
+from torch_fl._build_config import ACCELERATOR
+
+print("python", sys.version.split()[0])
+print("torch", torch.__version__)
+print("torch_file", torch.__file__)
+print("torch_fl_file", torch_fl.__file__)
+print("build_accelerator", ACCELERATOR)
+print("env_accelerator", os.environ.get("ACCELERATOR", "<unset>"))
+print("device_key", torch._C._get_privateuse1_backend_name())
+print("backend_config", os.environ.get("FLAGOS_BACKEND_CONFIG", "<unset>"))
+print("flag_gems", importlib.util.find_spec("flag_gems") is not None)
+print("flagcx", importlib.util.find_spec("flagcx") is not None)
+PY
+```
+
+Compare `build_accelerator` from `torch_fl/_build_config.py` against the
+requested `ACCELERATOR`. `_build_config.py` is generated at build time and is
+what the test gates read, so a mismatch means the installed extension was built
+for a different vendor and any AMP result from it is invalid.
+
+Also record the vendor runtime, SDK, visible devices, compiler, relevant
+`FLAGOS_*`, `GEMS_*`, `XPU_*`, `CUDA_*`, and `TORCH_*` variables, and the
+selected `FLAGOS_BACKEND_CONFIG`. If the environment cannot import the target
+vendor torch or discover the requested device, stop implementation claims and
+report an environment blocker.
+
+## Phase 1 — reproduce before designing
+
+Reproduce the smallest failing case in a fresh process. Capture stdout,
+stderr, exit status, and whether the process crashed. Classify the failure into
+exactly one primary layer before editing:
+
+| Symptom | Primary layer | First inspection |
+|---|---|---|
+| `Autocastflagos` dispatch error | registration | `csrc/aten/autocast.cc`, CMake definitions |
+| output dtype is wrong | policy/routing | ATen policy macros, config, selected backend |
+| `cudaErrorInvalidDeviceFunction` during cast | vendor cast/runtime | `_copy_from`, `_to_copy`, direct dtype cast |
+| non-finite check crash | GradScaler kernel | generated foreach kernel, backend helper |
+| scale changes but parameters update on overflow | scaler semantics | found-inf value, unscale, optimizer step |
+| finite eager step but wrong training result | numerical/training | CPU reference, gradients, optimizer state |
+| rank hang or unequal gradients | distributed AMP | process group, stream/order, scaler sync |
+| only FlagGems route fails | compiler route | config, generated wrapper, compiler logs |
+| one device index fails | device guard | current device, stream, pointer/view |
+
+Run layer-isolating probes, not a large combined script. For a cast failure,
+run direct FP32->target and target->FP32 conversions without autocast. For a
+GradScaler failure, invoke `_amp_foreach_non_finite_check_and_unscale_` with
+one finite tensor and one tensor containing `inf` or `nan` before testing a
+model. For a training failure, first test a scalar parameter and SGD.
+
+Do not change autocast policy to hide a vendor kernel failure. Do not route an
+operator to FlagGems merely because its native path failed; prove the selected
+route and compare both paths when relevant.
+
+## Phase 2 — inspect the repository path
+
+Read the complete relevant files before editing and trace the call chain:
+
+- `csrc/aten/autocast.cc`: generic `AutocastPrivateUse1` policy registration;
+- `csrc/aten/copy_ops.cc`: `_copy_from`, `_to_copy`, stream synchronization,
+  and portable conversion paths;
+- `csrc/aten/generated/cuda_kernels.cc`: generated CUDA-boxing wrappers;
+- `scripts/codegen_ops.py`: source of truth for generated wrappers and configs;
+- `csrc/CMakeLists.txt` and the top-level `CMakeLists.txt`: build definitions;
+- `torch_fl/__init__.py` and `torch_fl/configs/`: route selection;
+- `tests/integration/test_amp.py`: shared AMP contract tests;
+- `docs/reference/operator-support.md`,
+  `docs/reference/compatibility.md`, and vendor installation docs: measured
+  support records.
+
+For a native non-CUDA-compatible backend, also read [[native-op-backend]] and
+follow its category/template rules. For a CUDA-compatible vendor, read
+[[cuda-compat-vendor]] and preserve CUDA boxing unless measurement rules it out.
+For a FlagGems route, read [[flaggems-integration]] and validate that route
+separately rather than treating native/boxing evidence as FlagGems evidence.
+
+Search for an existing implementation on another platform and reuse its helper,
+macro, guard, test fixture, or codegen category where semantics match. Record
+why a reused path is safe for the target vendor.
+
+## Phase 3 — choose the implementation strategy
+
+Use this decision table:
+
+| Measured condition | Strategy |
+|---|---|
+| Generic policy missing but backend kernels work | enable the existing generic `AutocastPrivateUse1` policy table for the target build |
+| CUDA-shaped vendor cast kernel works | keep generated CUDA boxing and add only policy/test wiring |
+| CUDA-shaped vendor cast kernel fails | route conversion through an existing portable path; synchronize before blocking copies |
+| Generated AMP kernel is ABI-compatible and works | keep generated dispatch and add contract coverage |
+| Generated AMP kernel crashes or has a vendor ABI limitation | add a focused backend helper and route to it from the generator |
+| FlagGems wrapper is the failing route | fix registry/schema/codegen/config; do not add a handwritten operator kernel |
+| Native vendor API is required | add a category/template/mapping entry through native-op codegen |
+| Requested dtype is unsupported | fail clearly or mark it not validated; do not silently fall back to a wrong dtype |
+
+Prefer the smallest change that fixes the measured layer. Keep vendor-specific
+preprocessor guards narrow (`USE_<VENDOR>`), use existing namespaces and stream
+helpers, and make error messages name the AMP operation and expected device.
+
+For a host-staged workaround, document all of the following in code and vendor
+docs:
+
+- the exact vendor runtime error or crash that necessitated it;
+- the synchronization point before a blocking copy;
+- whether strides, empty tensors, and dtype preservation are handled;
+- that it is correctness-first and may be slower;
+- the follow-up needed for a device-side implementation.
+
+## Phase 4 — implement with generated artifacts
+
+### Autocast registration
+
+Use upstream policy macros (`AT_FORALL_LOWER_PRECISION_FP`, `AT_FORALL_FP32`,
+`AT_FORALL_FP32_SET_OPT_DTYPE`, `AT_FORALL_PROMOTE`) and the existing dispatcher
+helpers. Do not enumerate individual operators by hand when the generic table
+already describes their policy. If safety restrictions such as banned BCE are
+changed for another vendor, call out the cross-vendor semantic impact.
+
+### GradScaler
+
+The minimum implementation contract is:
+
+```text
+_amp_foreach_non_finite_check_and_unscale_
+  -> detect inf/nan
+  -> unscale every finite gradient exactly once
+  -> write found_inf for both finite and overflow cases
+  -> let scaler.step skip overflow updates
+  -> let scaler.update grow/back off consistently
+```
+
+If a generated wrapper is changed, modify `scripts/codegen_ops.py` first and
+regenerate `csrc/aten/generated/cuda_kernels.cc`. Include all output variants
+that the schema exposes. Do not hand-edit generated artifacts. Check that tensor
+lists, `found_inf`, `inv_scale`, outputs, generators, and device views use the
+exact generated signatures.
+
+### Tests
+
+Extend `tests/integration/test_amp.py` only when its contract applies to the
+new measured accelerator. Otherwise add a focused platform-marked test. Tests
+must:
+
+- use the current logical device key, not a hard-coded CUDA API;
+- compare values against CPU FP32 references;
+- assert dtype, shape, device, finiteness, and parameter state;
+- test finite and overflow paths separately;
+- leave autocast state and global settings restored;
+- skip only when the required hardware/runtime is absent, with a precise reason.
+
+Unit tests must not require vendor hardware. Use source/config fakes for policy
+and codegen logic. Hardware tests must use the vendor interpreter and explicit
+environment variables.
+
+## Phase 5 — regenerate and prove idempotency
+
+Run the generator in the exact build environment. On Kunlun, the vendor
+runtime may be initialized while torch imports, so preserve the runtime
+variables required by the vendor interpreter:
+
+```bash
+unset XPU_CUPTI_ENABLE_DEVICE
+export XPU_ENABLE_PROFILER_TRACING=1
+FLAGOS_CODEGEN_ALL=1 python scripts/codegen_ops.py
+```
+
+Review every generated file. Restore unrelated generated drift instead of
+bundling it. Check the generator exit status **before** comparing output, then
+run it again and require identical patches (or an empty intended-scope diff):
+
+```bash
+set -eu
+FLAGOS_CODEGEN_ALL=1 python scripts/codegen_ops.py
+# Save the complete tracked generated patch. Inspect any untracked generated
+# files separately before deciding whether they belong in the change.
+git diff --binary > /tmp/amp-codegen-first.patch
+FLAGOS_CODEGEN_ALL=1 python scripts/codegen_ops.py
+git diff --binary > /tmp/amp-codegen-second.patch
+cmp -s /tmp/amp-codegen-first.patch /tmp/amp-codegen-second.patch
+printf '%s\n' "AMP codegen idempotent"
+```
+
+If the complete generator rewrites pre-existing unrelated artifacts, isolate
+the intended generated delta and record the pre-existing drift. Never claim
+idempotency by comparing only one hand-selected function while silently
+committing other generated changes. A failed generator run is a failed gate,
+even if two empty or unchanged patch files happen to compare equal.
+
+## Phase 6 — build and run the contract in layers
+
+Build through `setup.py`/`pip`, not by invoking `cmake` directly. `setup.py`
+supplies build variables that the top-level `CMakeLists.txt` requires and that
+are easy to omit by hand — notably `PYTHON_INCLUDE_DIR`, `PYTORCH_INSTALL_DIR`,
+and `CMAKE_INSTALL_PREFIX`. A bare `cmake -S . -B <dir> -DACCELERATOR=<vendor>`
+fails at configure time with `Cannot find Python directory`, and it also writes
+`torch_fl/_build_config.py`, which the test gates read.
+
+For Kunlun XPU, use the documented vendor invocation:
+
+```bash
+unset XPU_CUPTI_ENABLE_DEVICE
+export XPU_ENABLE_PROFILER_TRACING=1
+export LD_LIBRARY_PATH=/usr/local/xcudart/lib:/usr/local/xpu/lib:$LD_LIBRARY_PATH
+
+ACCELERATOR=kunlun \
+  XPU_ROOT=/usr/local/xpu \
+  XCUDART_ROOT=/usr/local/xcudart \
+  FLAGOS_BUILD_JOBS="$(nproc)" \
+  /path/to/vendor/python setup.py build_ext --inplace
+```
+
+Use `pip install --no-build-isolation -e .` for an installed editable build, and
+`build_ext --inplace` for an in-place source checkout. A plain `build_ext`
+without `--inplace` leaves the extension in a temporary directory and
+`import torch_fl._C` then fails. Consult the vendor installation document for
+the authoritative flags rather than reconstructing them.
+
+Install or select the newly built extension; never validate against a stale
+library without printing its path and build identity:
+
+```bash
+python -c "import torch_fl, torch_fl._C; print(torch_fl.__file__); print(torch_fl._C.__file__)"
+```
+
+Run checks in this order:
+
+1. **State:** enabled/disabled nesting, target dtype, exception cleanup, and
+   restoration after a failed operator.
+2. **Cast:** direct target casts and reverse casts, including float64 copy and
+   empty tensors where applicable.
+3. **Operator policy:** lower-precision (`mm`, `linear`, `conv2d`), FP32-
+   preserving (`log`, `layer_norm`, loss/reduction), explicit dtype, promotion,
+   and safety restrictions.
+4. **GradScaler primitive:** one finite and one non-finite gradient; assert
+   unscaled values and `found_inf`.
+5. **GradScaler semantics:** finite update/growth and overflow skip/backoff;
+   assert parameters before and after the optimizer step.
+6. **Single-device training:** deterministic model, fixed inputs, CPU FP32
+   reference, finite outputs/gradients/parameters, and optimizer state.
+7. **Distributed AMP, only if requested:** at least two ranks; use strict
+   FlagCX selection when applicable; assert synchronized overflow decisions and
+   optimizer steps. Otherwise report it not validated.
+
+Use the shared suite where the platform gate is justified:
+
+```bash
+ACCELERATOR=<vendor> <vendor-env> python -m pytest tests/integration/test_amp.py -v
+```
+
+Also run focused config/codegen tests, `ruff check .`, `ruff format --check .`,
+`python -m compileall -q torch_fl tests`, and relevant unit tests. Capture actual
+output and exit status. If a broad unit suite fails for pre-existing vendor
+reasons, rerun at the base or a clean worktree and report both results; never
+hide the failure or call it an AMP pass.
+
+## Phase 7 — automated completion gate
+
+Before declaring the development task complete, evaluate this matrix. A box is
+checked only with direct evidence:
+
+| Gate | Required proof | Status label |
+|---|---|---|
+| Environment | intended vendor torch, extension, device, and runtime paths printed | environment resolved / blocked |
+| Registration | target autocast dispatch key executes a policy operator | autocast registration validated |
+| State | nesting and exception cleanup assertions pass | autocast state validated |
+| Policy | all requested policy classes pass CPU-reference comparison | autocast validated for `<dtype>/<operators>` |
+| GradScaler primitive | finite/non-finite and unscale assertions pass | non-finite handling validated |
+| GradScaler semantics | finite update/growth and overflow skip/backoff pass | GradScaler validated for `<scope>` |
+| Training | deterministic model update matches CPU reference | training validated for `<workload>` |
+| Distributed | two or more ranks and synchronized scaler decisions pass | distributed AMP validated |
+| Generation | second generator run produces no intended-scope diff | codegen idempotent |
+| Quality | lint, format, compile, relevant tests pass | quality checks passed |
+| Records | docs reflect measured hardware and unsupported scope | support records updated |
+
+A missing gate must be reported as `not validated`, `blocked`, or `not
+revalidated`, never as supported. The final response must include:
+
+- files changed and why;
+- root cause and the layer that was fixed;
+- exact test commands and output summaries;
+- hardware/interpreter/torch/runtime identity;
+- generated artifact and idempotency result;
+- known failures and whether they pre-date the change;
+- explicit dtype, route, distributed, and performance boundaries.
+
+## Phase 8 — commit and PR automation
+
+Only when the user requests submission:
+
+1. Read `.github/AI_AGENT_GUIDE.md`, `.github/CLAUDE_CODE_GUIDE.md`, and
+   `.github/PULL_REQUEST_TEMPLATE/ai_agent_pr.md`.
+2. Fetch the intended upstream branch before linting or rebasing.
+3. Isolate the AMP change from unrelated commits and generated drift.
+4. Use an English conventional commit with the required Claude co-author trailer.
+5. Validate the AI PR body with:
+
+   ```bash
+   python scripts/validate_ai_pr.py --pr-body <body-file>
+   ```
+
+6. Push only to the contributor fork and create the PR against the requested
+   upstream branch. Add `ai-generated` and request a human reviewer who is not
+   the PR author.
+7. Paste actual P800/XPU or other vendor test output into the PR. Do not paste
+   a skip as a pass. Mention pre-existing failures and all unvalidated scope.
+
+Do not force-push a shared branch, expose proxy credentials, or place tokens in
+an evidence file, commit, PR body, or log.
+
+## Failure recovery loop
+
+When a gate fails, return to the smallest layer that can explain it:
+
+```text
+failure
+  -> preserve complete log and exit status
+  -> reduce to a minimal reproducer
+  -> classify registration / policy / cast / runtime / scaler / training / comm
+  -> inspect the existing path and comparable backend
+  -> implement one focused change
+  -> regenerate if applicable
+  -> rerun the failed gate and all dependent gates
+```
+
+Never patch several unrelated layers at once. If the vendor runtime is unstable
+or unavailable, finish static/codegen work that does not depend on it, then
+report the runtime-dependent scope as not validated.
+
+## Related skills
+
+[[runtime-bringup]] · [[torch-version-port]] · [[cuda-compat-vendor]] ·
+[[native-op-backend]] · [[flaggems-integration]] · [[pre-pr-checks]]


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: to be assigned by a maintainer other than the PR author (GitHub rejects a review request from the PR author)
- **Session Summary**: After the Kunlun P800 XPU AMP runtime landed in #210, the user asked for a skill that automates AMP *development* (not only validation), then asked that it target the `2.9` stable branch first.

## Summary
This PR adds `.claude/skills/amp-development/SKILL.md`, an agent workflow for developing
AMP support in torch_fl. The existing `amp-integration` skill validates a known AMP path
but has no procedure for the case that produced #210, where autocast registration, the
FP32->FP16 cast path, and the GradScaler foreach kernel each had to be diagnosed and fixed
as separate layers. The new skill encodes that layer-isolating workflow, the build and
codegen gates that actually work on vendor hardware, and fail-closed reporting rules so a
skip is never reported as support. This is a documentation-only change; no runtime,
generated artifact, or test behavior is modified.

## Change Type
- [x] Documentation
- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [x] Platform-agnostic (all platforms)
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU

The skill is platform-agnostic guidance. Its worked examples come from Kunlun P800 XPU
(`ACCELERATOR=kunlun`), because that is the hardware the workflow was exercised on. No
platform runtime code changes.

## Problem Analysis

### What was broken/missing?
The repository had `amp-integration`, which answers "does AMP work on this platform?" It
does not tell an agent what to do when AMP does *not* work. The Kunlun P800 XPU AMP work
in #210 required three distinct fixes in three distinct layers:

1. the generic `AutocastPrivateUse1` policy table was compiled only under `USE_DCU`, so
   the target build had no policy registration;
2. the CUDA TensorIterator cast path failed on the vendor runtime with
   `CUDA error: invalid device function` for FP32->FP16 `.to(dtype)`, while direct FP32
   `mm` and direct FP16 `mm` both worked;
3. the generated CUDA-boxing `_amp_foreach_non_finite_check_and_unscale_` segfaulted on
   the vendor runtime even with a single tensor.

Without a written workflow, the next agent facing this has no way to know that these are
separate layers, that a passing `mm` proves nothing about the scaler, or that a passing
FP16 result proves nothing about BF16.

### Why did it happen?
The AMP skill set was written from a validation perspective. Validation reports pass/fail
for one path; development requires classifying which of registration, policy, cast,
runtime, scaler, training, or communication is failing, and fixing exactly that layer.
Those are different procedures, and only the first existed.

### Investigation process:
1. Read the existing `.claude/skills/amp-integration/SKILL.md`, `cuda-compat-vendor`,
   `native-op-backend`, `flaggems-integration`, `flagcx-integration`, `runtime-bringup`,
   `torch-version-port`, and `pre-pr-checks` skills to avoid duplicating their scope and
   to link to them instead of restating their rules.
2. Reconstructed the #210 debugging path from the code it landed: `csrc/aten/autocast.cc`
   compile guard, `csrc/aten/copy_ops.cc` portable conversion path plus
   `SyncCurrentStreamBeforeBlockingCopy()`, `csrc/aten/amp_ops.{h,cc}` CPU-staged finite
   check, and the `gen_foreach` branch in `scripts/codegen_ops.py`.
3. Executed each prescribed command on Kunlun P800 XPU and corrected the ones that did
   not work, rather than shipping untested instructions. Three prescriptions failed and
   were rewritten (see Manual Verification).
4. Read `tests/integration/test_amp.py` on this branch to make every test reference
   resolve against the `2.9` layout.
5. Validated the finished document programmatically: frontmatter, section and phase
   numbering, code fence balance, every `[[wiki-link]]` resolving to an existing
   `.claude/skills/<name>/SKILL.md`, and every referenced repository path existing.

## Solution Design

### Implementation approach:
A single skill file with nine phases, each ending in an evidence gate:

- Phase 0 establishes a development ledger and prints the resolved environment.
- Phase 1 reproduces the failure and classifies it into exactly one primary layer using a
  symptom table.
- Phase 2 lists the files to read and links to the platform-specific skills.
- Phase 3 is a measured-condition to strategy decision table.
- Phase 4 covers autocast registration, GradScaler, and test implementation rules.
- Phase 5 regenerates artifacts and proves idempotency.
- Phase 6 builds and runs the gates in dependency order.
- Phase 7 is the completion matrix; an unproven gate must be labeled `not validated`,
  `blocked`, or `not revalidated`.
- Phase 8 is commit and PR automation.

### Key design decisions:
**Layer classification before editing.** The symptom table maps
`cudaErrorInvalidDeviceFunction` during cast to the vendor cast path, and a non-finite
check crash to the scaler kernel. Both were misdiagnosable as autocast policy bugs, and
"change the policy so the failing kernel is never called" is explicitly forbidden.

**Codegen exit status is checked before comparing patches.** The obvious idempotency check
(run twice, diff the diffs) reports success when the generator fails twice and writes
nothing. The skill requires `set -eu` and an explicit exit status, because this exact false
pass occurred during development.

**Build through `setup.py`, not bare `cmake`.** `setup.py` supplies `PYTHON_INCLUDE_DIR`,
`PYTORCH_INSTALL_DIR`, and `CMAKE_INSTALL_PREFIX`, and writes `torch_fl/_build_config.py`,
which the test gates read. A bare `cmake -S . -B <dir> -DACCELERATOR=<vendor>` fails with
`Cannot find Python directory`.

**`import torch_fl` before reading the device key.** The PrivateUse1 rename to `flagos`
happens at torch_fl import. Reading the key first yields `privateuseone` and every
subsequent autocast and device string is wrong.

**Host-staged workarounds must be labeled correctness-first.** The Kunlun cast and scaler
paths stage through CPU and synchronize before blocking copies. The skill requires
documenting the runtime error that forced it, the synchronization point, and the follow-up
for a device-side implementation, so it is never reported as a performance implementation.

**Link rather than restate.** Platform-specific rules stay in `native-op-backend`,
`cuda-compat-vendor`, and `flaggems-integration`.

### Code changes by file:
- `.claude/skills/amp-development/SKILL.md` (new, 459 lines): the AMP development workflow
  described above. No other file is touched.

### Changes by commit:
1. `54e0392` - `feat: add automated AMP development skill`: adds the skill in one commit
   because it is a single self-contained document.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (if applicable) - not applicable, no Python changed
- [ ] **All tests pass** (unit + integration) - AMP/config integration tests pass; the broad unit suite has pre-existing vendor failures documented below
- [x] **Manual testing completed** (include reproduction of original issue)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [x] **Documentation updated** (README, CLAUDE.md, docstrings as needed)
- [x] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
```bash
$ ruff check .
All checks passed!
ruff check exit=0

$ ruff format --check .
173 files already formatted
ruff format exit=0

$ /flagos/bin/python -m compileall -q torch_fl tests
compileall exit=0

$ git diff --check
diff-check exit=0
```

### Test Results
Hardware: Kunlun P800 XPU, XPU-RT 5.37.1, 8 visible devices.
Interpreter: `/flagos/bin/python` 3.10.20, torch 2.9.0+cu129,
`ACCELERATOR=kunlun`, device key `flagos`, device `flagos:0`.

```bash
# Command:
ACCELERATOR=kunlun /flagos/bin/python -m pytest tests/integration/test_amp.py -v

# Output:
platform linux -- Python 3.10.20, pytest-9.1.1, pluggy-1.6.0 -- /flagos/bin/python
collected 15 items

tests/integration/test_amp.py::test_float64_copy_preserves_dtype PASSED  [  6%]
tests/integration/test_amp.py::test_autocast_lower_precision[dtype0] PASSED [ 13%]
tests/integration/test_amp.py::test_autocast_lower_precision[dtype1] PASSED [ 20%]
tests/integration/test_amp.py::test_autocast_fp32[dtype0] PASSED         [ 26%]
tests/integration/test_amp.py::test_autocast_fp32[dtype1] PASSED         [ 33%]
tests/integration/test_amp.py::test_autocast_fp32_set_optional_dtype[dtype0] PASSED [ 40%]
tests/integration/test_amp.py::test_autocast_fp32_set_optional_dtype[dtype1] PASSED [ 46%]
tests/integration/test_amp.py::test_autocast_promote[dtype0] PASSED      [ 53%]
tests/integration/test_amp.py::test_autocast_promote[dtype1] PASSED      [ 60%]
tests/integration/test_amp.py::test_autocast_nested_state PASSED         [ 66%]
tests/integration/test_amp.py::test_binary_cross_entropy_is_banned_under_autocast PASSED [ 73%]
tests/integration/test_amp.py::test_amp_unscale_detects_non_finite_values PASSED [ 80%]
tests/integration/test_amp.py::test_autocast_grad_scaler_training_step PASSED [ 86%]
tests/integration/test_amp.py::test_grad_scaler_finite_step_and_growth PASSED [ 93%]
tests/integration/test_amp.py::test_grad_scaler_overflow_skips_step_and_backs_off PASSED [100%]

============================== 15 passed in 0.21s ==============================
amp exit=0
```

```bash
# Command:
ACCELERATOR=kunlun /flagos/bin/python -m pytest \
  tests/integration/ops/test_flaggems_conf_consistency.py -v

# Output:
collected 8 items
... test_conf_has_flagos_python_ops PASSED                               [ 12%]
... test_every_conf_op_maps_to_a_dispatcher PASSED                       [ 25%]
... test_conf_ops_have_flagos_python_kernels PASSED                      [ 37%]
... test_override_only_ops_are_not_default_routes PASSED                 [ 50%]
... test_no_orphan_flagos_python_kernels PASSED                          [ 62%]
... test_counts_match PASSED                                             [ 75%]
... test_kunlun_config_has_only_measured_routes PASSED                   [ 87%]
... test_kunlun_routes_have_flaggems_kernels PASSED                      [100%]

============================== 8 passed in 0.35s ===============================
conf exit=0
```

**Pre-existing unit test failures, reported honestly.** The broad unit suite is not green
on this box, both with and without this change:

```bash
# With this change:
$ ACCELERATOR=kunlun /flagos/bin/python -m pytest tests/unit/ -q
36 failed, 58 passed, 28 skipped, 2 warnings in 7.64s

# Same command with the change stashed (base = cbf3eda):
$ git stash push --include-untracked && \
  ACCELERATOR=kunlun /flagos/bin/python -m pytest tests/unit/ -q
36 failed, 58 passed, 28 skipped, 2 warnings in 7.56s
```

Identical counts at base and at HEAD. The failures are pre-existing BPU x86 stub and
PrivateUse1 profiler gaps on this environment, not caused by a markdown-only change, and
this PR does not claim to fix them.

### Manual Verification
The point of manual verification here is that the skill's own prescriptions execute
correctly. Three did not, and were fixed.

```bash
# 1. Phase 0 environment probe, as written in the skill
$ unset XPU_CUPTI_ENABLE_DEVICE; export XPU_ENABLE_PROFILER_TRACING=1
$ /flagos/bin/python <the Phase 0 probe>
python 3.10.20
torch 2.9.0+cu129
torch_file /flagos/lib/python3.10/site-packages/torch/__init__.py
torch_fl_file /public-flash/lvyufeng/Torch-FL/torch_fl/__init__.py
build_accelerator kunlun
env_accelerator <unset>
device_key flagos
backend_config /public-flash/lvyufeng/Torch-FL/torch_fl/configs/backends_cuda.conf
flag_gems True
flagcx True
ext_file /public-flash/lvyufeng/Torch-FL/torch_fl/_C.cpython-310-x86_64-linux-gnu.so
device_count 8
probe exit=0

# BEFORE fix: the probe read the device key before importing torch_fl and printed
#   privateuseone
# which would make every autocast/device string in the workflow wrong.
# AFTER fix: torch_fl is imported first and the key reads flagos.

# 2. Phase 5 codegen idempotency gate, as written in the skill
$ FLAGOS_CODEGEN_ALL=1 /flagos/bin/python scripts/codegen_ops.py   # twice
run1 exit=0
run2 exit=0
AMP codegen idempotent

# BEFORE fix: the gate had no `set -eu` and no exit status check, so two failed
# generator runs producing identical empty patches printed "idempotent".
# AFTER fix: exit status is checked before the patches are compared.
#
# Note: the full-scope generator on this box also rewrites FlagGems artifacts
# (flaggems_python_kernels.cc and three backends_*_flaggems.conf files) from the
# locally installed flag_gems version. That is pre-existing generator drift, not
# part of this change; it was restored with git checkout and the tree was
# confirmed byte-identical to its pre-codegen state. The skill's Phase 5 requires
# exactly this: isolate the intended delta, restore unrelated drift.

# 3. Phase 6 build prescription
# BEFORE fix: the skill prescribed bare cmake:
#   cmake -S . -B /tmp/torch-fl-amp-build -DACCELERATOR=kunlun ...
#   CMake Error at CMakeLists.txt:640 (message):
#     Cannot find Python directory
# AFTER fix: the skill prescribes setup.py, which supplies the variables the
# top-level CMakeLists.txt requires. The Kunlun AMP runtime in #210 was built
# this way:
#   build exit=0
#   [100%] Built target torch_bindings

# 4. Document structure validation
$ /flagos/bin/python <structure checker>
lines 459
fences 20 balanced
sections 14 phases [0, 1, 2, 3, 4, 5, 6, 7, 8]
links PASS
paths 14 PASS
main-only refs none
```

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (no reinventing)

The frontmatter shape, heading structure, `[[wiki-link]]` cross-references, and
evidence-gate style follow the existing `amp-integration`, `flagcx-integration`, and
`flaggems-integration` skills on this branch.

### Edge Cases Considered
1. **Stale extension.** Phase 6 requires printing `torch_fl.__file__` and
   `torch_fl._C.__file__` so results are never attributed to a stale library.
2. **Wrong-vendor build.** Phase 0 compares `_build_config.ACCELERATOR` against the
   requested `ACCELERATOR`; a mismatch invalidates every AMP result from that extension.
3. **Codegen false pass.** Covered above: exit status before patch comparison.
4. **Unrelated generator drift.** Phase 5 requires reviewing every generated file and
   restoring drift instead of bundling it. Exercised in this PR, as shown above.
5. **Device key timing.** `import torch_fl` before reading the PrivateUse1 name.
6. **Skip treated as pass.** A skip is defined as an evidence gap requiring the
   interpreter, reason, and hardware availability to be recorded.
7. **Dtype overclaim.** FP16 evidence does not establish BF16 or a vendor-specific dtype.
8. **Distributed overclaim.** Single-device eager training does not establish DDP or FSDP2.
9. **Branch layout drift.** All test references resolve against this branch's
   `tests/integration/test_amp.py`; verified by the path checker.

### Potential Risks
1. **Instructions can go stale.** Hard-coded paths such as `/usr/local/xpu` and the
   `test_amp.py` reference will drift if the layout changes. Mitigated by validating every
   referenced path at authoring time and by deferring to the vendor installation docs as
   authoritative for build flags.
2. **Prescriptive build guidance could mislead on another vendor.** The build snippet is
   explicitly labeled as the Kunlun XPU invocation, and the skill directs the reader to
   the vendor installation document rather than reconstructing flags.
3. **No runtime risk.** Documentation only; no code, generated artifact, or config
   changes, so no platform can regress from merging this.

### Rollback Plan
`git revert 54e0392`, or delete `.claude/skills/amp-development/SKILL.md`. Nothing depends
on the file at build or run time.

## Related Work
- Related to #210 (AMP support for Kunlun P800 XPU) - the runtime work this skill
  generalizes.
- Related to #197 (fail-closed FlagCX validation) - same evidence-gate discipline.
- Related to #183 (measured FlagGems Python routes on Kunlun P800).

## Explicitly Not Included
- No change to AMP runtime code, generated artifacts, or routing configuration. #210
  already landed the Kunlun P800 XPU AMP runtime.
- No new or modified tests. The skill references the existing
  `tests/integration/test_amp.py` suite rather than adding coverage.
- No device-side replacement for the host-staged Kunlun cast and GradScaler paths. The
  skill documents them as correctness-first with a follow-up needed; the optimization is
  separate work.
- No AMP performance measurement. Kunlun AMP throughput is not characterized, and the
  skill requires reporting it as not validated rather than inferring it.
- No distributed AMP validation. Not run for this PR, so it is reported as not validated.
- No BF16 claim beyond what `tests/integration/test_amp.py` measures.
- No update to `docs/reference/operator-support.md`. This change neither adds, enables,
  removes, disables, nor reroutes any operator, so the CLAUDE.md operator-record rule does
  not apply.

## Human Review Notes

### Areas needing special attention:
1. **Scope boundary against `amp-integration`.** Please confirm the split is right:
   `amp-integration` validates, `amp-development` changes the repository. If reviewers
   prefer a single skill, this should be merged into `amp-integration` instead.
2. **Accuracy of the Phase 1 symptom table.** Each row comes from a real failure observed
   during the #210 work. Reviewers with DCU, Ascend, MetaX, or GCU experience should check
   whether any row misleads on their platform.
3. **Phase 6 build prescription.** Verified on Kunlun P800 XPU only. Reviewers should check
   whether the `setup.py build_ext --inplace` guidance holds for their vendor flow.

### Questions for reviewer:
1. Should this land on `main` as well? An equivalent `main`-targeted PR (#232) exists and
   references `main`'s `test_amp_contract.py` / `amp_support.py` layout; the two branches
   have diverged in AMP test structure, so they cannot share one file verbatim.
2. Should the skill hard-code the Kunlun paths at all, or only point at the vendor
   installation document?

## Additional Context
Full environment identity for the results above: Kunlun P800 XPU, XPU-RT 5.37.1, 8 visible
devices, `/flagos/bin/python` 3.10.20, torch 2.9.0+cu129, `ACCELERATOR=kunlun`, device key
`flagos`, backend config `torch_fl/configs/backends_cuda.conf`, base commit `cbf3eda`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
