### PR TITLE
feat: run HuggingFace official tests per model on accelerators

### DIFF
--- a/.claude/skills/hf-coverage-survey/SKILL.md
+++ b/.claude/skills/hf-coverage-survey/SKILL.md
@@ -43,8 +43,8 @@ Default to the latest `transformers`. Pin an older line only to reproduce a
 known-good state or to check a regression:
 
 ```bash
-python tests/manual/hf_model_probe.py --model qwen3
-python tests/manual/hf_model_probe.py --model qwen3 --transformers-version 4.50.2
+python tests/manual/transformers_model_probe.py --model qwen3
+python tests/manual/transformers_model_probe.py --model qwen3 --transformers-version 4.50.2
 ```
 
 Install each requested `transformers` into its own cached virtual environment
@@ -72,15 +72,22 @@ environment failure, not a coverage data point.
 
 ## Step 2 — inject `flagos` as the HF test device
 
-`transformers` supports a third-party device through two environment variables
-and a spec module. It validates only that the device name is constructible by
-`torch.device`, so `flagos` is accepted without patching HF:
+`transformers` supports a third-party device through a device-spec module.
+The spec imports `torch_fl`, registers the PrivateUse1 name, and supplies the
+backend hooks that HuggingFace needs:
 
 ```bash
-export TRANSFORMERS_TEST_DEVICE=flagos
 export TRANSFORMERS_TEST_DEVICE_SPEC=tests/manual/hf_device_spec.py
-export RUN_THIRD_PARTY_DEVICE_TESTS=1
 ```
+
+Do not set `TRANSFORMERS_TEST_DEVICE=flagos` for Transformers 5.16.1: that
+release validates the variable with `torch.device()` before importing the spec,
+so a custom PrivateUse1 name is not accepted at that point. The spec's
+`DEVICE_NAME` becomes the effective test device after it is loaded.
+
+For built-in devices, `TRANSFORMERS_TEST_DEVICE` remains available as an
+alternative to a spec file.
+
 
 The spec module must define `DEVICE_NAME` plus the three backend hooks HF
 dispatches on; a missing hook raises at import unless HF has a default:
@@ -97,11 +104,29 @@ Note the gating split this produces, and do not try to defeat it:
 `require_torch_gpu` skips because it compares against `cuda` literally. Cases
 skipped by `require_torch_gpu` are CUDA-specific and are not coverage gaps.
 
-The `transformers` wheel ships no `tests/` directory. The per-model probe in
-this skill therefore does not need an HF source checkout. A checkout is required
-only for the optional `--hf-tests` mode, and its `git describe` must match the
-installed `transformers` version — a version-mismatched checkout produces
-failures that belong to HF, not to torch_fl.
+The `transformers` wheel ships no `tests/` directory. The synthetic probe
+(`tests/manual/transformers_model_probe.py`) does not need an HF source checkout.
+To run HuggingFace's own assertions, use the official runner:
+
+```bash
+python tests/manual/transformers_hf_tests.py --model qwen3
+```
+
+It obtains a cached source tree for the exact installed version, verifies the
+version declared by `src/transformers/__init__.py`, and runs only
+`tests/models/<module>/` for that architecture. Set `--source-dir` to use a
+prepared tree, or use `--offline` to require an existing versioned cache. A
+version-mismatched source tree produces failures that belong to HF, not to
+torch_fl. The runner injects `flagos` through
+`TRANSFORMERS_TEST_DEVICE_SPEC=tests/manual/hf_device_spec.py`.
+
+The actual device contract used here is `TRANSFORMERS_TEST_DEVICE_SPEC` and
+the three hooks in the spec module. No third-party test switch or other
+pass-oriented environment override is added.
+
+The official runner preserves per-test JSON evidence and does not create issues.
+Baseline promotion, fingerprint deduplication, and GitHub issue creation remain
+a separate opt-in follow-up.
 
 ## Step 3 — probe one model in layers
 
@@ -227,13 +252,16 @@ The first run on a platform records a baseline and files nothing. Later runs
 file only fingerprints absent from the baseline. Issue filing stays opt-in:
 
 ```bash
-# first run on a platform: record the baseline, file nothing
-python tests/manual/hf_model_probe.py --model qwen3 --promote-baseline
-
-# later runs: file only newly appeared failures
-python tests/manual/hf_model_probe.py --model qwen3 \
-  --baseline docs/reference/hf-coverage-baseline-musa.json --file-issues
+# first run on a platform: keep the JSON as the baseline, file nothing
+python tests/manual/transformers_hf_tests.py --model qwen3 \
+  --out results/musa/qwen3.json
 ```
+
+Baseline promotion, fingerprint diffing, and issue filing are not implemented in
+either harness yet. Both write per-result JSON with normalized failure
+fingerprints; the reporter that compares against a baseline and writes to the
+tracker is a separate change. Until it exists, filing is a manual decision made
+from the JSON, not something a run performs.
 
 Default to report-only. Opening issues writes to a shared tracker and cannot be
 cleanly undone, so it must be requested explicitly rather than inferred.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -144,6 +144,46 @@ in the installed version. Issue filing is intentionally not part of this probe;
 a future reporter consumes its JSON after fingerprint deduplication and a
 baseline comparison.
 
+### Official HuggingFace per-model tests
+
+`tests/manual/transformers_hf_tests.py` runs HuggingFace's official test files for
+one architecture at a time. It selects only
+`transformers/tests/models/<module>/`, where the module name is resolved by
+Transformers' `model_type_to_module_name()` (for example, `blip-2` maps to
+`blip_2`). Each invocation uses a fresh subprocess so an accelerator fault does
+not contaminate another model's result.
+
+The installed Transformers wheel does not include its `tests/` tree. The runner
+caches the complete, version-matched source tree under
+`~/.cache/torch_fl/hf-tests/transformers-<version>/` (or `HF_COVERAGE_CACHE` /
+`--cache-dir`) and verifies the source declaration against the installed wheel.
+Use `--source-dir` for an already prepared checkout. It never installs or
+upgrades torch or Transformers. Install the requested wheel without dependencies
+so the PyTorch build used by torch-fl remains unchanged:
+
+```bash
+python -m pip install --no-deps transformers==5.16.1
+TORCH_DEVICE_BACKEND_AUTOLOAD=0 \
+python tests/manual/transformers_hf_tests.py \
+  --model qwen3 --transformers-version 5.16.1 --out /tmp/qwen3-official.json
+```
+
+The runner injects `flagos` through Transformers' official
+`TRANSFORMERS_TEST_DEVICE_SPEC` contract using
+`tests/manual/hf_device_spec.py`. The spec imports torch-fl before declaring the
+PrivateUse1 device name; this is required because Transformers 5.16.1 validates
+`TRANSFORMERS_TEST_DEVICE` with `torch.device()` before it loads a custom spec.
+CUDA-only tests remain upstream skips and are recorded separately from ordinary
+skips. Per-test JSON evidence includes the
+pytest node ID, status, duration, failure detail, and captured output; collection
+errors, missing optional dependencies, timeouts, and accelerator crashes are
+kept distinct. `--offline` requires a previously cached source tree and also
+sets the HuggingFace offline environment variables.
+
+This runner is an execution and evidence tool only. It does not create GitHub
+issues. Baseline promotion, failure fingerprinting, duplicate search, and issue
+comments/creation will consume these JSON results in a separate follow-up.
+
 ### Model Tests
 
 Model integration tests accept command-line options for model path and hyperparameters.

