### PR TITLE
fix: support uint16/uint32/uint64 dtype casts on flagos backend

### DIFF
--- a/csrc/aten/copy_ops.cc
+++ b/csrc/aten/copy_ops.cc
@@ -71,6 +71,76 @@ inline void SyncCurrentStreamBeforeBlockingCopy() {
 #endif
 }
 
+// The maca CUDA copy kernel (reached via DeviceBoxingGuard + at::native::copy_)
+// has no UInt16/UInt32/UInt64 case in its dtype dispatch, so any dtype *cast*
+// to or from those types raises `"copy_" not implemented for 'UInt32'`. The
+// host copy kernel supports the full set, so route those casts through a CPU
+// round-trip instead. Same-dtype copies are unaffected: they take the direct
+// memcpy path and never reach a dtype dispatch.
+bool cast_needs_cpu_roundtrip(c10::ScalarType src, c10::ScalarType dst) {
+  if (src == dst) {
+    return false;
+  }
+  const auto is_unsigned = [](c10::ScalarType t) {
+    return t == c10::kUInt16 || t == c10::kUInt32 || t == c10::kUInt64;
+  };
+  return is_unsigned(src) || is_unsigned(dst);
+}
+
+// Copy `src` (a flagos device tensor) into `dst` (a flagos device tensor),
+// casting dtype and honoring both tensors' strides, via a host round-trip.
+// This is the fallback for dtype casts the native CUDA copy kernel cannot do
+// (see cast_needs_cpu_roundtrip). The blocking Memcpys drain the current stream
+// first so a kernel result produced on a side stream is visible.
+void strided_copy_cast_via_cpu(const at::Tensor& src, const at::Tensor& dst) {
+  at::Tensor src_contig = src.is_contiguous()
+      ? src
+      : at::native::flagos::contiguous(src, c10::MemoryFormat::Contiguous);
+  size_t nbytes = src_contig.numel() * src_contig.element_size();
+  at::Tensor cpu_src =
+      at::empty(src_contig.sizes(), src_contig.options().device(at::kCPU));
+  SyncCurrentStreamBeforeBlockingCopy();
+  if (nbytes > 0) {
+    Memcpy(
+        cpu_src.data_ptr(), src_contig.data_ptr(), nbytes, MemcpyDeviceToHost);
+  }
+
+  // Map dst's whole storage (not just its view) into CPU byte memory so a
+  // strided in-place copy preserves the parts of the storage dst's view does
+  // not cover. The CPU copy then writes only dst's logical elements.
+  size_t dst_storage_nbytes = dst.storage().nbytes();
+  at::Tensor cpu_dst_storage = at::empty(
+      {static_cast<int64_t>(dst_storage_nbytes)},
+      dst.options().device(at::kCPU).dtype(at::kByte));
+  int64_t dst_storage_offset_bytes =
+      dst.storage_offset() * static_cast<int64_t>(dst.element_size());
+  char* dst_storage_base =
+      static_cast<char*>(dst.data_ptr()) - dst_storage_offset_bytes;
+  if (dst_storage_nbytes > 0) {
+    Memcpy(
+        cpu_dst_storage.data_ptr(),
+        dst_storage_base,
+        dst_storage_nbytes,
+        MemcpyDeviceToHost);
+  }
+
+  at::Tensor cpu_dst = at::empty({0}, dst.options().device(at::kCPU));
+  cpu_dst.set_(
+      cpu_dst_storage.storage(),
+      dst.storage_offset(),
+      dst.sizes(),
+      dst.strides());
+  at::native::copy_(cpu_dst, cpu_src, false);
+
+  if (dst_storage_nbytes > 0) {
+    Memcpy(
+        dst_storage_base,
+        cpu_dst_storage.data_ptr(),
+        dst_storage_nbytes,
+        MemcpyHostToDevice);
+  }
+}
+
 } // namespace
 
 ADD_IMPL_TO_DISPATCHER(
@@ -145,9 +215,15 @@ at::Tensor _copy_from(
 #elif !defined(USE_ASCEND) && !defined(USE_TSINGMICRO) && !defined(USE_GCU) && \
     !defined(USE_MUSA) && !defined(USE_BPU)
       // CUDA platform: use DeviceBoxingGuard to dispatch to native CUDA
-      // strided copy kernel (handles strides, dtype casts on-device).
-      DeviceBoxingGuard guard(self, dst);
-      at::native::copy_(const_cast<at::Tensor&>(dst), self, false);
+      // strided copy kernel (handles strides, dtype casts on-device). The
+      // native copy kernel has no UInt16/UInt32/UInt64 case, so those casts
+      // take the host round-trip instead.
+      if (cast_needs_cpu_roundtrip(self.scalar_type(), dst.scalar_type())) {
+        strided_copy_cast_via_cpu(self, dst);
+      } else {
+        DeviceBoxingGuard guard(self, dst);
+        at::native::copy_(const_cast<at::Tensor&>(dst), self, false);
+      }
 #else
       // Ascend: copy on-device via aclnnInplaceCopy, which honors both src and
       // dst strides/offset and casts dtype. Avoids the CPU round-trip below.
@@ -448,11 +524,25 @@ at::Tensor _to_copy(
       }
 #else
       // CUDA platform: use DeviceBoxingGuard + CUDA TensorIterator copy kernel
-      // for dtype cast on-device, avoiding costly CPU round-trip.
-      result = at::empty(self_contig.sizes(), self_contig.options()
-          .dtype(dtype).device(c10::Device(c10::kPrivateUse1, device_index)));
-      DeviceBoxingGuard guard(self_contig, result);
-      at::native::copy_(result, self_contig, false);
+      // for dtype cast on-device, avoiding costly CPU round-trip. The native
+      // copy kernel has no UInt16/UInt32/UInt64 case, so those casts take the
+      // host round-trip instead.
+      if (cast_needs_cpu_roundtrip(self_contig.scalar_type(), dtype)) {
+        result = at::empty(
+            self_contig.sizes(),
+            self_contig.options()
+                .dtype(dtype)
+                .device(c10::Device(c10::kPrivateUse1, device_index)));
+        strided_copy_cast_via_cpu(self_contig, result);
+      } else {
+        result = at::empty(
+            self_contig.sizes(),
+            self_contig.options()
+                .dtype(dtype)
+                .device(c10::Device(c10::kPrivateUse1, device_index)));
+        DeviceBoxingGuard guard(self_contig, result);
+        at::native::copy_(result, self_contig, false);
+      }
 #endif
     } else {
       result = at::empty(


### PR DESCRIPTION
<!--
⚠️ AI-GENERATED PR TEMPLATE ⚠️
This template is for PRs created by AI agents (Claude Code, GitHub Codex, Cursor, etc.).
ALL sections marked REQUIRED must be completed before submission.
PRs missing required sections will be automatically closed.
-->

## AI Agent Information
- **Agent/Tool**: Claude Code CLI
- **Model**: Claude Fable 5
- **Human Reviewer**: @<!-- TODO: assign maintainer username -->
- **Session Summary**: Debugged a Hugging Face `Gemma3TextModelTest::test_beam_sample_generate` failure on MetaX flagos, traced to `ex_cumsum_bins.to(torch.uint32)` inside FlagGems `radix_sort`, and fixed the missing unsigned dtype cast in the torch_fl copy path.

## Summary

On the MetaX `flagos` backend, any device-side dtype cast to or from `uint16` / `uint32` / `uint64` raised `NotImplementedError: "copy_" not implemented for 'UInt32'`. The root cause is that the maca precompiled CUDA copy kernel has no `UInt16`/`UInt32`/`UInt64` case in its dtype dispatch, while torch_fl forwards all device-side casts through `DeviceBoxingGuard` + `at::native::copy_` to that kernel. This PR adds two helpers in `csrc/aten/copy_ops.cc` that route those casts through a host round-trip, leaving all other dtypes on the native CUDA copy kernel.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Optimization
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] CI/Infrastructure
- [ ] Breaking Change

## Platforms Affected
- [ ] CUDA
- [x] MetaX
- [ ] Ascend
- [ ] PPU
- [ ] Platform-agnostic (all platforms)

## Problem Analysis
### What was broken/missing?

Device-side dtype casts involving `uint16`, `uint32`, or `uint64` failed on the flagos backend. Both the in-place `copy_` path (`_copy_from`) and the `.to(dtype)` path (`_to_copy`) threw `NotImplementedError: "copy_" not implemented for 'UInt32'`. This broke Hugging Face Transformers beam search for Gemma3: `TopPLogitsWarper.__call__` → `torch.sort(..., descending=False)` → FlagGems `radix_sort` → `ex_cumsum_bins.to(torch.uint32)`.

### Why did it happen?

torch_fl routes "flagos → flagos, different dtype" through a single CUDA branch:

```cpp
DeviceBoxingGuard guard(self, dst);
at::native::copy_(const_cast<at::Tensor&>(dst), self, false);
```

`DeviceBoxingGuard` boxes the flagos tensors as CUDA tensors, and `at::native::copy_` dispatches to the **maca precompiled CUDA copy kernel** (`libtorch_cuda.so` → `copy_stub` → `copy_kernel_cuda`). That kernel's dtype dispatch has no `UInt16`/`UInt32`/`UInt64` branch — these unsigned types are not in `AT_DISPATCH_ALL_TYPES` — so it falls through to the default case and throws. Only unsigned 16/32/64 are affected; `uint8`, signed ints, floats, and `bool` all cast fine, and same-dtype `uint32` copies take the direct `memcpy` fast path and never reach dtype dispatch.

### Investigation process:
1. Reproduced the failure with a minimal 3-line reproducer (`int64` tensor → `.to(torch.uint32)`), independent of FlagGems/Transformers.
2. Confirmed only unsigned 16/32/64 fail; `uint8`, signed ints, floats, and `bool` cast fine; same-dtype `uint32` copies are unaffected.
3. Traced both `copy_` (`_copy_from`) and `.to(dtype)` (`_to_copy`) to the shared `DeviceBoxingGuard` + `at::native::copy_` CUDA branch in `copy_ops.cc`.
4. Confirmed the maca kernel dtype dispatch lacks the unsigned 16/32/64 branches, and that `libtorch_cuda.so` is a precompiled wheel that cannot be patched in-place.

## Solution Design
### Implementation approach:

Add two helpers in `csrc/aten/copy_ops.cc` and route the CUDA branches of `_copy_from` / `_to_copy` through a host round-trip when the cast involves unsigned 16/32/64:

1. `cast_needs_cpu_roundtrip(src, dst)` — returns `false` for same-dtype copies (the direct `memcpy` path is unaffected), `true` when either side is `kUInt16` / `kUInt32` / `kUInt64`.
2. `strided_copy_cast_via_cpu(src, dst)` — D2H pulls `src` (making it contiguous first if needed), performs the strided + dtype cast on CPU via `at::native::copy_` (which supports all types), then H2D writes back `dst`'s whole storage so strided in-place semantics are preserved. The blocking `Memcpy` calls `SyncCurrentStreamBeforeBlockingCopy()` first so kernel results produced on a side stream are visible.
3. Wire into both sites:
   - `_copy_from` (in-place `copy_` path): `if (cast_needs_cpu_roundtrip(...)) strided_copy_cast_via_cpu(self, dst); else { DeviceBoxingGuard ...; at::native::copy_(...) }`
   - `_to_copy` (`.to(dtype)` path): allocate the result via `at::empty`, then `strided_copy_cast_via_cpu(self_contig, result)` for affected casts; keep the boxing + `at::native::copy_` path otherwise.

Ascend / MUSA and other backend branches are untouched.

### Key design decisions:

The more thorough fix would be to add `UInt16`/`UInt32`/`UInt64` branches to the maca CUDA copy kernel, but that requires patching the precompiled `libtorch_cuda.so` and republishing the vendor wheel — out of scope for a torch_fl change. Routing the missing types through a CPU round-trip keeps the change local to the integration layer, is semantically correct (CPU-side casts support the full type set), and only costs one extra D2H/H2D for these rare casts. Same-dtype copies deliberately bypass the round-trip to preserve the existing fast path.

### Code changes by file:
- `csrc/aten/copy_ops.cc` (lines 80-145): added `cast_needs_cpu_roundtrip` and `strided_copy_cast_via_cpu` helpers.
- `csrc/aten/copy_ops.cc` (lines 215-226): `_copy_from` CUDA branch now routes unsigned 16/32/64 casts through `strided_copy_cast_via_cpu`; all other cases keep the `DeviceBoxingGuard` + `at::native::copy_` path.
- `csrc/aten/copy_ops.cc` (lines 524-545): `_to_copy` CUDA branch does the same for the `.to(dtype)` path.

### Changes by commit:
1. `fix: support uint16/uint32/uint64 dtype casts on flagos backend` — the single logical change; not yet committed at time of drafting.

## Verification
### Pre-submission Checklist
- [ ] **Linting passed** (ruff check, ruff format --check) — TODO: run (C++-only change; ruff should report clean on Python files)
- [ ] **Type checking passed** (if applicable) — N/A (C++ change)
- [ ] **All tests pass** (unit + integration)
- [x] **Manual testing completed** (reproduction of original issue)
- [x] **No debug/temporary code** (no print statements, commented code, TODOs)
- [ ] **Documentation updated** (README, CLAUDE.md, docstrings as needed) — TODO: update `docs/reference/operator-support.md` if this changes operator routing
- [ ] **Commit messages follow conventions** (type: description format)
- [x] **All text in English** (required per CLAUDE.md)

### Linting Results
<!-- TODO: paste actual output after running -->
```bash
$ ruff check
# Output: TODO

$ ruff format --check
# Output: TODO
```

### Test Results
```bash
# Command:
bash run_test.sh   # wraps: pytest tests/models/gemma3/test_modeling_gemma3.py::Gemma3TextModelTest::test_beam_sample_generate -v -s

# Output:
1 passed, 38 warnings in 20.75s
```

Minimal probe (all returned correct values, no exceptions):
- `int64 → uint16/uint32/uint64`
- `uint32 → int64` (including `2^31` and `2^32 - 1` edge values)
- in-place `copy_` (int64 → uint32)
- strided `copy_` (non-contiguous src → uint32)

### Manual Verification
```bash
# Command to reproduce original issue:
python -c "
import torch_fl, torch
x = torch.ones((2, 3), device='flagos:0', dtype=torch.int32)
y = torch.cumsum(x, -1) - x
y.to(torch.uint32)
"

# Output BEFORE fix:
NotImplementedError: "copy_" not implemented for 'UInt32'

# Output AFTER fix:
# (no exception; cast returns a uint32 tensor with correct values)
```

## Performance Impact
<details>
<summary>Click to expand performance notes</summary>

No benchmark was run — this change only affects unsigned 16/32/64 dtype casts, which previously threw. The trade-off is one extra D2H/H2D round-trip for those rare casts; same-dtype copies and all other dtypes are unchanged and keep the on-device fast path.
</details>

## Breaking Changes
None. Existing behavior for all dtypes that already worked is unchanged; only previously-throwing casts now succeed.

## Code Quality Verification
### Style Consistency
- [x] Matched existing code style in modified files
- [x] Followed naming conventions (checked similar code)
- [x] Comment density matches surrounding code
- [x] Used project's existing utilities/helpers (`at::native::copy_`, `Memcpy`, `SyncCurrentStreamBeforeBlockingCopy`)

### Edge Cases Considered
1. Same-dtype `uint32` copy — bypasses the round-trip and keeps the `memcpy` fast path (`cast_needs_cpu_roundtrip` returns `false`).
2. Non-contiguous `src` — made contiguous via `at::native::flagos::contiguous` before the D2H pull.
3. Overflow boundary values — `2^31` and `2^32 - 1` verified for `uint32 → int64`.
4. In-place `copy_` onto a strided `dst` view — the whole storage is pulled/written so parts of the storage not covered by the view are preserved.

### Potential Risks
1. The host round-trip is synchronous (blocking `Memcpy`), so these casts no longer overlap with the device stream — acceptable given they are rare and previously threw.
2. Behavior depends on the CPU-side `at::native::copy_` cast semantics for unsigned types; these match PyTorch CPU reference behavior.

### Rollback Plan
Revert the change to `csrc/aten/copy_ops.cc` — it is a self-contained patch touching only that file, and the previous behavior (throwing `NotImplementedError`) is restored immediately.

## Related Work
- Fixes #257

## Explicitly Not Included
- Patching the maca precompiled `libtorch_cuda.so` to add `UInt16`/`UInt32`/`UInt64` kernel branches (requires a vendor wheel republish).
- Any change to the FlagGems `radix_sort` kernel itself; the torch_fl copy path is the correct layer for this fix.
- No changes to Ascend / MUSA / other backend branches.

## Human Review Notes
### Areas needing special attention:
1. The `strided_copy_cast_via_cpu` whole-storage write-back logic — verify the `storage_offset`/`data_ptr` arithmetic is correct for non-zero offsets.
2. Whether `_copy_from_and_resize` (line 353) needs the same treatment; it was left unchanged because the reported failure did not reach it.

### Questions for reviewer:
1. Is a CPU round-trip acceptable at this integration layer, or is there an existing helper for host-side strided cast we should reuse instead?
2. Should this also cover `_copy_from_and_resize` for completeness even though no reproduction exercises it?

## Additional Context
- Root-cause chain: `transformers/generation/logits_process.py` → `torch.sort` → FlagGems `sort` → `radix_sort` → `ex_cumsum_bins.to(torch.uint32)`.
- Related registration (unchanged): `csrc/aten/register.cc:428-430` registers `_copy_from` / `copy_` / `_to_copy` for PrivateUse1.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
