### PR TITLE
feat: probe masked-LM and base auto-models in transformers coverage survey

### DIFF
--- a/tests/manual/transformers_model_probe.py
+++ b/tests/manual/transformers_model_probe.py
@@ -465,19 +465,48 @@ def build_config():
     return cfg
 
 
+# Auto classes tried in order, with the task label recorded for the result.
+# The harness is not causal-LM-only: decoder architectures get a causal head
+# plus `generate()`, encoder architectures fall back to a masked-LM head, and
+# anything else falls back to the bare `AutoModel` body. `AutoModel` maps every
+# config type, so it is the catch-all that keeps non-text or headless models
+# measurable instead of failing them as `UNSUPPORTED_TASK`.
+AUTO_CLASSES = (
+    ("causal_lm", "AutoModelForCausalLM"),
+    ("masked_lm", "AutoModelForMaskedLM"),
+    ("base", "AutoModel"),
+)
+
+
 def build_model(cfg):
-    from transformers import AutoModelForCausalLM
+    from transformers import AutoModel, AutoModelForCausalLM, AutoModelForMaskedLM
+
     torch.manual_seed(SEED)
-    try:
-        model = AutoModelForCausalLM.from_config(cfg)
-    except Exception as exc:  # noqa: BLE001
-        fail("config", "UNSUPPORTED_TASK", exc,
-             detail="no causal-LM mapping, or the config cannot instantiate one")
+    classes = (AutoModelForCausalLM, AutoModelForMaskedLM, AutoModel)
+    last_unrecognized = None
+    for (task, label), cls in zip(AUTO_CLASSES, classes):
+        try:
+            model = cls.from_config(cfg)
+            break
+        except ValueError as exc:
+            # "Unrecognized configuration class ... for this kind of AutoModel"
+            # means this model type has no mapping for the head, not that the
+            # config is broken. Fall through to the next candidate. Any other
+            # ValueError is a genuine instantiation failure and stops the run.
+            message = str(exc)
+            if "Unrecognized configuration class" in message or "should be one of" in message:
+                last_unrecognized = exc
+                continue
+            fail("config", "UNSUPPORTED_TASK", exc,
+                 detail=f"config is a {label} but cannot instantiate a model")
+    else:
+        fail("config", "UNSUPPORTED_TASK", last_unrecognized,
+             detail="no auto-model mapping (causal LM, masked LM, or base)")
     params = sum(p.numel() for p in model.parameters())
     if params > MAX_PARAMS:
         fail("config", "CONFIG_TOO_LARGE", params=params, max_params=MAX_PARAMS,
              detail="config ignored the tiny overrides; refusing to allocate")
-    return model.to(DTYPE).eval(), params
+    return model.to(DTYPE).eval(), params, task
 
 
 # --- comparison ---------------------------------------------------------------
@@ -679,7 +708,7 @@ def run_layer(layer, cpu_model, dev_model, cpu_inputs, dev_inputs):
 # Load and run after definitions so config errors are reported in the protocol.
 try:
     cfg = build_config()
-    model, params = build_model(cfg)
+    model, params, task = build_model(cfg)
     # Module.to() mutates in place and returns self, so the CPU baseline must
     # be a distinct object. Sharing one would compare the device against
     # itself and report every layer as passing.
@@ -689,7 +718,7 @@ try:
     dev_model.probe_optimizer = torch.optim.SGD(dev_model.parameters(), lr=1e-3)
     cpu_inputs = make_inputs(cfg)
     dev_inputs = tensors_on(cpu_inputs, DEV)
-    emit("config", "PASS", params=params)
+    emit("config", "PASS", params=params, task=task)
 except SystemExit:
     raise
 except Exception as exc:  # noqa: BLE001
@@ -709,6 +738,8 @@ def summarize(result: dict, layers: list[str]) -> str:
         f"duration   {result['duration_s']}s",
     ]
     config = result["layers"].get("config", {})
+    if config.get("task"):
+        lines.append(f"task       {config['task']}")
     if config.get("params"):
         lines.append(f"params     {config['params']:,}")
     if result.get("context_poison"):


