### PR TITLE
fix: MUSA mm/bmm fault on degenerate size-1-dim stride

### DIFF
--- a/csrc/aten/backends/musa/mudnn_common.h
+++ b/csrc/aten/backends/musa/mudnn_common.h
@@ -184,6 +184,23 @@ class MudnnTensorWrapper {
       sizes_.assign(1, 1);
       strides_.assign(1, 1);
     }
+    // PyTorch's is_contiguous() ignores the stride of any size-1 dimension
+    // (that dim contributes only index 0, so no read ever depends on it), so
+    // a transpose like `torch.randn(2, 1).t()` reports contiguous while
+    // leaving a degenerate stride behind -- e.g. shape (1, 2) stride (1, 1).
+    // mudnn's own validation is stricter (MatMul's lda check wants the
+    // leading dimension's stride >= the trailing extent) and rejects that
+    // degenerate value. Rewrite every size-1 dim's stride to the value a
+    // real C-contiguous tensor of this shape would carry there; the actual
+    // number is unconstrained for correctness since the dim has one
+    // element, so this only needs to satisfy mudnn's shape validation.
+    int64_t contiguous_stride = 1;
+    for (int64_t i = static_cast<int64_t>(sizes_.size()) - 1; i >= 0; --i) {
+      if (sizes_[i] == 1) {
+        strides_[i] = contiguous_stride;
+      }
+      contiguous_stride *= sizes_[i];
+    }
     tensor_.SetType(ToMudnnDataType(tensor.scalar_type()));
     // data_ptr() already accounts for storage_offset.
     tensor_.SetAddr(tensor.const_data_ptr());

--- a/tests/integration/ops/test_musa_dispatch.py
+++ b/tests/integration/ops/test_musa_dispatch.py
@@ -491,6 +491,61 @@ class TestMusaMixedDeviceOperandOrder:
         torch.testing.assert_close(out.cpu(), fn(scalar, t_cpu))
 
 