--- a/tests/manual/hf_device_spec.py
+++ b/tests/manual/hf_device_spec.py
@@ -1,0 +1,40 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""HuggingFace test device specification for the ``flagos`` accelerator.
+
+``transformers.testing_utils`` imports this module when
+``TRANSFORMERS_TEST_DEVICE_SPEC`` points at it, and merges the hooks below into
+its ``BACKEND_*`` dispatch tables. That is the whole custom-device contract: HF
+validates only that ``DEVICE_NAME`` is constructible by ``torch.device``, so no
+patch of the official tests is needed.
+
+Importing ``torch_fl`` here is what registers the device; without it
+``torch.flagos`` does not exist and HF raises while loading the spec.
+
+The gating split this produces is deliberate. ``require_torch_accelerator``
+passes because the device is neither CPU nor None, so device-agnostic tests run
+on the accelerator. ``require_torch_gpu`` compares against ``cuda`` literally
+and therefore skips, which is correct: those cases are CUDA-specific and are not
+coverage gaps for this platform.
+"""
+
+import torch
+
+import torch_fl  # noqa: F401 - registers the flagos device on torch
+
+DEVICE_NAME = "flagos"
+
+MANUAL_SEED_FN = torch.flagos.manual_seed
+EMPTY_CACHE_FN = torch.flagos.empty_cache
+DEVICE_COUNT_FN = torch.flagos.device_count

--- a/tests/manual/transformers_hf_source.py
+++ b/tests/manual/transformers_hf_source.py
@@ -1,0 +1,326 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Locate an exact-version Transformers source tree for the official tests.
+
+The published wheel does not contain ``tests/``.  The runner therefore uses the
+source archive for the same release as the installed wheel.  The archive is
+kept intact while validating paths and links because official tests import
+repository fixtures outside ``tests/`` as well as shared files inside it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+import urllib.request
+from importlib.metadata import PackageNotFoundError, version as package_version
+from pathlib import Path
+
+PYPI_TRANSFORMERS_JSON = "https://pypi.org/pypi/transformers/json"
+ARCHIVE_URL = (
+    "https://codeload.github.com/huggingface/transformers/tar.gz/refs/tags/v{version}"
+)
+DEFAULT_CACHE = Path.home() / ".cache" / "torch_fl" / "hf-tests"
+CACHE_FORMAT = 2
+CACHE_MARKER = ".torch-fl-hf-source"
+VERSION_FILE = Path("src") / "transformers" / "__init__.py"
+
+
+class SourceError(RuntimeError):
+    """A source tree could not be obtained, so no test result is attributable."""
+
+
+def atomic_write(path: Path, value: object) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=path.name, dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(value, f, indent=1, sort_keys=True)
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def installed_transformers() -> str | None:
+    try:
+        return package_version("transformers")
+    except PackageNotFoundError:
+        return None
+
+
+def latest_transformers(timeout: int = 30) -> str | None:
+    """Resolve the newest published release, or None when offline."""
+    try:
+        with urllib.request.urlopen(PYPI_TRANSFORMERS_JSON, timeout=timeout) as resp:
+            return json.load(resp)["info"]["version"]
+    except Exception:  # noqa: BLE001 - offline is normal on a vendor box
+        return None
+
+
+def resolve_version(requested: str, offline: bool) -> dict:
+    """Require the requested source and installed wheel versions to match."""
+    have = installed_transformers()
+    if have is None:
+        raise SourceError(
+            "transformers is not installed in this interpreter.\n"
+            "Install it without touching torch:\n"
+            "  python -m pip install --no-deps transformers==<version>"
+        )
+    record = {
+        "requested": requested,
+        "installed": have,
+        "latest": None,
+        "version": have,
+    }
+    if requested == "latest":
+        if not offline:
+            record["latest"] = latest_transformers()
+        return record
+    if have != requested:
+        raise SourceError(
+            f"requested transformers {requested} but {have} is installed.\n"
+            "The official tests must run against the version they ship with.\n"
+            f"  python -m pip install --no-deps transformers=={requested}"
+        )
+    return record
+
+
+def cache_root(cache_dir: str | os.PathLike[str] | None = None) -> Path:
+    """Where source trees are kept, one directory per Transformers version."""
+    if cache_dir:
+        return Path(cache_dir).expanduser()
+    if value := os.environ.get("HF_COVERAGE_CACHE"):
+        return Path(value).expanduser()
+    return DEFAULT_CACHE
+
+
+def source_dir(version: str, cache_dir: str | os.PathLike[str] | None = None) -> Path:
+    return cache_root(cache_dir) / f"transformers-{version}"
+
+
+def source_version(path: str | os.PathLike[str]) -> str | None:
+    """Read the version declared by a source tree, or None if it is absent."""
+    try:
+        text = (Path(path) / VERSION_FILE).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("__version__"):
+            _, _, value = stripped.partition("=")
+            return value.strip().strip("\"'") or None
+    return None
+
+
+def _cache_marker(path: Path) -> dict | None:
+    try:
+        value = json.loads((path / CACHE_MARKER).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def is_usable(path: str | os.PathLike[str], version: str) -> bool:
+    """Only reuse complete archives created by the current cache format."""
+    root = Path(path)
+    marker = _cache_marker(root)
+    return bool(
+        marker
+        and marker.get("format") == CACHE_FORMAT
+        and marker.get("version") == version
+        and (root / "tests" / "models").is_dir()
+        and source_version(root) == version
+    )
+
+
+def _safe_members(tar: tarfile.TarFile, prefix: str):
+    """Yield archive members whose paths and links stay below ``prefix``."""
+    root = f"{prefix}/"
+    for member in tar.getmembers():
+        name = member.name
+        if name == prefix:
+            relative = "."
+        else:
+            if not name.startswith(root):
+                raise SourceError(
+                    f"archive member is outside its top-level directory: {name}"
+                )
+            relative = name[len(root) :]
+            resolved = os.path.normpath(relative)
+            if (
+                not relative
+                or os.path.isabs(relative)
+                or resolved == ".."
+                or resolved.startswith("../")
+            ):
+                raise SourceError(f"refusing to extract unsafe archive member: {name}")
+
+        if member.issym():
+            link_target = member.linkname
+            resolved = os.path.normpath(
+                os.path.join(os.path.dirname(relative), link_target)
+            )
+            if (
+                not link_target
+                or os.path.isabs(link_target)
+                or resolved == ".."
+                or resolved.startswith("../")
+            ):
+                raise SourceError(f"refusing to extract unsafe archive link: {name}")
+        elif member.islnk():
+            # Tar hard-link targets are archive paths, unlike symlink targets,
+            # but accept a prefix-relative form as well for portability.
+            link_target = member.linkname
+            if link_target.startswith(root):
+                link_target = link_target[len(root) :]
+            resolved = os.path.normpath(link_target)
+            if (
+                not link_target
+                or os.path.isabs(link_target)
+                or resolved == ".."
+                or resolved.startswith("../")
+            ):
+                raise SourceError(f"refusing to extract unsafe archive link: {name}")
+
+        yield member
+
+
+def _archive_prefix(names: list[str]) -> str:
+    prefixes = {name.split("/", 1)[0] for name in names if name}
+    if len(prefixes) != 1:
+        raise SourceError("archive must contain exactly one top-level directory")
+    return prefixes.pop()
+
+
+def _extract_complete_archive(archive: Path, staging: Path) -> Path:
+    with tarfile.open(archive, "r:gz") as tar:
+        names = tar.getnames()
+        if not names:
+            raise SourceError(f"archive {archive} is empty")
+        prefix = _archive_prefix(names)
+        tar.extractall(staging, members=list(_safe_members(tar, prefix)))
+    return staging / prefix
+
+
+def _write_cache_marker(root: Path, version: str) -> None:
+    atomic_write(root / CACHE_MARKER, {"format": CACHE_FORMAT, "version": version})
+
+
+def _validate_extracted(root: Path, archive: Path) -> str:
+    version = source_version(root)
+    if not (root / "tests" / "models").is_dir() or version is None:
+        raise SourceError(
+            f"archive {archive} is missing the official tests or version marker"
+        )
+    return version
+
+
+# Keep extraction in a small function so the security-sensitive member filter
+# remains separately testable and the cache operation stays easy to audit.
+def extract_archive(
+    archive: str | os.PathLike[str], dest: str | os.PathLike[str]
+) -> Path:
+    """Safely extract the complete archive into an atomic versioned cache."""
+    dest = Path(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f"{dest.name}.partial-", dir=dest.parent))
+    try:
+        unpacked = _extract_complete_archive(Path(archive), staging)
+        version = _validate_extracted(unpacked, Path(archive))
+        _write_cache_marker(unpacked, version)
+        if dest.exists():
+            shutil.rmtree(dest)
+        os.replace(unpacked, dest)
+    except tarfile.TarError as exc:
+        raise SourceError(f"could not read archive {archive}: {exc}") from exc
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+    return dest
+
+
+def download_archive(
+    version: str, dest: str | os.PathLike[str], timeout: int = 300
+) -> Path:
+    url = ARCHIVE_URL.format(version=version)
+    dest = Path(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=f"{dest.name}.", dir=dest.parent)
+    os.close(fd)
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp, open(
+            tmp, "wb"
+        ) as out:
+            shutil.copyfileobj(resp, out)
+        os.replace(tmp, dest)
+    except Exception as exc:  # noqa: BLE001 - network and HTTP errors read alike here
+        raise SourceError(
+            f"could not download the transformers {version} source from {url}: {exc}\n"
+            "Provide a prepared tree with --source-dir, or point --cache-dir at one."
+        ) from exc
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+    return dest
+
+
+def ensure_source(
+    version: str,
+    cache_dir: str | os.PathLike[str] | None = None,
+    offline: bool = False,
+    timeout: int = 300,
+) -> dict:
+    """Return a complete exact-version source tree, downloading when needed."""
+    target = source_dir(version, cache_dir)
+    if is_usable(target, version):
+        return {"path": str(target), "version": version, "downloaded": False}
+    if offline:
+        raise SourceError(
+            f"no complete cached transformers {version} source at {target} and --offline "
+            "was requested. Prepare the tree once with network access, or pass --source-dir."
+        )
+    archive = cache_root(cache_dir) / f"transformers-v{version}.tar.gz"
+    download_archive(version, archive, timeout=timeout)
+    extract_archive(archive, target)
+    if not is_usable(target, version):
+        raise SourceError(
+            f"downloaded source at {target} declares transformers {source_version(target)}, "
+            f"expected {version}"
+        )
+    return {"path": str(target), "version": version, "downloaded": True}
+
+
+def use_source(
+    version: str,
+    source_dir_override: str | os.PathLike[str] | None,
+    cache_dir: str | os.PathLike[str] | None,
+    offline: bool,
+    timeout: int = 300,
+) -> dict:
+    """Resolve either an explicitly supplied checkout or the versioned cache."""
+    if source_dir_override:
+        path = Path(source_dir_override).expanduser().resolve()
+        found = source_version(path)
+        if not (path / "tests" / "models").is_dir():
+            raise SourceError(f"{path} has no tests/models directory")
+        if found != version:
+            raise SourceError(
+                f"source tree {path} declares transformers {found}, but {version} is installed."
+            )
+        return {"path": str(path), "version": version, "downloaded": False}
+    return ensure_source(version, cache_dir=cache_dir, offline=offline, timeout=timeout)

--- a/tests/manual/transformers_hf_tests.py
+++ b/tests/manual/transformers_hf_tests.py
@@ -1,0 +1,709 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run HuggingFace's own tests for one model architecture on an accelerator.
+
+This is a manual hardware measurement, not a pytest test: CI does not invoke
+files in ``tests/manual``. Where ``transformers_model_probe.py`` builds a tiny
+model and probes four layers of its own design, this runner executes the
+assertions HuggingFace maintains for the architecture --- everything under
+``tests/models/<module>/`` in the transformers source tree that matches the
+installed wheel.
+
+The unit of work is one architecture per invocation, in its own subprocess. A
+sweep is an external loop. Accelerator faults are not contained: one illegal
+memory access poisons the device context, after which every later test in the
+same process fails with the same symptom, so a poisoned run is reported as one
+finding for the model rather than as a list of independent failures.
+
+Usage:
+  python tests/manual/transformers_hf_tests.py --model qwen3
+  python tests/manual/transformers_hf_tests.py --model qwen3 --out /tmp/qwen3.json
+  python tests/manual/transformers_hf_tests.py --model blip-2 --collect-only
+  python tests/manual/transformers_hf_tests.py --list-models
+
+Issue filing is deliberately not part of this runner. It writes an auditable
+JSON result that a later reporter consumes, so that executing tests and writing
+to a shared tracker stay separable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from transformers_hf_source import (  # noqa: E402 - local manual-test helper
+    SourceError,
+    atomic_write,
+    resolve_version,
+    use_source,
+)
+
+HARNESS_VERSION = 1
+SCHEMA_VERSION = 1
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEVICE_SPEC = Path(__file__).resolve().parent / "hf_device_spec.py"
+
+# One illegal access poisons the device context for the rest of the process.
+# Same pattern set as the model probe, so both harnesses call a fault a fault.
+POISON_RE = re.compile(
+    r"illegal memory access|device-side assert|unspecified launch failure|"
+    r"misaligned address|vmfault|acceleratorerror",
+    re.IGNORECASE,
+)
+
+# ``require_torch_gpu`` and its relatives compare against ``cuda`` literally, so
+# they skip on any other accelerator. Those cases are CUDA-specific and are not
+# coverage gaps for this platform; keeping them separate from ordinary skips is
+# what stops a report from inflating its own denominator.
+CUDA_ONLY_RE = re.compile(
+    r"requires? (a )?(cuda|gpu|rocm)|cuda gpu|rocm|nvidia|"
+    r"test requires multiple cuda|bitsandbytes|flash.?attn",
+    re.IGNORECASE,
+)
+
+# A missing optional dependency is an environment gap, not a platform defect:
+# the official suite pulls accelerate, datasets, librosa, peft and more, and a
+# box without them never ran the assertion at all.
+ENVIRONMENT_RE = re.compile(
+    r"No module named|ModuleNotFoundError|ImportError|"
+    r"is not installed|requires the .{0,40} library|cannot import name",
+    re.IGNORECASE,
+)
+
+STATUSES = (
+    "PASS",
+    "FAIL",
+    "ERROR",
+    "XFAIL",
+    "XPASS",
+    "SKIP_CUDA_ONLY",
+    "SKIP_OTHER",
+    "ENVIRONMENT_ERROR",
+    "COLLECT_ERROR",
+)
+
+MARK = "@@HFTEST@@"
+
+
+# The plugin runs inside the pytest subprocess. It is written to a temporary
+# file and loaded with ``-p`` rather than added as a dependency: a new runtime
+# dependency for a manual harness would have to be installed on every vendor box
+# before that box could be measured at all.
+PLUGIN = r"""
+import json
+import os
+
+
+def _text(value):
+    if value is None:
+        return None
+    return str(value)[:8000]
+
+
+class Recorder:
+    def __init__(self, path):
+        self.path = path
+        self.records = []
+
+    def add(self, record):
+        self.records.append(record)
+        # Append as we go: a fault that kills the interpreter still leaves the
+        # tests that already finished on disk.
+        with open(self.path, "a") as f:
+            f.write(json.dumps(record) + "\n")
+            f.flush()
+
+    def pytest_runtest_logreport(self, report):
+        if report.when == "call" or report.outcome == "failed" or report.skipped:
+            self.add(
+                {
+                    "kind": "test",
+                    "nodeid": report.nodeid,
+                    "when": report.when,
+                    "outcome": report.outcome,
+                    "duration": getattr(report, "duration", None),
+                    "wasxfail": getattr(report, "wasxfail", None) is not None,
+                    "longrepr": _text(report.longrepr),
+                    "sections": [
+                        [name, _text(content)] for name, content in report.sections[:6]
+                    ],
+                }
+            )
+
+    def pytest_collectreport(self, report):
+        if report.failed:
+            self.add(
+                {
+                    "kind": "collect",
+                    "nodeid": report.nodeid,
+                    "outcome": "failed",
+                    "longrepr": _text(report.longrepr),
+                }
+            )
+
+    def pytest_collection_finish(self, session):
+        self.add({"kind": "collected", "count": len(session.items)})
+
+
+def pytest_configure(config):
+    path = os.environ["HF_TEST_REPORT"]
+    config.pluginmanager.register(Recorder(path), "torch_fl_hf_recorder")
+"""
+
+
+def classify_skip(reason: str | None) -> str:
+    """Split a skip into CUDA-only and everything else."""
+    if reason and CUDA_ONLY_RE.search(reason):
+        return "SKIP_CUDA_ONLY"
+    return "SKIP_OTHER"
+
+
+def classify_failure(detail: str | None) -> str:
+    """Decide whether a failure is a platform result or environment noise."""
+    if detail and ENVIRONMENT_RE.search(detail):
+        return "ENVIRONMENT_ERROR"
+    return "FAIL"
+
+
+def _is_xfail(record: dict) -> bool:
+    """Interpret the plugin's boolean xfail field defensively."""
+    return bool(record.get("wasxfail"))
+
+
+def reduce_records(records: list[dict]) -> dict:
+    """Fold raw pytest reports into one status per test node.
+
+    A node reports up to three times (setup, call, teardown). The worst outcome
+    decides, and a setup or teardown failure is an error rather than a failed
+    assertion: the test body never ran, so calling it a failure would blame the
+    model's behaviour for a harness problem.
+    """
+    # Keep this explicit rather than relying on the order of ``STATUSES``:
+    # SKIP_CUDA_ONLY and XFAIL are informational and must never hide a FAIL.
+    severity = {
+        "PASS": 0,
+        "SKIP_CUDA_ONLY": 0,
+        "SKIP_OTHER": 0,
+        "XFAIL": 0,
+        "XPASS": 1,
+        "FAIL": 3,
+        "ERROR": 4,
+        "ENVIRONMENT_ERROR": 5,
+        "COLLECT_ERROR": 6,
+    }
+
+    tests: dict[str, dict] = {}
+    collect_errors: list[dict] = []
+    collected = None
+
+    for record in records:
+        kind = record.get("kind")
+        if kind == "collected":
+            collected = record.get("count")
+            continue
+        if kind == "collect":
+            detail = record.get("longrepr")
+            collect_errors.append(
+                {
+                    "nodeid": record.get("nodeid"),
+                    "status": "ENVIRONMENT_ERROR"
+                    if detail and ENVIRONMENT_RE.search(detail)
+                    else "COLLECT_ERROR",
+                    "detail": detail,
+                }
+            )
+            continue
+        if kind != "test":
+            continue
+
+        nodeid = record.get("nodeid")
+        outcome = record.get("outcome")
+        when = record.get("when")
+        detail = record.get("longrepr")
+        entry = tests.setdefault(
+            nodeid,
+            {
+                "nodeid": nodeid,
+                "status": "PASS",
+                "duration_s": 0.0,
+                "detail": None,
+                "output": None,
+            },
+        )
+        duration = record.get("duration")
+        if isinstance(duration, (int, float)):
+            entry["duration_s"] = round(entry["duration_s"] + duration, 3)
+
+        if outcome == "skipped":
+            status = "XFAIL" if _is_xfail(record) else classify_skip(detail)
+        elif outcome == "failed":
+            if _is_xfail(record):
+                status = "XFAIL"
+            elif when == "call":
+                status = classify_failure(detail)
+            else:
+                status = (
+                    "ENVIRONMENT_ERROR"
+                    if (detail and ENVIRONMENT_RE.search(detail))
+                    else "ERROR"
+                )
+        elif outcome == "passed" and _is_xfail(record):
+            status = "XPASS"
+        else:
+            status = "PASS"
+
+        # Worst status wins, so a passing call cannot hide a teardown error.
+        old_status = entry["status"]
+        if severity.get(status, 0) > severity.get(old_status, 0) or (
+            old_status == "PASS" and status != "PASS"
+        ):
+            entry["status"] = status
+            entry["detail"] = detail
+            sections = record.get("sections") or []
+            entry["output"] = (
+                "\n".join(
+                    f"--- {name}\n{content}" for name, content in sections if content
+                )
+                or None
+            )
+
+    return {
+        "tests": sorted(tests.values(), key=lambda t: t["nodeid"]),
+        "collect_errors": collect_errors,
+        "collected": collected,
+    }
+
+
+def summarize_statuses(tests: list[dict], collect_errors: list[dict]) -> dict:
+    counts = {name: 0 for name in STATUSES}
+    for test in tests:
+        counts[test["status"]] += 1
+    for error in collect_errors:
+        counts[error["status"]] += 1
+    return {name: value for name, value in counts.items() if value}
+
+
+def verdict(result: dict) -> str:
+    """Reduce one model's run to a single verdict.
+
+    Ordered by how much each outcome invalidates the measurement. A run that
+    never executed the tests is not a coverage result and must not be counted as
+    support or as a defect.
+    """
+    run = result["run"]
+    if run.get("timed_out"):
+        return "TIMEOUT"
+    if run.get("context_poison"):
+        return "CRASH"
+    counts = result["summary"]
+    if run.get("crashed"):
+        return "CRASH"
+    if counts.get("COLLECT_ERROR"):
+        return "COLLECT_ERROR"
+    if counts.get("FAIL") or counts.get("ERROR"):
+        return "FAIL"
+    executed = counts.get("PASS", 0) + counts.get("XFAIL", 0) + counts.get("XPASS", 0)
+    if not executed:
+        if run.get("collect_only") and run.get("collected"):
+            return "PASS"
+        if counts.get("ENVIRONMENT_ERROR"):
+            return "ENVIRONMENT_ERROR"
+        return "NO_TESTS_RUN"
+    return "PASS"
+
+
+def pytest_process_crashed(returncode: int | None) -> bool:
+    """Recognize interpreter crashes without misclassifying pytest outcomes."""
+    return returncode is not None and returncode not in (0, 1, 2, 3, 4, 5)
+
+
+def read_report(path: Path) -> list[dict]:
+    """Parse the plugin's JSON-lines report, ignoring a truncated last line.
+
+    A crash can cut the file mid-write. Dropping only the damaged line keeps the
+    tests that did finish, which is exactly the evidence a crash needs.
+    """
+    records = []
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        return records
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def environment(device: str) -> dict:
+    """Collect the versions a result cannot be interpreted without."""
+    import torch
+    import transformers
+
+    commit = None
+    try:
+        commit = (
+            subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=REPO_ROOT,
+            ).stdout.strip()
+            or None
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return {
+        "python": sys.version.split()[0],
+        "torch": torch.__version__,
+        "transformers": transformers.__version__,
+        "torch_fl_commit": commit,
+        "device": device,
+        "harness_version": HARNESS_VERSION,
+    }
+
+
+def module_name(model: str) -> str:
+    """Map an architecture key to its test directory name.
+
+    Keys and directories disagree for a substantial minority of architectures
+    (``blip-2`` -> ``blip_2``), so the mapping has to come from transformers
+    itself rather than from a string transform of the key.
+    """
+    from transformers.models.auto.configuration_auto import model_type_to_module_name
+
+    return model_type_to_module_name(model)
+
+
+def known_models() -> list[str]:
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING_NAMES
+
+    return sorted(CONFIG_MAPPING_NAMES)
+
+
+def test_dir(source: Path, model: str) -> Path:
+    return source / "tests" / "models" / module_name(model)
+
+
+def child_env(source: Path, device: str, report: Path, offline: bool) -> dict:
+    """Build the environment HuggingFace's device injection contract needs."""
+    env = dict(os.environ)
+    # Custom PrivateUse1 names are registered by the spec. Transformers validates
+    # TRANSFORMERS_TEST_DEVICE before importing that spec, so setting it to
+    # ``flagos`` would fail at torch.device() validation.
+    env.pop("TRANSFORMERS_TEST_DEVICE", None)
+    env["TRANSFORMERS_TEST_DEVICE_SPEC"] = "hf_device_spec.py"
+    env["HF_TEST_REPORT"] = str(report)
+    # This repository also has a top-level ``tests`` package. If it stays
+    # importable, HF's ``tests.models...`` imports resolve into the wrong tree
+    # and every model test errors on import.
+    path_entries = [
+        entry
+        for entry in env.get("PYTHONPATH", "").split(os.pathsep)
+        if entry and Path(entry).resolve() != REPO_ROOT
+    ]
+    # HF's ``tests`` package must be importable by name: its model tests use
+    # relative imports such as ``from ...causal_lm_tester import ...``.
+    env["PYTHONPATH"] = os.pathsep.join([str(source), *path_entries])
+    if offline:
+        env["HF_HUB_OFFLINE"] = "1"
+        env["TRANSFORMERS_OFFLINE"] = "1"
+    env["_HF_TESTS_SOURCE"] = str(source)
+    return env
+
+
+def pytest_command(
+    target: Path, marks: str, extra: list[str], collect_only: bool
+) -> list[str]:
+    """Build the pytest invocation.
+
+    Deliberately minimal: no marker filtering and no plugin disabling by default,
+    so what runs is what ``pytest tests/models/<module>/`` runs upstream. Making
+    a platform look better by deselecting upstream tests would defeat the point
+    of measuring coverage.
+    """
+    command = [sys.executable, "-m", "pytest"]
+    if marks:
+        command += ["-m", marks]
+    if collect_only:
+        command.append("--collect-only")
+    command += extra
+    command.append(str(target))
+    return command
+
+
+def run_tests(model: str, source: Path, args: argparse.Namespace) -> dict:
+    """Run one architecture's official tests in an isolated subprocess."""
+    target = test_dir(source, model)
+    if not target.is_dir():
+        return {
+            "run": {"status": "NOT_IN_VERSION", "target": str(target)},
+            "tests": [],
+            "collect_errors": [],
+            "summary": {},
+        }
+
+    # Transformers resolves TRANSFORMERS_TEST_DEVICE_SPEC by importing the value
+    # as a module name after appending its directory to sys.path, so the spec has
+    # to be importable from the child's working directory. Running from a private
+    # directory keeps the shared source cache unmodified.
+    workdir = Path(tempfile.mkdtemp(prefix=f"hf-tests-{model.replace('/', '_')}-"))
+    report = workdir / "report.jsonl"
+    report.touch()
+    (workdir / "hf_report_plugin.py").write_text(PLUGIN)
+    shutil.copyfile(DEVICE_SPEC, workdir / DEVICE_SPEC.name)
+
+    env = child_env(source, args.device, report, args.offline)
+    command = pytest_command(
+        target,
+        args.marks,
+        [
+            # HF's conftest.py and its marker declarations live in the source
+            # tree; the child runs elsewhere, so point pytest at them explicitly.
+            "-c",
+            str(source / "pyproject.toml"),
+            "--rootdir",
+            str(source),
+            "-p",
+            "hf_report_plugin",
+            *args.pytest_arg,
+        ],
+        args.collect_only,
+    )
+
+    started = time.time()
+    try:
+        proc = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(workdir),
+            timeout=args.timeout,
+        )
+        stdout, stderr, rc = proc.stdout, proc.stderr, proc.returncode
+        timed_out = False
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        rc, timed_out = None, True
+
+    reduced = reduce_records(read_report(report))
+    combined = "\n".join(
+        [
+            stderr,
+            stdout,
+            *(item.get("detail") or "" for item in reduced["tests"]),
+            *(item.get("detail") or "" for item in reduced["collect_errors"]),
+        ]
+    )
+    poisoned = bool(POISON_RE.search(combined))
+    # pytest returns 0-5 for test outcomes; anything else (or a signal) means the
+    # interpreter died, which the per-test records cannot describe on their own.
+    crashed = pytest_process_crashed(rc)
+
+    result = {
+        "run": {
+            "status": "RAN",
+            "target": str(target),
+            "command": command,
+            "returncode": rc,
+            "timed_out": timed_out,
+            "collect_only": args.collect_only,
+            "crashed": crashed,
+            "context_poison": poisoned,
+            "duration_s": round(time.time() - started, 1),
+            "collected": reduced["collected"],
+            "report": str(report),
+            "workdir": str(workdir),
+            "stdout_tail": stdout.strip()[-4000:] or None,
+            "stderr_tail": stderr.strip()[-4000:] or None,
+        },
+        "tests": reduced["tests"],
+        "collect_errors": reduced["collect_errors"],
+    }
+    result["summary"] = summarize_statuses(reduced["tests"], reduced["collect_errors"])
+    return result
+
+
+def fingerprint(model: str, device: str, test: dict) -> str:
+    """Fingerprint the cause, not the occurrence.
+
+    Addresses, shapes, durations, and temporary paths are stripped so that a
+    differing pointer value does not read as a different failure. The later
+    reporter uses this for dedup; nothing here writes to a tracker.
+    """
+    detail = test.get("detail") or ""
+    normalized = re.sub(r"0x[0-9a-f]+", "0xADDR", detail, flags=re.IGNORECASE)
+    normalized = re.sub(r"\b\d+\.\d+s\b", "TIMEs", normalized)
+    normalized = re.sub(r"/tmp/[^\s'\"]+", "/tmp/PATH", normalized)
+    normalized = re.sub(r"\b\d+\b", "N", normalized)
+    payload = f"{test['status']}|{model}|{device}|{test['nodeid']}|{normalized[-2000:]}"
+    return hashlib.sha256(payload.encode()).hexdigest()[:12]
+
+
+def summarize(result: dict) -> str:
+    run = result["run"]
+    lines = [
+        f"model      {result['model']['requested']} "
+        f"(tests/models/{result['model']['module']})",
+        f"device     {result['environment']['device']}",
+        f"verdict    {result['verdict']}",
+        f"duration   {run.get('duration_s')}s",
+    ]
+    if run["status"] == "NOT_IN_VERSION":
+        lines.append(f"note       no test directory at {run['target']}")
+        return "\n".join(lines)
+    if run.get("context_poison"):
+        lines.append("WARNING    device context was poisoned; later tests are void")
+    if run.get("timed_out"):
+        lines.append(f"WARNING    timed out; partial results from {run['report']}")
+    counts = result["summary"]
+    lines.append("")
+    lines.append(
+        "  "
+        + "  ".join(f"{name}={value}" for name, value in sorted(counts.items()))
+        + (f"  (collected {run.get('collected')})" if run.get("collected") else "")
+    )
+    interesting = [
+        test
+        for test in result["tests"]
+        if test["status"] in ("FAIL", "ERROR", "ENVIRONMENT_ERROR")
+    ]
+    if interesting:
+        lines.append("")
+        for test in interesting[:20]:
+            first = (test.get("detail") or "").strip().splitlines()
+            lines.append(f"  {test['status']:<18} {test['nodeid']}")
+            if first:
+                lines.append(f"    {first[-1][:160]}")
+        if len(interesting) > 20:
+            lines.append(f"  ... {len(interesting) - 20} more in the JSON result")
+    for error in result["collect_errors"]:
+        lines.append(f"  {error['status']:<18} {error['nodeid']} (collection)")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run HuggingFace's official tests for one model on an accelerator"
+    )
+    parser.add_argument("--model", help="architecture key, e.g. qwen3 or blip-2")
+    parser.add_argument("--list-models", action="store_true", help="list architectures")
+    parser.add_argument("--device", default="flagos")
+    parser.add_argument(
+        "--transformers-version",
+        default="latest",
+        help="'latest' records the installed release; an explicit version must match it",
+    )
+    parser.add_argument("--source-dir", help="prepared transformers source tree")
+    parser.add_argument("--cache-dir", help="where version-matched sources are cached")
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="never download: require a cached source tree and set HF offline mode",
+    )
+    parser.add_argument(
+        "--marks",
+        default="",
+        help="optional pytest -m expression (disabled by default)",
+    )
+    parser.add_argument("--collect-only", action="store_true")
+    parser.add_argument("--timeout", type=int, default=3600)
+    parser.add_argument("--out", type=Path, help="write the JSON result here")
+    parser.add_argument(
+        "--pytest-arg",
+        action="append",
+        default=[],
+        help="extra argument passed through to pytest (repeatable)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list_models:
+        for name in known_models():
+            print(name)
+        return 0
+    if not args.model:
+        parser.error("--model is required (or use --list-models)")
+
+    try:
+        resolution = resolve_version(args.transformers_version, args.offline)
+        source = use_source(
+            resolution["version"],
+            args.source_dir,
+            args.cache_dir,
+            args.offline,
+        )
+    except SourceError as exc:
+        print(f"environment error: {exc}", file=sys.stderr)
+        return 2
+
+    env = environment(args.device)
+    env["transformers_requested"] = resolution["requested"]
+    env["transformers_latest"] = resolution["latest"]
+    env["source_path"] = source["path"]
+    env["source_version"] = source["version"]
+
+    result = run_tests(args.model, Path(source["path"]), args)
+    result["schema_version"] = SCHEMA_VERSION
+    result["model"] = {"requested": args.model, "module": module_name(args.model)}
+    result["environment"] = env
+    result["verdict"] = verdict(result)
+    for test in result["tests"]:
+        if test["status"] in ("FAIL", "ERROR", "ENVIRONMENT_ERROR"):
+            test["fingerprint"] = fingerprint(args.model, args.device, test)
+
+    print(
+        f"transformers {env['transformers']}  torch {env['torch']}"
+        f"  torch_fl {env['torch_fl_commit']}"
+    )
+    print(f"source       {source['path']}")
+    print()
+    print(summarize(result))
+
+    if args.out:
+        atomic_write(args.out, result)
+        print(f"\nJSON written to {args.out}")
+    return 0 if result["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_transformers_hf_tests.py
+++ b/tests/unit/test_transformers_hf_tests.py
@@ -1,0 +1,355 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pure tests for the official HuggingFace per-model runner."""
+
+import importlib.util
+import io
+import os
+import sys
+import tarfile
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_SCRIPT = REPO_ROOT / "tests" / "manual" / "transformers_hf_source.py"
+RUNNER_SCRIPT = REPO_ROOT / "tests" / "manual" / "transformers_hf_tests.py"
+
+
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+source = load("transformers_hf_source", SOURCE_SCRIPT)
+runner = load("transformers_hf_tests", RUNNER_SCRIPT)
+
+
+# --- source tree --------------------------------------------------------------
+
+
+def test_source_version_reads_exact_declared_version(tmp_path):
+    init = tmp_path / "src" / "transformers"
+    init.mkdir(parents=True)
+    (init / "__init__.py").write_text('__version__ = "5.16.1"\n')
+    (tmp_path / "tests" / "models").mkdir(parents=True)
+    source.atomic_write(
+        tmp_path / source.CACHE_MARKER,
+        {"format": source.CACHE_FORMAT, "version": "5.16.1"},
+    )
+    assert source.source_version(tmp_path) == "5.16.1"
+    assert source.is_usable(tmp_path, "5.16.1")
+    assert not source.is_usable(tmp_path, "5.16.0")
+
+
+def test_source_dir_is_version_scoped(tmp_path):
+    assert source.source_dir("5.16.1", tmp_path) == tmp_path / "transformers-5.16.1"
+    assert source.source_dir("4.50.2", tmp_path) != source.source_dir(
+        "5.16.1", tmp_path
+    )
+
+
+def make_archive(tmp_path, unsafe=False):
+    archive = tmp_path / "transformers.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        files = {
+            "transformers-5.16.1/tests/models/bert/test.py": "def test_ok(): pass\n",
+            "transformers-5.16.1/conftest.py": "# conftest\n",
+            "transformers-5.16.1/pyproject.toml": "[tool.pytest.ini_options]\n",
+            "transformers-5.16.1/src/transformers/__init__.py": '__version__ = "5.16.1"\n',
+            "transformers-5.16.1/.torch-fl-hf-source": '{"format": 2, "version": "5.16.1"}\n',
+        }
+        if unsafe:
+            files["transformers-5.16.1/../../escape"] = "no\n"
+        for name, text in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(text.encode())
+            tar.addfile(info, io.BytesIO(text.encode()))
+    return archive
+
+
+def test_extract_archive_is_complete_and_version_checked(tmp_path):
+    dest = tmp_path / "tree"
+    source.extract_archive(make_archive(tmp_path), dest)
+    assert (dest / "tests/models/bert/test.py").exists()
+    assert source.source_version(dest) == "5.16.1"
+
+
+def test_extract_archive_rejects_unsafe_member(tmp_path):
+    with pytest.raises(source.SourceError, match="unsafe"):
+        source.extract_archive(make_archive(tmp_path, unsafe=True), tmp_path / "tree")
+
+
+def make_link_archive(tmp_path, link_target):
+    archive = tmp_path / "transformers-links.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        files = {
+            "transformers-5.16.1/tests/models/bert/test.py": "def test_ok(): pass\n",
+            "transformers-5.16.1/src/transformers/__init__.py": '__version__ = "5.16.1"\n',
+            "transformers-5.16.1/.torch-fl-hf-source": '{"format": 2, "version": "5.16.1"}\n',
+            "transformers-5.16.1/target.txt": "target\n",
+        }
+        for name, text in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(text.encode())
+            tar.addfile(info, io.BytesIO(text.encode()))
+        link = tarfile.TarInfo("transformers-5.16.1/docs/link.txt")
+        link.type = tarfile.SYMTYPE
+        link.linkname = link_target
+        tar.addfile(link)
+    return archive
+
+
+def test_extract_archive_allows_safe_relative_symlink(tmp_path):
+    dest = tmp_path / "tree"
+    source.extract_archive(make_link_archive(tmp_path, "../target.txt"), dest)
+    assert (dest / "docs/link.txt").is_symlink()
+    assert (dest / "docs/link.txt").read_text() == "target\n"
+
+
+@pytest.mark.parametrize("link_target", ["/tmp/outside", "../../../../outside"])
+def test_extract_archive_rejects_unsafe_symlink(tmp_path, link_target):
+    with pytest.raises(source.SourceError, match="unsafe archive link"):
+        source.extract_archive(
+            make_link_archive(tmp_path, link_target), tmp_path / "tree"
+        )
+
+
+def test_use_source_rejects_version_mismatch(tmp_path):
+    init = tmp_path / "src" / "transformers"
+    init.mkdir(parents=True)
+    (init / "__init__.py").write_text('__version__ = "4.50.2"\n')
+    (tmp_path / "tests" / "models" / "bert").mkdir(parents=True)
+    with pytest.raises(source.SourceError, match="declares transformers 4.50.2"):
+        source.use_source("5.16.1", tmp_path, None, True)
+
+
+# --- model resolution and environment ---------------------------------------
+
+
+def install_fake_transformers_mapping(monkeypatch):
+    transformers = types.ModuleType("transformers")
+    models = types.ModuleType("transformers.models")
+    auto = types.ModuleType("transformers.models.auto")
+    configuration = types.ModuleType("transformers.models.auto.configuration_auto")
+    configuration.CONFIG_MAPPING_NAMES = {"qwen3": "Qwen3Config", "bert": "BertConfig"}
+    configuration.model_type_to_module_name = lambda key: (
+        "blip_2" if key == "blip-2" else key
+    )
+    transformers.models = models
+    models.auto = auto
+    auto.configuration_auto = configuration
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+    monkeypatch.setitem(sys.modules, "transformers.models", models)
+    monkeypatch.setitem(sys.modules, "transformers.models.auto", auto)
+    monkeypatch.setitem(
+        sys.modules, "transformers.models.auto.configuration_auto", configuration
+    )
+
+
+def test_module_name_uses_transformers_mapping(monkeypatch, tmp_path):
+    install_fake_transformers_mapping(monkeypatch)
+    assert runner.module_name("blip-2") == "blip_2"
+    assert runner.test_dir(tmp_path, "blip-2") == tmp_path / "tests/models/blip_2"
+
+
+def test_child_env_sets_hf_device_contract(monkeypatch, tmp_path):
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    env = runner.child_env(tmp_path, "flagos", tmp_path / "report.jsonl", True)
+    assert "TRANSFORMERS_TEST_DEVICE" not in env
+    assert env["TRANSFORMERS_TEST_DEVICE_SPEC"] == "hf_device_spec.py"
+    assert env["_HF_TESTS_SOURCE"] == str(tmp_path)
+    assert env["HF_HUB_OFFLINE"] == "1"
+    # HF's own ``tests`` package must win over this repository's.
+    entries = env["PYTHONPATH"].split(os.pathsep)
+    assert entries[0] == str(tmp_path)
+    assert str(REPO_ROOT) not in entries
+
+
+def test_child_env_does_not_override_test_behaviour(monkeypatch, tmp_path):
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    env = runner.child_env(tmp_path, "flagos", tmp_path / "report.jsonl", False)
+    assert "HF_HUB_OFFLINE" not in env
+    assert "TRANSFORMERS_OFFLINE" not in env
+
+
+def test_pytest_command_runs_upstream_tests_unfiltered(tmp_path):
+    command = runner.pytest_command(tmp_path / "tests/models/qwen3", "", [], False)
+    assert command[1:3] == ["-m", "pytest"]
+    assert command[3:] == [str(tmp_path / "tests/models/qwen3")]
+
+
+def test_known_model_listing_delegates_to_mapping(monkeypatch):
+    install_fake_transformers_mapping(monkeypatch)
+    assert runner.known_models() == ["bert", "qwen3"]
+
+
+# --- report reduction ---------------------------------------------------------
+
+
+def record(nodeid, outcome, when="call", detail=None, wasxfail=False, duration=0.1):
+    return {
+        "kind": "test",
+        "nodeid": nodeid,
+        "outcome": outcome,
+        "when": when,
+        "longrepr": detail,
+        "wasxfail": wasxfail,
+        "duration": duration,
+        "sections": [],
+    }
+
+
+def test_reduce_records_preserves_per_test_outcomes():
+    reduced = runner.reduce_records(
+        [
+            record("a::pass", "passed"),
+            record("a::fail", "failed", detail="assertion failed"),
+            record("a::cuda", "skipped", detail="test requires CUDA"),
+            record("a::skip", "skipped", detail="not applicable"),
+            record("a::xfail", "skipped", detail="known issue", wasxfail=True),
+        ]
+    )
+    statuses = {item["nodeid"]: item["status"] for item in reduced["tests"]}
+    assert statuses == {
+        "a::pass": "PASS",
+        "a::fail": "FAIL",
+        "a::cuda": "SKIP_CUDA_ONLY",
+        "a::skip": "SKIP_OTHER",
+        "a::xfail": "XFAIL",
+    }
+
+
+def test_reduce_records_marks_setup_import_error_as_environment_error():
+    reduced = runner.reduce_records(
+        [
+            record(
+                "a::setup",
+                "failed",
+                when="setup",
+                detail="ModuleNotFoundError: No module named 'accelerate'",
+            )
+        ]
+    )
+    assert reduced["tests"][0]["status"] == "ENVIRONMENT_ERROR"
+
+
+def test_reduce_records_marks_collection_error_separately():
+    reduced = runner.reduce_records(
+        [
+            {
+                "kind": "collect",
+                "nodeid": "tests/models/bert",
+                "longrepr": "SyntaxError: bad",
+            }
+        ]
+    )
+    assert reduced["collect_errors"][0]["status"] == "COLLECT_ERROR"
+    assert runner.summarize_statuses([], reduced["collect_errors"]) == {
+        "COLLECT_ERROR": 1
+    }
+
+
+def test_reduce_records_aggregates_setup_and_call_without_hiding_setup_error():
+    reduced = runner.reduce_records(
+        [
+            record("a::test", "passed", when="call"),
+            record(
+                "a::test", "failed", when="teardown", detail="fixture teardown failed"
+            ),
+        ]
+    )
+    assert reduced["tests"][0]["status"] == "ERROR"
+
+
+def test_classification_distinguishes_cuda_and_environment():
+    assert runner.classify_skip("test requires a CUDA GPU") == "SKIP_CUDA_ONLY"
+    assert runner.classify_skip("not supported on this model") == "SKIP_OTHER"
+    assert (
+        runner.classify_failure("ImportError: optional package missing")
+        == "ENVIRONMENT_ERROR"
+    )
+    assert runner.classify_failure("assert 1 == 2") == "FAIL"
+
+
+# --- process/verdict ----------------------------------------------------------
+
+
+def test_verdict_not_run_is_environment_or_no_tests():
+    assert (
+        runner.verdict({"run": {"timed_out": False, "crashed": False}, "summary": {}})
+        == "NO_TESTS_RUN"
+    )
+    assert (
+        runner.verdict(
+            {
+                "run": {"timed_out": False, "crashed": False},
+                "summary": {"ENVIRONMENT_ERROR": 1},
+            }
+        )
+        == "ENVIRONMENT_ERROR"
+    )
+
+
+def test_verdict_prioritizes_timeout_and_poison():
+    base = {"summary": {"FAIL": 2}, "run": {"timed_out": False, "crashed": False}}
+    assert runner.verdict({**base, "run": {"timed_out": True}}) == "TIMEOUT"
+    assert runner.verdict({**base, "run": {"context_poison": True}}) == "CRASH"
+    assert runner.verdict({**base, "run": {"crashed": True}}) == "CRASH"
+
+
+def test_not_in_version_result_has_no_tests(monkeypatch, tmp_path):
+    monkeypatch.setattr(runner, "module_name", lambda model: model)
+    args = runner.argparse.Namespace(device="flagos", offline=True)
+    result = runner.run_tests("bert", tmp_path, args)
+    assert result["run"]["status"] == "NOT_IN_VERSION"
+    assert result["tests"] == []
+
+
+def test_collect_only_with_collected_tests_is_a_pass():
+    result = {
+        "run": {
+            "timed_out": False,
+            "crashed": False,
+            "collect_only": True,
+            "collected": 3,
+        },
+        "summary": {},
+    }
+    assert runner.verdict(result) == "PASS"
+
+
+def test_pytest_internal_and_usage_exit_codes_are_not_crashes():
+    for returncode in (3, 4, 5):
+        assert not runner.pytest_process_crashed(returncode)
+    assert runner.pytest_process_crashed(6)
+    assert runner.pytest_process_crashed(-11)
+
+
+def test_fingerprint_normalizes_addresses_and_paths():
+    first = {"status": "FAIL", "nodeid": "x", "detail": "ptr 0xabc /tmp/foo 123"}
+    second = {"status": "FAIL", "nodeid": "x", "detail": "ptr 0xdef /tmp/bar 456"}
+    assert runner.fingerprint("bert", "flagos", first) == runner.fingerprint(
+        "bert", "flagos", second
+    )
+
+
+def test_atomic_result_write(tmp_path):
+    target = tmp_path / "nested" / "result.json"
+    runner.atomic_write(target, {"verdict": "PASS"})
+    assert target.exists()
+    assert [p.name for p in target.parent.iterdir()] == ["result.json"]


### PR DESCRIPTION
<!--
⚠️ AI-GENERATED PR TEMPLATE ⚠️
This template is for PRs created by AI agents (Claude Code, GitHub Codex, Cursor, etc.).
-->

## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Opus 5 (1M context)
- **Human Reviewer**: @aoyulong
- **Session Summary**: Implemented an official HuggingFace Transformers per-model test runner for accelerator backends, including exact-version source acquisition, custom device injection, subprocess isolation, structured reports, and unit coverage.

## Summary

This PR adds a user-facing harness for running HuggingFace's own `tests/models/<architecture>/` suite against a torch-fl accelerator device such as `flagos`. It downloads and caches the exact Transformers source version matching the installed wheel, injects the HuggingFace custom-device specification, runs one model architecture per isolated pytest subprocess, preserves detailed evidence, and produces a stable JSON result with per-test statuses and an overall verdict.

The implementation is intentionally report-only. Baseline promotion, fingerprint deduplication, operator attribution, and GitHub issue creation remain separate follow-up work.

## Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [x] Platform-agnostic (all platforms)

The runner is backend-neutral. The default device is `flagos`, but `--device` and the device specification module make the harness reusable for other PrivateUse1 accelerator integrations.

## Problem Analysis

### What was broken/missing?

torch-fl had synthetic model probes but no executable path for running the official HuggingFace model tests against an accelerator. Synthetic probes exercise selected forward, backward, and generation paths, but they do not cover the fixtures, mixins, optional-dependency gates, shape combinations, and regression tests maintained in the upstream Transformers repository.

The installed Transformers wheel also does not contain its `tests/` tree. A runner cannot simply point pytest at the installed package; it needs the source tree for the same release.

### Why did it happen?

The HuggingFace tests use a custom-device contract rather than torch-fl-specific configuration. In Transformers 5.16.1, the supported mechanism is `TRANSFORMERS_TEST_DEVICE_SPEC` pointing to an importable module that defines the device name and backend hooks. Setting only a repository-specific environment variable, or using source from a different release, would either fail to inject the device or produce results that cannot be attributed to the installed Transformers code.

Accelerator failures also require process isolation: an illegal memory access or device-side assert can poison the accelerator context and make subsequent tests report collateral failures. Treating every later failure as an independent model defect would overcount one process-level failure.

### Investigation process:
1. Examined the existing `hf-coverage-survey` workflow and synthetic model-probe implementation to identify the missing official-test path and preserve the existing report-only scope.
2. Inspected the Transformers 5.16.1 device-testing contract and verified that `TRANSFORMERS_TEST_DEVICE_SPEC` is required for the custom device; verified that CUDA-only gates should remain skips rather than being forced to execute.
3. Confirmed that the installed wheel omits `tests/`, then designed version-scoped source caching using the GitHub `v<version>` codeload archive and validation of `src/transformers/__init__.py`.
4. Tested archive extraction, including legitimate relative symlinks and malicious absolute or path-escaping links, and added unit coverage for both cases.
5. Ran the harness in the project Python environment, collected 296 Qwen3 tests from Transformers 5.16.1, and verified the resulting schema and process-level metadata.

## Solution Design

### Implementation approach:

- Resolve the installed Transformers version and require exact equality with the requested version, except for the explicitly supported `latest` mode.
- Download the matching GitHub source archive only when a complete version-scoped cache is unavailable. Validate archive paths, symlinks, source version, and the `tests/models` tree before atomically publishing the cache.
- Normalize architecture keys through Transformers' `model_type_to_module_name()` mapping so names such as `blip-2` resolve to `tests/models/blip_2`.
- Build a child-process environment that removes conflicting repository paths and `TRANSFORMERS_TEST_DEVICE`, prepends the upstream source tree, and sets `TRANSFORMERS_TEST_DEVICE_SPEC` to the local `hf_device_spec.py` module. `HF_HUB_OFFLINE` and `TRANSFORMERS_OFFLINE` are set only when `--offline` is requested.
- Run exactly one model directory per subprocess with timeout handling and a small generated pytest plugin. The plugin records setup, call, and teardown reports as JSON lines without adding a runtime dependency such as `pytest-json-report`.
- Reduce raw reports into stable statuses (`PASS`, `FAIL`, `ERROR`, `XFAIL`, `XPASS`, `SKIP_CUDA_ONLY`, `SKIP_OTHER`, `ENVIRONMENT_ERROR`, and `COLLECT_ERROR`), retain collection errors separately, detect accelerator poison, and aggregate the verdict with process-level failures taking priority.
- Write the final structured result atomically, including environment metadata, command, stdout/stderr tails, report path, per-test evidence, summary counts, and verdict.

### Key design decisions:

1. **Exact source/wheel matching**: Source tests are tied to the installed Transformers release. Reusing an arbitrary checkout would mix test code and runtime code from different versions and invalidate failures.
2. **Version-scoped persistent cache**: Each release uses `transformers-<version>` under `~/.cache/torch_fl/hf-tests` (or `HF_COVERAGE_CACHE`/`--cache-dir`), preventing cross-version contamination and allowing offline reruns.
3. **Safe complete-archive extraction**: The complete repository archive is retained because official tests import shared repository files. Member paths and links are validated before extraction, while safe relative symlinks remain supported.
4. **HuggingFace's device-spec contract**: The runner uses `TRANSFORMERS_TEST_DEVICE_SPEC` and deliberately removes `TRANSFORMERS_TEST_DEVICE` from the child environment for the tested Transformers release, avoiding an unsupported or conflicting override.
5. **One model per process**: A poisoned accelerator context cannot be reliably recovered in-process, so subprocess isolation makes the model the unit of attribution.
6. **Generated local pytest plugin**: This collects the required evidence without imposing another dependency on vendor environments.
7. **Report-only scope**: No baseline or external GitHub write is performed by the runner; measurement and issue filing remain independently reviewable steps.

### Code changes by file:

- `tests/manual/hf_device_spec.py`: Adds the minimal HuggingFace custom-device module for `flagos`, including manual seed, cache clearing, and device-count hooks.
- `tests/manual/transformers_hf_source.py`: Adds installed-version resolution, latest-version lookup, version-scoped caching, exact GitHub archive download, secure extraction, source validation, and explicit source errors.
- `tests/manual/transformers_hf_tests.py`: Adds the official per-model CLI, architecture normalization, isolated child environment, generated pytest reporting plugin, timeout/crash/poison handling, status reduction, verdict aggregation, and atomic JSON output.
- `tests/unit/test_transformers_hf_tests.py`: Adds 25 pure unit tests covering source handling, archive safety, architecture mapping, environment construction, report reduction, error classification, process outcomes, fingerprints, and atomic writes.
- `.claude/skills/hf-coverage-survey/SKILL.md`: Aligns the coverage-survey instructions with the executable official runner and documents the Transformers device-spec behavior and report-only boundaries.
- `docs/development/testing.md`: Documents installation without replacing torch, exact source caching, runner usage, device injection, one-model isolation, and result categories.

### Changes by commit:

1. `2458b6d` - `feat: run HuggingFace official tests per model on accelerators`: Adds the complete runner, source helper, device specification, unit tests, skill documentation, and developer testing documentation in one focused feature commit.

## Verification

### Pre-submission Checklist
- [x] **Linting passed** (`ruff check`, `ruff format --check`)
- [x] **Type checking passed** (not applicable; this change adds Python scripts without a project type-checking gate)
- [x] **All relevant tests pass** (25 focused unit tests)
- [x] **Manual testing completed** (Qwen3 source collection against Transformers 5.16.1)
- [x] **No debug/temporary code** (reviewed changed files; no debug prints or temporary TODOs)
- [x] **Documentation updated** (skill and developer testing documentation)
- [x] **Commit messages follow conventions** (`feat:` subject and required trailer)
- [x] **All text in English** (required per `CLAUDE.md`)

### Linting Results

```text
$ /publi-flash/lvyufeng/env/miniconda3/envs/torch210cpu/bin/ruff check
All checks passed!

$ /publi-flash/lvyufeng/env/miniconda3/envs/torch210cpu/bin/ruff format --check
320 files already formatted
```

The initial shell environment did not have `ruff` on `PATH`; the checks were rerun in the project `torch210cpu` environment, where they completed successfully.

### Test Results

```text
$ pytest tests/unit/test_transformers_hf_tests.py -v
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.2.2, pluggy-1.6.0
collecting ... collected 25 items

25 tests passed in 0.23s
============================== 25 passed in 0.23s ==============================
```

The 25 tests covered all focused runner and source-helper cases, including safe relative symlink extraction and rejection of absolute/path-escaping links.

### Manual Verification

```text
$ python tests/manual/transformers_hf_tests.py \
    --model qwen3 --transformers-version 5.16.1 \
    --device flagos --collect-only --out /tmp/qwen3-collect.json

========================= 296 tests collected in 5.35s =========================
```

The generated result recorded:

```json
{
 "environment": {
  "device": "flagos",
  "source_version": "5.16.1",
  "transformers": "5.16.1",
  "transformers_requested": "5.16.1"
 },
 "model": {"module": "qwen3", "requested": "qwen3"},
 "run": {"collect_only": true, "collected": 296, "crashed": false,
         "context_poison": false, "returncode": 0, "status": "RAN"},
 "verdict": "PASS"
}
```

A non-collection Qwen3 run was also exercised in the MUSA/flagos environment. It collected 296 tests, with 138 failures and 29 passes before the accelerator context became poisoned; the poison signature was detected and represented as a process-level crash rather than being counted as 296 independent accelerator defects.

## Performance Impact

Not applicable. This is a manual testing harness and does not change runtime operator or model execution paths. Source archives are downloaded once and reused from a version-scoped cache; each requested model incurs the intentional startup cost of a fresh pytest subprocess.

## Breaking Changes

None. The feature adds scripts and documentation only and does not change the torch-fl runtime API or default test behavior.

## Code Quality Verification

### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions and reused existing project patterns
- [x] Comment density matches surrounding code
- [x] Used project utilities and standard-library facilities without adding unnecessary dependencies

### Edge Cases Considered
1. Installed Transformers is missing or does not exactly match the requested version: returns an explicit `SourceError` with installation guidance.
2. `latest` resolution is unavailable offline: preserves the installed version rather than silently changing the environment.
3. Cache marker, source version, or `tests/models` is missing or mismatched: cache is rejected and never treated as valid evidence.
4. Archive contains paths outside one top-level directory, absolute paths, escaping members, absolute symlinks, or path-escaping symlinks/hard links: extraction fails safely.
5. Legitimate relative symlinks in the upstream archive: extraction succeeds and preserves the link.
6. Architecture directory differs from the model key (`blip-2`/`blip_2`): Transformers' canonical mapping is used.
7. Requested architecture is absent from the pinned source version: result is `NOT_IN_VERSION` with no fabricated test result.
8. Setup/teardown failures, collection errors, optional dependency failures, CUDA-only skips, ordinary assertion failures, xfail/xpass, and other skips are classified separately.
9. Pytest timeout, signal termination, nonstandard crash return codes, and accelerator poison signatures are represented at the run level with timeout/crash verdict priority.
10. Interrupted or repeated output writes: temporary files and atomic replacement prevent partial JSON results.

### Potential Risks
1. Upstream Transformers changes its custom-device environment contract or report behavior; the harness may require a version-specific compatibility update.
2. A vendor runtime may emit a new poison signature not covered by the current conservative regular expression; such a failure could initially be classified as an ordinary process failure rather than poison.
3. Downloaded archives and full official test suites consume disk space and can require optional dependencies; `--offline`, `--cache-dir`, and `--source-dir` provide controlled deployment options.
4. The official suite can include tests requiring CUDA-specific capabilities or external services; these are recorded as categorized skips or environment errors rather than hidden.

### Rollback Plan

Revert commit `2458b6d`. The change is additive, so rollback removes the runner, its unit tests, and related documentation without requiring a runtime migration or data conversion.

## Related Work

- Related to the existing synthetic Transformers model probe and the `hf-coverage-survey` skill.
- No issue is linked because this PR introduces new testing infrastructure rather than closing a tracked bug.
- No dependency on an external PR.

## Explicitly Not Included

- Pretrained-weight benchmarking or large-model performance measurement.
- Baseline promotion, failure fingerprint deduplication, operator attribution, or automatic regression comparison.
- Automatic GitHub issue, comment, or pull-request creation from test results.
- Changes to torch-fl operator routing, kernels, runtime APIs, or CPU fallback behavior.
- Claims about operator support records or hardware coverage percentages; those require separately measured hardware evidence.
- Running the complete multi-architecture sweep in CI; the intended unit is one model per invocation.

## Human Review Notes

### Areas needing special attention:
1. Verify the Transformers 5.16.1 custom-device contract and the deliberate removal of `TRANSFORMERS_TEST_DEVICE` from the child environment.
2. Review `_safe_members()` and atomic extraction carefully, especially relative symlink and hard-link validation.
3. Review subprocess verdict precedence and context-poison handling to ensure collateral failures are not overcounted.
4. Confirm the JSON schema and status names are suitable for a future baseline/fingerprint reporter.

### Questions for reviewer:
1. Should the generated report plugin eventually be promoted to a shared testing utility, or remain local to this manual runner?
2. Are the current `latest` and offline semantics appropriate for vendor test boxes, or should a pinned default be required in a follow-up?
3. Should additional vendor-specific accelerator poison signatures be added after collecting runtime evidence?

## Additional Context

The committed diff contains six files and 1,516 net insertions relative to `main`. Existing unrelated untracked PR drafts and `.claude/worktrees/` were left untouched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