### PR DESCRIPTION
## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude (claude-fable-5)
- **Human Reviewer**: @<!-- TODO: assign human reviewer -->
- **Session Summary**: Ran the `hf-coverage-survey` skill on a MetaX accelerator.
  Probing `mpnet` returned `UNSUPPORTED_TASK` because the harness only
  instantiates causal-LM models; this PR extends it to masked-LM and base
  auto-models.

## Summary

`tests/manual/transformers_model_probe.py` hardcoded
`AutoModelForCausalLM.from_config(cfg)`, so every encoder or encoder-decoder
architecture in `CONFIG_MAPPING` (e.g. `mpnet`, `bert`, `roberta`) was reported
`UNSUPPORTED_TASK` at the config layer and never measured. This PR makes
`build_model()` fall back through `AutoModelForCausalLM` →
`AutoModelForMaskedLM` → `AutoModel` and records the selected model kind as a
`task` field in the config event, so the survey can measure non-causal-LM
architectures.

## Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [ ] MetaX
- [ ] Ascend
- [ ] PPU
- [x] Platform-agnostic (all platforms)

## Problem Analysis
### What was broken/missing?

The coverage probe could only measure decoder-only causal-LM models. Encoder
and encoder-decoder models (masked-LM, sequence-classification, and other
headless architectures) were reported `UNSUPPORTED_TASK` and dropped from the
survey entirely.

### Why did it happen?

The CHILD script's `build_model()` imported only `AutoModelForCausalLM` and
called `AutoModelForCausalLM.from_config(cfg)` with no fallback. For an encoder
config like `MPNetConfig`, `from_config` raises
`ValueError: Unrecognized configuration class ... for this kind of AutoModel:
AutoModelForCausalLM`, which the harness turned into `UNSUPPORTED_TASK`.

### Investigation process:
1. Ran `python tests/manual/transformers_model_probe.py --model mpnet --offline`
   and observed `UNSUPPORTED_TASK` at the config layer.
2. Read the CHILD script's `build_model()` and confirmed the hardcoded
   `AutoModelForCausalLM`.
3. Confirmed `mpnet` builds via `AutoModelForMaskedLM.from_config`, and noted
   the `generate` layer already guards on `hasattr(model, "generate")`.

## Solution Design
### Implementation approach:

`build_model()` tries auto-model classes in order and records the winner as a
`task` label, falling through only on the "no mapping for this head" error
rather than swallowing genuine instantiation failures:

- `causal_lm` → `AutoModelForCausalLM`
- `masked_lm` → `AutoModelForMaskedLM`
- `base` → `AutoModel` (maps every config type; the catch-all)

The caller unpacks and emits the `task` in the config event, and `summarize()`
prints it so a result is self-describing.

### Key design decisions:
- Only `ValueError` whose message matches "Unrecognized configuration class" or
  "should be one of" triggers the fall-through; any other `ValueError` is a
  genuine instantiation failure and still fails the run as `UNSUPPORTED_TASK`.
- `AutoModel` last, as the universal fallback, so no architecture in
  `CONFIG_MAPPING` is silently unmeasurable.
- The `generate` layer guard already exists (`hasattr(model, "generate")`), so
  encoder models report `generate` as `UNSUPPORTED` without any extra change.

### Code changes by file:
- `tests/manual/transformers_model_probe.py` (`AUTO_CLASSES`, `build_model`):
  add the three-step auto-model fallback and return the selected `task`.
- `tests/manual/transformers_model_probe.py` (main CHILD driver): unpack and
  emit `task` in the config event.
- `tests/manual/transformers_model_probe.py` (`summarize`): print the `task`.

### Changes by commit:
1. `2972f2b` - `feat: probe masked-LM and base auto-models in transformers
   coverage survey`: the full change described above.

## Verification
### Pre-submission Checklist
- [x] **Linting passed** (ruff check, ruff format --check)
- [x] **Type checking passed** (N/A — no new type annotations)
- [x] **All tests pass** (`tests/manual` is not run by CI; verified by manual
      probe runs below)