+class TestMusaDegenerateStride:
+    """A transpose of a size-1 dimension is still `is_contiguous() == True`
+    (issue #240): PyTorch's contiguity check ignores the stride of any
+    size-1 dim, since no read ever depends on it, so `.contiguous()` is a
+    no-op and the degenerate stride reaches mudnn unchanged. mudnn's own
+    validation is stricter and rejects it (`MatMul` raised `INVALID_PARAMETER,
+    lda 1`); `MudnnTensorWrapper` must rewrite it before handing tensors to
+    any mudnn op, not just `mm`.
+    """
+
+    @pytest.mark.musa
+    def test_mm_transposed_size_one_dim(self):
+        # The degenerate stride only survives a transpose done *after* the
+        # tensor is already on-device -- moving a CPU tensor there via
+        # `.to()` renormalizes the stride, silently missing the bug.
+        a = torch.randn(2, 1, device=DEVICE)
+        b = torch.randn(2, 32, device=DEVICE)
+        at = a.t()
+        assert at.is_contiguous()
+        out = torch.mm(at, b)
+        torch.testing.assert_close(out.cpu(), torch.mm(a.cpu().t(), b.cpu()))
+
+    @pytest.mark.musa
+    def test_bmm_transposed_size_one_dim(self):
+        a = torch.randn(3, 2, 1, device=DEVICE)
+        b = torch.randn(3, 2, 32, device=DEVICE)
+        at = a.transpose(1, 2)
+        assert at.is_contiguous()
+        out = torch.bmm(at, b)
+        torch.testing.assert_close(
+            out.cpu(), torch.bmm(a.cpu().transpose(1, 2), b.cpu())
+        )
+
+    @pytest.mark.musa
+    def test_bert_regression_head_backward(self):
+        """BertForSequenceClassification with num_labels=1 (regression via
+        MSE loss) produces exactly this shape in the final linear layer's
+        weight gradient during backward."""
+        transformers = pytest.importorskip("transformers")
+        torch.manual_seed(0)
+        config = transformers.BertConfig(
+            hidden_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            intermediate_size=128,
+            num_labels=1,
+        )
+        model = transformers.BertForSequenceClassification(config).to(DEVICE)
+        input_ids = torch.randint(0, config.vocab_size, (2, 8), device=DEVICE)
+        labels = torch.randn(2, 1, device=DEVICE)
+        loss = model(input_ids=input_ids, labels=labels).loss
+        loss.backward()
+        assert loss.device.type == "flagos"
+
+
 class TestMusaAutograd:
     """Autograd works through the mudnn kernels.
 


### PR DESCRIPTION
## Summary
`torch.randn(2, 1, device=musa).t()` reports `is_contiguous() == True` because PyTorch's contiguity check ignores the stride of any size-1 dimension, leaving a degenerate stride (e.g. shape `(1, 2)` stride `(1, 1)`) in place. mudnn's own `MatMul` validation is stricter and rejects that stride with `INVALID_PARAMETER, lda 1`, which faulted `BertForSequenceClassification(num_labels=1)` backward on MUSA since the regression head's weight gradient takes exactly that shape. This PR rewrites degenerate size-1-dim strides in `MudnnTensorWrapper` before any tensor reaches mudnn.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [x] Platform-agnostic
<!-- Fixed in the shared MudnnTensorWrapper used by MUSA's mudnn backend; MUSA is the only platform that goes through this wrapper today. -->

## Detailed Description

### Problem
PyTorch's `is_contiguous()` ignores the stride of any size-1 dimension, since no read ever depends on it. A transpose like `torch.randn(2, 1).t()` therefore reports contiguous while leaving a degenerate stride behind (shape `(1, 2)`, stride `(1, 1)`), and `.contiguous()` is a no-op on it. mudnn's `MatMul` validates strides more strictly than PyTorch and rejects that value (`INVALID_PARAMETER, lda 1`). This exact shape shows up in the weight gradient of a `num_labels=1` regression head, so `BertForSequenceClassification` backward faulted on MUSA.

### Solution
Rewrite every size-1 dimension's stride in `MudnnTensorWrapper` (`csrc/aten/backends/musa/mudnn_common.h`) to the value a real C-contiguous tensor of that shape would carry there, before the tensor descriptor is handed to mudnn. Fixed at the wrapper level rather than in the `mm`/`bmm` codegen templates, since any mudnn op could be handed the same degenerate stride, not just matmul.

### Changes by Commit
1. `2b2ad54`: Rewrite degenerate size-1-dim stride in `MudnnTensorWrapper`; add `TestMusaDegenerateStride` covering `mm`, `bmm`, and the BERT regression-head backward.

## Testing

### Test Coverage
- [x] Unit tests added/updated
- [x] Integration tests pass
- [ ] Manual testing completed

### Test Commands
```bash
# Integration tests (MUSA)
pytest tests/integration/ops/test_musa_dispatch.py -v
pytest tests/integration/ops/test_mm_dispatch.py tests/integration/ops/test_bmm_dispatch.py tests/integration/ops/test_matmul_backward_dispatch.py -v
```

### Test Results
```
tests/integration/ops/test_musa_dispatch.py::TestMusaDegenerateStride::test_mm_transposed_size_one_dim PASSED
tests/integration/ops/test_musa_dispatch.py::TestMusaDegenerateStride::test_bmm_transposed_size_one_dim PASSED
tests/integration/ops/test_musa_dispatch.py::TestMusaDegenerateStride::test_bert_regression_head_backward PASSED

105 passed, 1 warning in 43.05s  (test_musa_dispatch.py, full file)
150 passed, 19 skipped in 50.27s  (test_musa_dispatch.py + test_mm_dispatch.py + test_bmm_dispatch.py + test_matmul_backward_dispatch.py)
```
All three new tests were verified to fail against the pre-fix code with the reported `INVALID_PARAMETER, lda 1` fault, and pass after the fix.

## Verification

### Pre-merge Checklist
- [x] All tests pass (see test results above)
- [x] Code follows project style (ran linters)
- [ ] Documentation updated (if applicable)
- [ ] CLAUDE.md updated (if adding new conventions)
- [x] Commit messages follow conventions
- [x] No debug code or temporary changes
- [x] PR description is in **English** (required per CLAUDE.md)

### Linting
```bash
# Ran: ruff check tests/integration/ops/test_musa_dispatch.py && ruff format --check tests/integration/ops/test_musa_dispatch.py
# Result: All passed
```

## Explicitly Not Included
- Auditing other mudnn tensor-wrapper call sites for similar degenerate-stride assumptions beyond what `MudnnTensorWrapper` already covers -- this fix is scoped to the wrapper itself, which is the single choke point all mudnn ops go through.

## Related Issues/PRs
Fixes #240

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