- [x] **Manual testing completed** (mpnet before/after, qwen2 regression)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [x] **Documentation updated** (n/a for this harness-only change)
- [x] **Commit messages follow conventions** (`feat:` prefix)
- [x] **All text in English**

### Linting Results
```bash
$ ruff check .
All checks passed!

$ ruff format --check .
230 files already formatted
```

### Test Results
`tests/manual` is a manual harness; CI does not invoke it. Verified via the
probe itself:

```bash
$ python tests/manual/transformers_model_probe.py --model mpnet --offline
```

BEFORE (main):
```
model      mpnet
verdict    UNSUPPORTED_TASK
  transfer  NOT_REACHED
  forward   NOT_REACHED
  backward  NOT_REACHED
  generate  NOT_REACHED
```

AFTER (this PR):
```
model      mpnet
device     flagos  dtype float32
verdict    WRONG
task       masked_lm
  transfer  PASS
  forward   PASS
  backward  WRONG  tolerance at grad.mpnet.embeddings.word_embeddings.weight (max_abs 1.38e-05)
  generate  NOT_REACHED
```

The remaining `backward WRONG` is the separate `aten::mm` reduced-precision
matmul defect (tracked in its own issue), not a harness gap. The harness now
builds and measures mpnet through `masked_lm`; its `forward` passes.

Regression — decoder path unchanged:
```bash
$ python tests/manual/transformers_model_probe.py --model qwen2 --offline
```
```
task       causal_lm
  transfer  PASS
  forward   WRONG  tolerance at out.logits (max_abs 0.000197)
  backward  NOT_REACHED
  generate  NOT_REACHED
```

### Manual Verification
- `--model mpnet --offline`: `UNSUPPORTED_TASK` → `task=masked_lm`, transfer
  PASS, forward PASS.
- `--model qwen2 --offline`: `task=causal_lm`, unchanged result (regression).

## Performance Impact
None — this is a manual survey harness; no hot path.

## Breaking Changes
None.

## Code Quality Verification
### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (reused `fail()`/`emit()`)

### Edge Cases Considered
1. Model with no causal-LM head but a masked-LM head (`mpnet`) → `masked_lm`.
2. Model with neither (headless, e.g. some composite configs) → `base`.
3. Model whose config is recognized but genuinely broken → still
   `UNSUPPORTED_TASK` with the real error (not silently downgraded).
4. Decoder model regression → still `causal_lm`, behavior unchanged.

### Potential Risks
1. `AutoModel` is a very permissive fallback; a model that "builds" as base may
   exercise less than intended (no LM head). Mitigated by recording `task`, so
   results are explicit about what was measured.
2. The `ValueError` message matching is string-based; if transformers rewords
   the error, the fall-through stops matching and a config falls back to
   `UNSUPPORTED_TASK` (safe direction, just less coverage).

### Rollback Plan
Revert the single commit `2972f2b`; the harness returns to causal-LM-only
behavior with no other impact.

## Related Work
- Fixes #254

## Explicitly Not Included
- The `aten::mm`/`bmm` reduced-precision fp32 matmul defect (separate issue).
- `docs/reference/hf-coverage.md` and `results/` survey evidence (separate
  change).
- No change to `tests/manual/transformers_hf_tests.py`, which already runs
  HF's own per-architecture tests and does not hardcode a model head.

## Human Review Notes
### Areas needing special attention:
1. The `task` field is added to the config event and `summarize()`; confirm the
   JSON schema consumers (if any) tolerate the extra field.
2. The string-based `ValueError` fall-through — verify it is acceptable vs.
   checking the auto-model mapping directly.

### Questions for reviewer:
1. Is `AutoModel` as a final fallback desirable, or should headless models stay
   `UNSUPPORTED_TASK`?
2. Should `task` be surfaced anywhere else in the result besides the config
   event and the summary line?

## Additional Context
Survey context: MetaX (MACA 3.8.1) box, torch 2.10.0+cpu, transformers 5.16.1,
torch_fl commit 474fd0b.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
